### PR TITLE
Parse number

### DIFF
--- a/src/compiler/debug.rs
+++ b/src/compiler/debug.rs
@@ -3,7 +3,7 @@
 pub struct DebugType {}
 
 impl DebugType {
-    fn fail(&self, message: Option<&str>) -> ! {
+    pub fn fail(&self, message: Option<&str>) -> ! {
         let message = match message {
             Some(message) => format!("Debug failure. {}", message),
             None => "Debug failure.".to_string(),

--- a/src/compiler/diagnostic_information_map_generated.rs
+++ b/src/compiler/diagnostic_information_map_generated.rs
@@ -18,10 +18,22 @@ const fn diag(
 pub struct Diagnostics;
 #[allow(non_upper_case_globals)]
 impl Diagnostics {
+    pub const Identifier_expected: DiagnosticMessage = diag(
+        1003,
+        DiagnosticCategory::Error,
+        "Identifier_expected_1003",
+        "Identifier expected.",
+    );
     pub const _0_expected: DiagnosticMessage = diag(
         1005,
         DiagnosticCategory::Error,
         "_0_expected_1005",
         "'{0}' expected.",
+    );
+    pub const Expression_expected: DiagnosticMessage = diag(
+        1109,
+        DiagnosticCategory::Error,
+        "Expression_expected_1109",
+        "Expression expected.",
     );
 }

--- a/src/compiler/factory/base_node_factory.rs
+++ b/src/compiler/factory/base_node_factory.rs
@@ -3,5 +3,6 @@ use crate::{BaseNode, SyntaxKind};
 pub trait BaseNodeFactory {
     fn create_base_source_file_node(&self, kind: SyntaxKind) -> BaseNode;
     fn create_base_identifier_node(&self, kind: SyntaxKind) -> BaseNode;
+    fn create_base_token_node(&self, kind: SyntaxKind) -> BaseNode;
     fn create_base_node(&self, kind: SyntaxKind) -> BaseNode;
 }

--- a/src/compiler/factory/base_node_factory.rs
+++ b/src/compiler/factory/base_node_factory.rs
@@ -2,5 +2,6 @@ use crate::{BaseNode, SyntaxKind};
 
 pub trait BaseNodeFactory {
     fn create_base_source_file_node(&self, kind: SyntaxKind) -> BaseNode;
+    fn create_base_identifier_node(&self, kind: SyntaxKind) -> BaseNode;
     fn create_base_node(&self, kind: SyntaxKind) -> BaseNode;
 }

--- a/src/compiler/factory/node_factory.rs
+++ b/src/compiler/factory/node_factory.rs
@@ -1,6 +1,6 @@
 use crate::{
-    BaseNode, BaseNodeFactory, EmptyStatement, Identifier, NodeArray, NodeArrayOrVec, NodeFactory,
-    SourceFile, SyntaxKind,
+    BaseNode, BaseNodeFactory, EmptyStatement, Expression, ExpressionStatement, Identifier,
+    NodeArray, NodeArrayOrVec, NodeFactory, SourceFile, SyntaxKind,
 };
 
 impl NodeFactory {
@@ -42,6 +42,17 @@ impl NodeFactory {
     ) -> EmptyStatement {
         EmptyStatement {
             _node: self.create_base_node(base_factory, SyntaxKind::EmptyStatement),
+        }
+    }
+
+    pub fn create_expression_statement<TBaseNodeFactory: BaseNodeFactory>(
+        &self,
+        base_factory: &TBaseNodeFactory,
+        expression: Expression,
+    ) -> ExpressionStatement {
+        ExpressionStatement {
+            _node: self.create_base_node(base_factory, SyntaxKind::ExpressionStatement),
+            expression,
         }
     }
 

--- a/src/compiler/factory/node_factory.rs
+++ b/src/compiler/factory/node_factory.rs
@@ -1,6 +1,6 @@
 use crate::{
-    BaseNode, BaseNodeFactory, EmptyStatement, NodeArray, NodeArrayOrVec, NodeFactory, SourceFile,
-    SyntaxKind,
+    BaseNode, BaseNodeFactory, EmptyStatement, Identifier, NodeArray, NodeArrayOrVec, NodeFactory,
+    SourceFile, SyntaxKind,
 };
 
 impl NodeFactory {
@@ -12,6 +12,28 @@ impl NodeFactory {
             NodeArrayOrVec::NodeArray(node_array) => node_array,
             NodeArrayOrVec::Vec(elements) => NodeArray::new(elements),
         }
+    }
+
+    fn create_base_identifier<TBaseNodeFactory: BaseNodeFactory>(
+        &self,
+        base_factory: &TBaseNodeFactory,
+        text: &str,
+    ) -> Identifier {
+        let node = base_factory.create_base_identifier_node(SyntaxKind::Identifier);
+        let node = Identifier {
+            _node: node,
+            escaped_text: text.to_string(),
+        };
+        node
+    }
+
+    pub fn create_identifier<TBaseNodeFactory: BaseNodeFactory>(
+        &self,
+        base_factory: &TBaseNodeFactory,
+        text: &str,
+    ) -> Identifier {
+        let node = self.create_base_identifier(base_factory, text);
+        node
     }
 
     pub fn create_empty_statement<TBaseNodeFactory: BaseNodeFactory>(

--- a/src/compiler/factory/node_factory.rs
+++ b/src/compiler/factory/node_factory.rs
@@ -1,6 +1,7 @@
 use crate::{
-    BaseNode, BaseNodeFactory, EmptyStatement, Expression, ExpressionStatement, Identifier,
-    NodeArray, NodeArrayOrVec, NodeFactory, SourceFile, SyntaxKind,
+    BaseLiteralLikeNode, BaseNode, BaseNodeFactory, EmptyStatement, Expression,
+    ExpressionStatement, Identifier, NodeArray, NodeArrayOrVec, NodeFactory, NumericLiteral,
+    SourceFile, SyntaxKind,
 };
 
 impl NodeFactory {
@@ -11,6 +12,30 @@ impl NodeFactory {
         match elements.into() {
             NodeArrayOrVec::NodeArray(node_array) => node_array,
             NodeArrayOrVec::Vec(elements) => NodeArray::new(elements),
+        }
+    }
+
+    fn create_base_literal<TBaseNodeFactory: BaseNodeFactory>(
+        &self,
+        base_factory: &TBaseNodeFactory,
+        kind: SyntaxKind,
+        value: &str,
+    ) -> BaseLiteralLikeNode {
+        let node = self.create_base_token(base_factory, kind);
+        BaseLiteralLikeNode {
+            _node: node,
+            text: value.to_string(),
+        }
+    }
+
+    pub fn create_numeric_literal<TBaseNodeFactory: BaseNodeFactory>(
+        &self,
+        base_factory: &TBaseNodeFactory,
+        value: &str,
+    ) -> NumericLiteral {
+        let node = self.create_base_literal(base_factory, SyntaxKind::NumericLiteral, value);
+        NumericLiteral {
+            _literal_like_node: node,
         }
     }
 
@@ -34,6 +59,14 @@ impl NodeFactory {
     ) -> Identifier {
         let node = self.create_base_identifier(base_factory, text);
         node
+    }
+
+    pub fn create_base_token<TBaseNodeFactory: BaseNodeFactory>(
+        &self,
+        base_factory: &TBaseNodeFactory,
+        kind: SyntaxKind,
+    ) -> BaseNode {
+        base_factory.create_base_token_node(kind)
     }
 
     pub fn create_empty_statement<TBaseNodeFactory: BaseNodeFactory>(

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -222,7 +222,7 @@ impl ParserType {
     }
 
     fn create_missing_node(
-        &self,
+        &mut self,
         kind: SyntaxKind,
         diagnostic_message: DiagnosticMessage,
     ) -> MissingNode {
@@ -233,7 +233,7 @@ impl ParserType {
     }
 
     fn create_identifier(
-        &self,
+        &mut self,
         is_identifier: bool,
         diagnostic_message: Option<DiagnosticMessage>,
     ) -> Identifier {
@@ -248,7 +248,7 @@ impl ParserType {
         }
     }
 
-    fn parse_identifier(&self, diagnostic_message: Option<DiagnosticMessage>) -> Identifier {
+    fn parse_identifier(&mut self, diagnostic_message: Option<DiagnosticMessage>) -> Identifier {
         self.create_identifier(self.is_identifier(), diagnostic_message)
     }
 
@@ -308,13 +308,13 @@ impl ParserType {
         }
     }
 
-    fn parse_expression(&self) -> Expression {
+    fn parse_expression(&mut self) -> Expression {
         let expr = self.parse_assignment_expression_or_higher();
 
         expr
     }
 
-    fn parse_assignment_expression_or_higher(&self) -> Expression {
+    fn parse_assignment_expression_or_higher(&mut self) -> Expression {
         let expr = self.parse_binary_expression_or_higher(OperatorPrecedence::Lowest);
 
         self.parse_conditional_expression_rest(expr)
@@ -324,7 +324,7 @@ impl ParserType {
         left_operand
     }
 
-    fn parse_binary_expression_or_higher(&self, precedence: OperatorPrecedence) -> Expression {
+    fn parse_binary_expression_or_higher(&mut self, precedence: OperatorPrecedence) -> Expression {
         let left_operand = self.parse_unary_expression_or_higher();
         self.parse_binary_expression_rest(precedence, left_operand)
     }
@@ -347,7 +347,7 @@ impl ParserType {
         left_operand
     }
 
-    fn parse_unary_expression_or_higher(&self) -> Expression {
+    fn parse_unary_expression_or_higher(&mut self) -> Expression {
         if self.is_update_expression() {
             let update_expression = self.parse_update_expression();
             return update_expression;
@@ -362,31 +362,41 @@ impl ParserType {
         }
     }
 
-    fn parse_update_expression(&self) -> Expression {
+    fn parse_update_expression(&mut self) -> Expression {
         let expression = self.parse_left_hand_side_expression_or_higher();
 
         expression
     }
 
-    fn parse_left_hand_side_expression_or_higher(&self) -> Expression {
+    fn parse_left_hand_side_expression_or_higher(&mut self) -> Expression {
         let expression = self.parse_member_expression_or_higher();
 
         self.parse_call_expression_rest(expression)
     }
 
-    fn parse_member_expression_or_higher(&self) -> Expression {
+    fn parse_member_expression_or_higher(&mut self) -> Expression {
         let expression = self.parse_primary_expression();
         self.parse_member_expression_rest(expression)
     }
 
-    fn parse_primary_expression(&self) -> Expression {
+    fn parse_member_expression_rest(&self, expression: Expression) -> Expression {
+        loop {
+            return expression;
+        }
+    }
+
+    fn parse_call_expression_rest(&self, expression: Expression) -> Expression {
+        expression
+    }
+
+    fn parse_primary_expression(&mut self) -> Expression {
         self.parse_identifier(Some(Diagnostics::Expression_expected))
             .into()
     }
 
-    fn parse_expression_or_labeled_statement(&self) -> Statement {
+    fn parse_expression_or_labeled_statement(&mut self) -> Statement {
         let expression = self.parse_expression();
-        let node = self.factory.create_expression_statement(expression);
+        let node = self.factory.create_expression_statement(self, expression);
         self.finish_node(node.into())
     }
 

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -273,7 +273,7 @@ impl ParserType {
     }
 
     fn is_list_terminator(&self) -> bool {
-        if matches!(self.token(), SyntaxKind::EndOfFileToken) {
+        if self.token() == SyntaxKind::EndOfFileToken {
             return true;
         }
         false

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -324,6 +324,7 @@ impl ParserType {
 
     fn is_start_of_left_hand_side_expression(&self) -> bool {
         match self.token() {
+            SyntaxKind::NumericLiteral => true,
             _ => self.is_identifier(),
         }
     }

--- a/src/compiler/scanner.rs
+++ b/src/compiler/scanner.rs
@@ -1,5 +1,10 @@
 use crate::{CharacterCodes, SyntaxKind};
 
+struct ScanNumberReturn {
+    type_: SyntaxKind,
+    value: String,
+}
+
 pub struct Scanner {
     text: Option<String>,
     pos: Option<usize>,
@@ -37,6 +42,24 @@ impl Scanner {
                 CharacterCodes::asterisk => {
                     self.set_pos(self.pos() + 1);
                     return self.set_token(SyntaxKind::AsteriskToken);
+                }
+                CharacterCodes::_0
+                | CharacterCodes::_1
+                | CharacterCodes::_2
+                | CharacterCodes::_3
+                | CharacterCodes::_4
+                | CharacterCodes::_5
+                | CharacterCodes::_6
+                | CharacterCodes::_7
+                | CharacterCodes::_8
+                | CharacterCodes::_9 => {
+                    let ScanNumberReturn {
+                        type_: token,
+                        value: token_value,
+                    } = self.scan_number();
+                    self.set_token(token);
+                    self.set_token_value(&token_value);
+                    return token;
                 }
                 CharacterCodes::semicolon => {
                     self.set_pos(self.pos() + 1);
@@ -140,6 +163,55 @@ impl Scanner {
 
     fn set_token_value(&mut self, token_value: &str) {
         self.token_value = Some(token_value.to_string());
+    }
+
+    fn is_digit(&self, ch: char) -> bool {
+        ch >= CharacterCodes::_0 && ch <= CharacterCodes::_9
+    }
+
+    fn scan_number_fragment(&mut self) -> String {
+        let start = self.pos();
+        let result = "".to_string();
+        loop {
+            let ch = self.text().chars().nth(self.pos());
+            let ch = match ch {
+                Some(ch) => ch,
+                None => break,
+            };
+            if self.is_digit(ch) {
+                self.set_pos(self.pos() + 1);
+                continue;
+            }
+            break;
+        }
+        let mut ret = result;
+        ret.push_str(
+            &self
+                .text()
+                .chars()
+                .skip(start)
+                .take(self.pos() - start)
+                .collect::<String>(),
+        );
+        ret
+    }
+
+    fn scan_number(&mut self) -> ScanNumberReturn {
+        let start = self.pos();
+        let main_fragment = self.scan_number_fragment();
+        let end = self.pos();
+        let result: String = self.text().chars().skip(start).take(end - start).collect();
+
+        self.set_token_value(&result);
+        let type_ = self.check_big_int_suffix();
+        ScanNumberReturn {
+            type_,
+            value: self.token_value().to_string(),
+        }
+    }
+
+    fn check_big_int_suffix(&self) -> SyntaxKind {
+        SyntaxKind::NumericLiteral
     }
 
     // fn scan_identifier(&self, start_character: char) -> {

--- a/src/compiler/scanner.rs
+++ b/src/compiler/scanner.rs
@@ -7,6 +7,7 @@ pub struct Scanner {
     start_pos: Option<usize>,
     token_pos: Option<usize>,
     token: Option<SyntaxKind>,
+    token_value: Option<String>,
 }
 
 impl Scanner {
@@ -16,6 +17,10 @@ impl Scanner {
 
     pub fn get_token_pos(&self) -> usize {
         self.token_pos()
+    }
+
+    pub fn get_token_value(&self) -> &str {
+        self.token_value()
     }
 
     pub fn scan(&mut self) -> SyntaxKind {
@@ -76,6 +81,7 @@ impl Scanner {
             start_pos: None,
             token_pos: None,
             token: None,
+            token_value: None,
         }
     }
 
@@ -126,6 +132,14 @@ impl Scanner {
     fn set_token(&mut self, token: SyntaxKind) -> SyntaxKind {
         self.token = Some(token);
         token
+    }
+
+    fn token_value(&self) -> &str {
+        self.token_value.as_ref().unwrap()
+    }
+
+    fn set_token_value(&mut self, token_value: &str) {
+        self.token_value = Some(token_value.to_string());
     }
 
     // fn scan_identifier(&self, start_character: char) -> {

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -14,6 +14,7 @@ pub enum SyntaxKind {
     EndOfFileToken,
     SemicolonToken,
     AsteriskToken,
+    Identifier,
     EmptyStatement,
     SourceFile,
 }
@@ -29,6 +30,7 @@ pub trait NodeInterface {
 
 #[derive(Debug)]
 pub enum Node {
+    Expression(Expression),
     Statement(Statement),
 }
 
@@ -65,6 +67,43 @@ impl From<NodeArray> for NodeArrayOrVec {
 impl From<Vec<Node>> for NodeArrayOrVec {
     fn from(vec: Vec<Node>) -> Self {
         NodeArrayOrVec::Vec(vec)
+    }
+}
+
+#[derive(Debug)]
+pub struct Identifier {
+    pub _node: BaseNode,
+    pub escaped_text: String,
+}
+
+impl NodeInterface for Identifier {
+    fn kind(&self) -> SyntaxKind {
+        self._node.kind
+    }
+}
+
+impl From<Identifier> for Expression {
+    fn from(identifier: Identifier) -> Self {
+        Expression::Identifier(identifier)
+    }
+}
+
+#[derive(Debug)]
+pub enum Expression {
+    Identifier(Identifier),
+}
+
+impl NodeInterface for Expression {
+    fn kind(&self) -> SyntaxKind {
+        match self {
+            Expression::Identifier(identifier) => identifier.kind(),
+        }
+    }
+}
+
+impl From<Expression> for Node {
+    fn from(expression: Expression) -> Self {
+        Node::Expression(expression)
     }
 }
 

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -263,6 +263,16 @@ pub struct CreateProgramOptions<'config> {
 pub struct CharacterCodes;
 #[allow(non_upper_case_globals)]
 impl CharacterCodes {
+    pub const _0: char = '0';
+    pub const _1: char = '1';
+    pub const _2: char = '2';
+    pub const _3: char = '3';
+    pub const _4: char = '4';
+    pub const _5: char = '5';
+    pub const _6: char = '6';
+    pub const _7: char = '7';
+    pub const _8: char = '8';
+    pub const _9: char = '9';
     pub const asterisk: char = '*';
     pub const semicolon: char = ';';
     pub const slash: char = '/';

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -16,6 +16,7 @@ pub enum SyntaxKind {
     AsteriskToken,
     Identifier,
     EmptyStatement,
+    ExpressionStatement,
     SourceFile,
 }
 
@@ -38,6 +39,7 @@ impl NodeInterface for Node {
     fn kind(&self) -> SyntaxKind {
         match self {
             Node::Statement(statement) => statement.kind(),
+            Node::Expression(expression) => expression.kind(),
         }
     }
 }
@@ -110,12 +112,14 @@ impl From<Expression> for Node {
 #[derive(Debug)]
 pub enum Statement {
     EmptyStatement(EmptyStatement),
+    ExpressionStatement(ExpressionStatement),
 }
 
 impl NodeInterface for Statement {
     fn kind(&self) -> SyntaxKind {
         match self {
             Statement::EmptyStatement(empty_statement) => empty_statement.kind(),
+            Statement::ExpressionStatement(expression_statement) => expression_statement.kind(),
         }
     }
 }
@@ -140,6 +144,24 @@ impl NodeInterface for EmptyStatement {
 impl From<EmptyStatement> for Statement {
     fn from(empty_statement: EmptyStatement) -> Self {
         Statement::EmptyStatement(empty_statement)
+    }
+}
+
+#[derive(Debug)]
+pub struct ExpressionStatement {
+    pub _node: BaseNode,
+    pub expression: Expression,
+}
+
+impl NodeInterface for ExpressionStatement {
+    fn kind(&self) -> SyntaxKind {
+        self._node.kind
+    }
+}
+
+impl From<ExpressionStatement> for Statement {
+    fn from(expression_statement: ExpressionStatement) -> Self {
+        Statement::ExpressionStatement(expression_statement)
     }
 }
 

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -8,10 +8,11 @@ impl Path {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum SyntaxKind {
     Unknown,
     EndOfFileToken,
+    NumericLiteral,
     SemicolonToken,
     AsteriskToken,
     Identifier,
@@ -38,8 +39,8 @@ pub enum Node {
 impl NodeInterface for Node {
     fn kind(&self) -> SyntaxKind {
         match self {
-            Node::Statement(statement) => statement.kind(),
             Node::Expression(expression) => expression.kind(),
+            Node::Statement(statement) => statement.kind(),
         }
     }
 }
@@ -93,12 +94,14 @@ impl From<Identifier> for Expression {
 #[derive(Debug)]
 pub enum Expression {
     Identifier(Identifier),
+    LiteralLikeNode(LiteralLikeNode),
 }
 
 impl NodeInterface for Expression {
     fn kind(&self) -> SyntaxKind {
         match self {
             Expression::Identifier(identifier) => identifier.kind(),
+            Expression::LiteralLikeNode(literal_like_node) => literal_like_node.kind(),
         }
     }
 }
@@ -106,6 +109,66 @@ impl NodeInterface for Expression {
 impl From<Expression> for Node {
     fn from(expression: Expression) -> Self {
         Node::Expression(expression)
+    }
+}
+
+#[derive(Debug)]
+pub struct BaseLiteralLikeNode {
+    pub _node: BaseNode,
+    pub text: String,
+}
+
+pub trait LiteralLikeNodeInterface {
+    fn text(&self) -> &str;
+}
+
+#[derive(Debug)]
+pub enum LiteralLikeNode {
+    NumericLiteral(NumericLiteral),
+}
+
+impl NodeInterface for LiteralLikeNode {
+    fn kind(&self) -> SyntaxKind {
+        match self {
+            LiteralLikeNode::NumericLiteral(numeric_literal) => numeric_literal.kind(),
+        }
+    }
+}
+
+impl From<LiteralLikeNode> for Expression {
+    fn from(literal_like_node: LiteralLikeNode) -> Self {
+        Expression::LiteralLikeNode(literal_like_node)
+    }
+}
+
+impl LiteralLikeNodeInterface for LiteralLikeNode {
+    fn text(&self) -> &str {
+        match self {
+            LiteralLikeNode::NumericLiteral(numeric_literal) => numeric_literal.text(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct NumericLiteral {
+    pub _literal_like_node: BaseLiteralLikeNode,
+}
+
+impl NodeInterface for NumericLiteral {
+    fn kind(&self) -> SyntaxKind {
+        self._literal_like_node._node.kind
+    }
+}
+
+impl From<NumericLiteral> for LiteralLikeNode {
+    fn from(numeric_literal: NumericLiteral) -> Self {
+        LiteralLikeNode::NumericLiteral(numeric_literal)
+    }
+}
+
+impl LiteralLikeNodeInterface for NumericLiteral {
+    fn text(&self) -> &str {
+        &self._literal_like_node.text
     }
 }
 

--- a/src/compiler/utilities.rs
+++ b/src/compiler/utilities.rs
@@ -4,9 +4,10 @@ use std::cmp::Ordering;
 
 use crate::{BaseNode, DiagnosticMessage, DiagnosticWithDetachedLocation, SyntaxKind};
 
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum OperatorPrecedence {
     Comma,
+    Multiplicative,
     Primary,
     Invalid = -1,
 }
@@ -28,11 +29,20 @@ impl PartialOrd for OperatorPrecedence {
 }
 
 pub fn get_binary_operator_precedence(kind: SyntaxKind) -> OperatorPrecedence {
+    match kind {
+        SyntaxKind::AsteriskToken => return OperatorPrecedence::Multiplicative,
+        _ => (),
+    }
     OperatorPrecedence::Invalid
 }
 
 #[allow(non_snake_case)]
 fn Node(kind: SyntaxKind) -> BaseNode {
+    BaseNode { kind }
+}
+
+#[allow(non_snake_case)]
+fn Token(kind: SyntaxKind) -> BaseNode {
     BaseNode { kind }
 }
 
@@ -46,6 +56,10 @@ pub struct ObjectAllocator {}
 impl ObjectAllocator {
     pub fn get_node_constructor(&self) -> fn(SyntaxKind) -> BaseNode {
         Node
+    }
+
+    pub fn get_token_constructor(&self) -> fn(SyntaxKind) -> BaseNode {
+        Token
     }
 
     pub fn get_identifier_constructor(&self) -> fn(SyntaxKind) -> BaseNode {

--- a/src/compiler/utilities.rs
+++ b/src/compiler/utilities.rs
@@ -1,9 +1,43 @@
 #![allow(non_upper_case_globals)]
 
+use std::cmp::Ordering;
+
 use crate::{BaseNode, DiagnosticMessage, DiagnosticWithDetachedLocation, SyntaxKind};
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub enum OperatorPrecedence {
+    Comma,
+    Primary,
+    Invalid = -1,
+}
+
+impl OperatorPrecedence {
+    pub const Lowest: OperatorPrecedence = OperatorPrecedence::Comma;
+}
+
+impl Ord for OperatorPrecedence {
+    fn cmp(&self, other: &Self) -> Ordering {
+        (*self as isize).cmp(&(*other as isize))
+    }
+}
+
+impl PartialOrd for OperatorPrecedence {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+pub fn get_binary_operator_precedence(kind: SyntaxKind) -> OperatorPrecedence {
+    OperatorPrecedence::Invalid
+}
 
 #[allow(non_snake_case)]
 fn Node(kind: SyntaxKind) -> BaseNode {
+    BaseNode { kind }
+}
+
+#[allow(non_snake_case)]
+fn Identifier(kind: SyntaxKind) -> BaseNode {
     BaseNode { kind }
 }
 
@@ -12,6 +46,10 @@ pub struct ObjectAllocator {}
 impl ObjectAllocator {
     pub fn get_node_constructor(&self) -> fn(SyntaxKind) -> BaseNode {
         Node
+    }
+
+    pub fn get_identifier_constructor(&self) -> fn(SyntaxKind) -> BaseNode {
+        Identifier
     }
 
     pub fn get_source_file_constructor(&self) -> fn(SyntaxKind) -> BaseNode {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,9 @@ pub use compiler::sys::{get_sys, System};
 pub use compiler::types::{
     BaseNode, CharacterCodes, CompilerHost, CreateProgramOptions, Diagnostic, DiagnosticCategory,
     DiagnosticMessage, DiagnosticWithDetachedLocation, EmptyStatement, ExitStatus, Expression,
-    Identifier, ModuleResolutionHost, Node, NodeArray, NodeArrayOrVec, NodeFactory, NodeInterface,
-    ParsedCommandLine, Path, Program, SourceFile, Statement, StructureIsReused, SyntaxKind,
+    ExpressionStatement, Identifier, ModuleResolutionHost, Node, NodeArray, NodeArrayOrVec,
+    NodeFactory, NodeInterface, ParsedCommandLine, Path, Program, SourceFile, Statement,
+    StructureIsReused, SyntaxKind,
 };
 pub use compiler::utilities::{
     create_detached_diagnostic, get_binary_operator_precedence, object_allocator,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,11 +18,14 @@ pub use compiler::scanner::{create_scanner, Scanner};
 pub use compiler::sys::{get_sys, System};
 pub use compiler::types::{
     BaseNode, CharacterCodes, CompilerHost, CreateProgramOptions, Diagnostic, DiagnosticCategory,
-    DiagnosticMessage, DiagnosticWithDetachedLocation, EmptyStatement, ExitStatus,
-    ModuleResolutionHost, Node, NodeArray, NodeArrayOrVec, NodeFactory, NodeInterface,
+    DiagnosticMessage, DiagnosticWithDetachedLocation, EmptyStatement, ExitStatus, Expression,
+    Identifier, ModuleResolutionHost, Node, NodeArray, NodeArrayOrVec, NodeFactory, NodeInterface,
     ParsedCommandLine, Path, Program, SourceFile, Statement, StructureIsReused, SyntaxKind,
 };
-pub use compiler::utilities::{create_detached_diagnostic, object_allocator};
+pub use compiler::utilities::{
+    create_detached_diagnostic, get_binary_operator_precedence, object_allocator,
+    OperatorPrecedence,
+};
 pub use compiler::watch::emit_files_and_report_errors_and_get_exit_status;
 pub use execute_command_line::execute_command_line::execute_command_line;
 pub use rust_helpers::is_same_variant;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,11 +17,11 @@ pub use compiler::program::create_program;
 pub use compiler::scanner::{create_scanner, Scanner};
 pub use compiler::sys::{get_sys, System};
 pub use compiler::types::{
-    BaseNode, CharacterCodes, CompilerHost, CreateProgramOptions, Diagnostic, DiagnosticCategory,
-    DiagnosticMessage, DiagnosticWithDetachedLocation, EmptyStatement, ExitStatus, Expression,
-    ExpressionStatement, Identifier, ModuleResolutionHost, Node, NodeArray, NodeArrayOrVec,
-    NodeFactory, NodeInterface, ParsedCommandLine, Path, Program, SourceFile, Statement,
-    StructureIsReused, SyntaxKind,
+    BaseLiteralLikeNode, BaseNode, CharacterCodes, CompilerHost, CreateProgramOptions, Diagnostic,
+    DiagnosticCategory, DiagnosticMessage, DiagnosticWithDetachedLocation, EmptyStatement,
+    ExitStatus, Expression, ExpressionStatement, Identifier, LiteralLikeNode, ModuleResolutionHost,
+    Node, NodeArray, NodeArrayOrVec, NodeFactory, NodeInterface, NumericLiteral, ParsedCommandLine,
+    Path, Program, SourceFile, Statement, StructureIsReused, SyntaxKind,
 };
 pub use compiler::utilities::{
     create_detached_diagnostic, get_binary_operator_precedence, object_allocator,


### PR DESCRIPTION
In this PR:
- parse numeric literal

To test:
If you have a file named eg `tmp.tsx` in the repo root directory whose contents are just a number eg `12` (no trailing newline) and run `cargo run tmp.tsx` you should see debug-logging of a single `SourceFile` whose `statements` contains a single `ExpressionStatement` whose `expression` is a `NumericLiteral` with `text: "12"`