### PR TITLE
Parse number multiplication

### DIFF
--- a/src/compiler/factory/node_factory.rs
+++ b/src/compiler/factory/node_factory.rs
@@ -1,7 +1,7 @@
 use crate::{
-    BaseLiteralLikeNode, BaseNode, BaseNodeFactory, EmptyStatement, Expression,
-    ExpressionStatement, Identifier, NodeArray, NodeArrayOrVec, NodeFactory, NumericLiteral,
-    SourceFile, SyntaxKind,
+    BaseLiteralLikeNode, BaseNode, BaseNodeFactory, BinaryExpression, EmptyStatement, Expression,
+    ExpressionStatement, Identifier, Node, NodeArray, NodeArrayOrVec, NodeFactory, NumericLiteral,
+    SourceFile, SyntaxKind, Token,
 };
 
 impl NodeFactory {
@@ -67,6 +67,41 @@ impl NodeFactory {
         kind: SyntaxKind,
     ) -> BaseNode {
         base_factory.create_base_token_node(kind)
+    }
+
+    pub fn create_token<TBaseNodeFactory: BaseNodeFactory>(
+        &self,
+        base_factory: &TBaseNodeFactory,
+        token: SyntaxKind,
+    ) -> Token {
+        let node = self.create_base_token(base_factory, token);
+        Token { _node: node }
+    }
+
+    fn create_base_expression<TBaseNodeFactory: BaseNodeFactory>(
+        &self,
+        base_factory: &TBaseNodeFactory,
+        kind: SyntaxKind,
+    ) -> BaseNode {
+        let node = self.create_base_node(base_factory, kind);
+        node
+    }
+
+    pub fn create_binary_expression<TBaseNodeFactory: BaseNodeFactory>(
+        &self,
+        base_factory: &TBaseNodeFactory,
+        left: Expression,
+        operator: Node,
+        right: Expression,
+    ) -> BinaryExpression {
+        let node = self.create_base_expression(base_factory, SyntaxKind::BinaryExpression);
+        let node = BinaryExpression {
+            _node: node,
+            left: Box::new(left),
+            operator_token: Box::new(operator),
+            right: Box::new(right),
+        };
+        node
     }
 
     pub fn create_empty_statement<TBaseNodeFactory: BaseNodeFactory>(

--- a/src/compiler/factory/node_factory.rs
+++ b/src/compiler/factory/node_factory.rs
@@ -95,12 +95,7 @@ impl NodeFactory {
         right: Expression,
     ) -> BinaryExpression {
         let node = self.create_base_expression(base_factory, SyntaxKind::BinaryExpression);
-        let node = BinaryExpression {
-            _node: node,
-            left: Box::new(left),
-            operator_token: Box::new(operator),
-            right: Box::new(right),
-        };
+        let node = BinaryExpression::new(node, left, operator, right);
         node
     }
 

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -5,7 +5,7 @@ use std::sync::{Mutex, MutexGuard};
 use crate::{
     create_detached_diagnostic, create_node_factory, create_scanner,
     get_binary_operator_precedence, is_same_variant, last_or_undefined, normalize_path,
-    object_allocator, BaseNode, BaseNodeFactory, Debug_, DiagnosticMessage,
+    object_allocator, BaseNode, BaseNodeFactory, BinaryExpression, Debug_, DiagnosticMessage,
     DiagnosticWithDetachedLocation, Diagnostics, Expression, Identifier, LiteralLikeNode, Node,
     NodeArray, NodeArrayOrVec, NodeFactory, NodeInterface, OperatorPrecedence, Scanner, SourceFile,
     Statement, SyntaxKind,
@@ -219,6 +219,13 @@ impl ParserType {
         false
     }
 
+    fn parse_token_node(&mut self) -> Node {
+        let kind = self.token();
+        self.next_token();
+        self.finish_node(self.factory.create_token(self, kind))
+            .into()
+    }
+
     fn create_node_array(&self, elements: Vec<Node>) -> NodeArray {
         self.factory.create_node_array(elements)
     }
@@ -364,9 +371,9 @@ impl ParserType {
     }
 
     fn parse_binary_expression_rest(
-        &self,
+        &mut self,
         precedence: OperatorPrecedence,
-        left_operand: Expression,
+        mut left_operand: Expression,
     ) -> Expression {
         loop {
             let new_precedence = get_binary_operator_precedence(self.token());
@@ -376,6 +383,12 @@ impl ParserType {
             if !consume_current_operator {
                 break;
             }
+
+            let operator_token = self.parse_token_node();
+            let right = self.parse_binary_expression_or_higher(new_precedence);
+            left_operand = self
+                .make_binary_expression(left_operand, operator_token, right)
+                .into();
         }
 
         left_operand
@@ -383,6 +396,18 @@ impl ParserType {
 
     fn is_binary_operator(&self) -> bool {
         get_binary_operator_precedence(self.token()) > OperatorPrecedence::Comma
+    }
+
+    fn make_binary_expression(
+        &mut self,
+        left: Expression,
+        operator_token: Node,
+        right: Expression,
+    ) -> BinaryExpression {
+        self.finish_node(
+            self.factory
+                .create_binary_expression(self, left, operator_token, right),
+        )
     }
 
     fn parse_unary_expression_or_higher(&mut self) -> Expression {

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -44,7 +44,7 @@ struct ParserType {
 impl ParserType {
     fn new() -> Self {
         ParserType {
-            scanner: create_scanner(),
+            scanner: create_scanner(true),
             NodeConstructor: None,
             IdentifierConstructor: None,
             TokenConstructor: None,

--- a/src/compiler/scanner.rs
+++ b/src/compiler/scanner.rs
@@ -6,6 +6,7 @@ struct ScanNumberReturn {
 }
 
 pub struct Scanner {
+    skip_trivia: bool,
     text: Option<String>,
     pos: Option<usize>,
     end: Option<usize>,
@@ -39,6 +40,12 @@ impl Scanner {
             let ch = code_point_at(self.text(), self.pos());
 
             match ch {
+                CharacterCodes::space => {
+                    if self.skip_trivia {
+                        self.set_pos(self.pos() + 1);
+                        continue;
+                    }
+                }
                 CharacterCodes::asterisk => {
                     self.set_pos(self.pos() + 1);
                     return self.set_token(SyntaxKind::AsteriskToken);
@@ -93,8 +100,9 @@ impl Scanner {
         self.set_token(SyntaxKind::Unknown);
     }
 
-    fn new() -> Self {
+    fn new(skip_trivia: bool) -> Self {
         Scanner {
+            skip_trivia,
             text: None,
             pos: None,
             end: None,
@@ -215,8 +223,8 @@ impl Scanner {
     // }
 }
 
-pub fn create_scanner() -> Scanner {
-    Scanner::new()
+pub fn create_scanner(skip_trivia: bool) -> Scanner {
+    Scanner::new(skip_trivia)
 }
 
 fn code_point_at(s: &str, i: usize) -> char {

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -16,6 +16,7 @@ pub enum SyntaxKind {
     SemicolonToken,
     AsteriskToken,
     Identifier,
+    BinaryExpression,
     EmptyStatement,
     ExpressionStatement,
     SourceFile,
@@ -32,6 +33,7 @@ pub trait NodeInterface {
 
 #[derive(Debug)]
 pub enum Node {
+    Token(Token),
     Expression(Expression),
     Statement(Statement),
 }
@@ -39,9 +41,27 @@ pub enum Node {
 impl NodeInterface for Node {
     fn kind(&self) -> SyntaxKind {
         match self {
+            Node::Token(token) => token.kind(),
             Node::Expression(expression) => expression.kind(),
             Node::Statement(statement) => statement.kind(),
         }
+    }
+}
+
+#[derive(Debug)]
+pub struct Token {
+    pub _node: BaseNode,
+}
+
+impl NodeInterface for Token {
+    fn kind(&self) -> SyntaxKind {
+        self._node.kind
+    }
+}
+
+impl From<Token> for Node {
+    fn from(token: Token) -> Self {
+        Node::Token(token)
     }
 }
 
@@ -94,6 +114,7 @@ impl From<Identifier> for Expression {
 #[derive(Debug)]
 pub enum Expression {
     Identifier(Identifier),
+    BinaryExpression(BinaryExpression),
     LiteralLikeNode(LiteralLikeNode),
 }
 
@@ -101,6 +122,7 @@ impl NodeInterface for Expression {
     fn kind(&self) -> SyntaxKind {
         match self {
             Expression::Identifier(identifier) => identifier.kind(),
+            Expression::BinaryExpression(binary_expression) => binary_expression.kind(),
             Expression::LiteralLikeNode(literal_like_node) => literal_like_node.kind(),
         }
     }
@@ -109,6 +131,26 @@ impl NodeInterface for Expression {
 impl From<Expression> for Node {
     fn from(expression: Expression) -> Self {
         Node::Expression(expression)
+    }
+}
+
+#[derive(Debug)]
+pub struct BinaryExpression {
+    pub _node: BaseNode,
+    pub left: Box<Expression>,
+    pub operator_token: Box<Node>,
+    pub right: Box<Expression>,
+}
+
+impl NodeInterface for BinaryExpression {
+    fn kind(&self) -> SyntaxKind {
+        self._node.kind
+    }
+}
+
+impl From<BinaryExpression> for Expression {
+    fn from(binary_expression: BinaryExpression) -> Self {
+        Expression::BinaryExpression(binary_expression)
     }
 }
 

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -306,6 +306,7 @@ pub struct CreateProgramOptions<'config> {
 pub struct CharacterCodes;
 #[allow(non_upper_case_globals)]
 impl CharacterCodes {
+    pub const space: char = ' ';
     pub const _0: char = '0';
     pub const _1: char = '1';
     pub const _2: char = '2';

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -142,6 +142,22 @@ pub struct BinaryExpression {
     pub right: Box<Expression>,
 }
 
+impl BinaryExpression {
+    pub fn new(
+        base_node: BaseNode,
+        left: Expression,
+        operator_token: Node,
+        right: Expression,
+    ) -> Self {
+        Self {
+            _node: base_node,
+            left: Box::new(left),
+            operator_token: Box::new(operator_token),
+            right: Box::new(right),
+        }
+    }
+}
+
 impl NodeInterface for BinaryExpression {
     fn kind(&self) -> SyntaxKind {
         self._node.kind

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,11 +17,12 @@ pub use compiler::program::create_program;
 pub use compiler::scanner::{create_scanner, Scanner};
 pub use compiler::sys::{get_sys, System};
 pub use compiler::types::{
-    BaseLiteralLikeNode, BaseNode, CharacterCodes, CompilerHost, CreateProgramOptions, Diagnostic,
-    DiagnosticCategory, DiagnosticMessage, DiagnosticWithDetachedLocation, EmptyStatement,
-    ExitStatus, Expression, ExpressionStatement, Identifier, LiteralLikeNode, ModuleResolutionHost,
-    Node, NodeArray, NodeArrayOrVec, NodeFactory, NodeInterface, NumericLiteral, ParsedCommandLine,
-    Path, Program, SourceFile, Statement, StructureIsReused, SyntaxKind,
+    BaseLiteralLikeNode, BaseNode, BinaryExpression, CharacterCodes, CompilerHost,
+    CreateProgramOptions, Diagnostic, DiagnosticCategory, DiagnosticMessage,
+    DiagnosticWithDetachedLocation, EmptyStatement, ExitStatus, Expression, ExpressionStatement,
+    Identifier, LiteralLikeNode, ModuleResolutionHost, Node, NodeArray, NodeArrayOrVec,
+    NodeFactory, NodeInterface, NumericLiteral, ParsedCommandLine, Path, Program, SourceFile,
+    Statement, StructureIsReused, SyntaxKind, Token,
 };
 pub use compiler::utilities::{
     create_detached_diagnostic, get_binary_operator_precedence, object_allocator,


### PR DESCRIPTION
In this PR:
- parse multiplication of integer literals

To test:
If you have a file named eg `tmp.tsx` in the repo root directory whose contents are just a multiplication of two integer literals eg `12 * 3` (no trailing newline) and run `cargo run tmp.tsx` you should see debug-logging of a single `SourceFile` whose `statements` contains a single `ExpressionStatement` whose `expression` is a `BinaryExpression` with `left` as `NumericLiteral` with `text: "12"`, `operator_token` as `Token` with `kind: AsteriskToken`, and `right` as `NumericLiteral` with `text: "3"`

Based on `parse-asterisk`