### PR TITLE
Parse boolean multiplication

### DIFF
--- a/src/compiler/factory/node_factory.rs
+++ b/src/compiler/factory/node_factory.rs
@@ -1,7 +1,7 @@
 use crate::{
     BaseLiteralLikeNode, BaseNode, BaseNodeFactory, BinaryExpression, EmptyStatement, Expression,
     ExpressionStatement, Identifier, Node, NodeArray, NodeArrayOrVec, NodeFactory, NumericLiteral,
-    SourceFile, SyntaxKind, Token,
+    SourceFile, SyntaxKind,
 };
 
 impl NodeFactory {
@@ -73,9 +73,9 @@ impl NodeFactory {
         &self,
         base_factory: &TBaseNodeFactory,
         token: SyntaxKind,
-    ) -> Token {
+    ) -> BaseNode {
         let node = self.create_base_token(base_factory, token);
-        Token { _node: node }
+        node
     }
 
     fn create_base_expression<TBaseNodeFactory: BaseNodeFactory>(

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -219,11 +219,10 @@ impl ParserType {
         false
     }
 
-    fn parse_token_node(&mut self) -> Node {
+    fn parse_token_node(&mut self) -> BaseNode {
         let kind = self.token();
         self.next_token();
         self.finish_node(self.factory.create_token(self, kind))
-            .into()
     }
 
     fn create_node_array(&self, elements: Vec<Node>) -> NodeArray {
@@ -387,7 +386,7 @@ impl ParserType {
             let operator_token = self.parse_token_node();
             let right = self.parse_binary_expression_or_higher(new_precedence);
             left_operand = self
-                .make_binary_expression(left_operand, operator_token, right)
+                .make_binary_expression(left_operand, operator_token.into(), right)
                 .into();
         }
 
@@ -455,6 +454,9 @@ impl ParserType {
     fn parse_primary_expression(&mut self) -> Expression {
         match self.token() {
             SyntaxKind::NumericLiteral => return self.parse_literal_node().into(),
+            SyntaxKind::TrueKeyword | SyntaxKind::FalseKeyword => {
+                return self.parse_token_node().into()
+            }
             _ => (),
         }
 

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -386,7 +386,7 @@ impl ParserType {
             let operator_token = self.parse_token_node();
             let right = self.parse_binary_expression_or_higher(new_precedence);
             left_operand = self
-                .make_binary_expression(left_operand, operator_token.into(), right)
+                .make_binary_expression(left_operand, operator_token, right)
                 .into();
         }
 
@@ -397,16 +397,18 @@ impl ParserType {
         get_binary_operator_precedence(self.token()) > OperatorPrecedence::Comma
     }
 
-    fn make_binary_expression(
+    fn make_binary_expression<TNode: Into<Node>>(
         &mut self,
         left: Expression,
-        operator_token: Node,
+        operator_token: TNode,
         right: Expression,
     ) -> BinaryExpression {
-        self.finish_node(
-            self.factory
-                .create_binary_expression(self, left, operator_token, right),
-        )
+        self.finish_node(self.factory.create_binary_expression(
+            self,
+            left,
+            operator_token.into(),
+            right,
+        ))
     }
 
     fn parse_unary_expression_or_higher(&mut self) -> Expression {

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -16,6 +16,8 @@ pub enum SyntaxKind {
     SemicolonToken,
     AsteriskToken,
     Identifier,
+    FalseKeyword,
+    TrueKeyword,
     BinaryExpression,
     EmptyStatement,
     ExpressionStatement,
@@ -306,7 +308,13 @@ pub struct CreateProgramOptions<'config> {
 pub struct CharacterCodes;
 #[allow(non_upper_case_globals)]
 impl CharacterCodes {
+    pub const max_ascii_character: char = '';
+
     pub const space: char = ' ';
+
+    pub const underscore: char = '_';
+    pub const dollar_sign: char = '$';
+
     pub const _0: char = '0';
     pub const _1: char = '1';
     pub const _2: char = '2';
@@ -317,6 +325,61 @@ impl CharacterCodes {
     pub const _7: char = '7';
     pub const _8: char = '8';
     pub const _9: char = '9';
+
+    pub const a: char = 'a';
+    pub const b: char = 'b';
+    pub const c: char = 'c';
+    pub const d: char = 'd';
+    pub const e: char = 'e';
+    pub const f: char = 'f';
+    pub const g: char = 'g';
+    pub const h: char = 'h';
+    pub const i: char = 'i';
+    pub const j: char = 'j';
+    pub const k: char = 'k';
+    pub const l: char = 'l';
+    pub const m: char = 'm';
+    pub const n: char = 'n';
+    pub const o: char = 'o';
+    pub const p: char = 'p';
+    pub const q: char = 'q';
+    pub const r: char = 'r';
+    pub const s: char = 's';
+    pub const t: char = 't';
+    pub const u: char = 'u';
+    pub const v: char = 'v';
+    pub const w: char = 'w';
+    pub const x: char = 'x';
+    pub const y: char = 'y';
+    pub const z: char = 'z';
+
+    pub const A: char = 'A';
+    pub const B: char = 'B';
+    pub const C: char = 'C';
+    pub const D: char = 'D';
+    pub const E: char = 'E';
+    pub const F: char = 'F';
+    pub const G: char = 'G';
+    pub const H: char = 'H';
+    pub const I: char = 'I';
+    pub const J: char = 'J';
+    pub const K: char = 'K';
+    pub const L: char = 'L';
+    pub const M: char = 'M';
+    pub const N: char = 'N';
+    pub const O: char = 'O';
+    pub const P: char = 'P';
+    pub const Q: char = 'Q';
+    pub const R: char = 'R';
+    pub const S: char = 'S';
+    pub const T: char = 'T';
+    pub const U: char = 'U';
+    pub const V: char = 'V';
+    pub const W: char = 'W';
+    pub const X: char = 'X';
+    pub const Y: char = 'Y';
+    pub const Z: char = 'Z';
+
     pub const asterisk: char = '*';
     pub const semicolon: char = ';';
     pub const slash: char = '/';

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -24,18 +24,13 @@ pub enum SyntaxKind {
     SourceFile,
 }
 
-#[derive(Debug)]
-pub struct BaseNode {
-    pub kind: SyntaxKind,
-}
-
 pub trait NodeInterface {
     fn kind(&self) -> SyntaxKind;
 }
 
 #[derive(Debug)]
 pub enum Node {
-    Token(Token),
+    BaseNode(BaseNode),
     Expression(Expression),
     Statement(Statement),
 }
@@ -43,7 +38,7 @@ pub enum Node {
 impl NodeInterface for Node {
     fn kind(&self) -> SyntaxKind {
         match self {
-            Node::Token(token) => token.kind(),
+            Node::BaseNode(base_node) => base_node.kind(),
             Node::Expression(expression) => expression.kind(),
             Node::Statement(statement) => statement.kind(),
         }
@@ -51,19 +46,19 @@ impl NodeInterface for Node {
 }
 
 #[derive(Debug)]
-pub struct Token {
-    pub _node: BaseNode,
+pub struct BaseNode {
+    pub kind: SyntaxKind,
 }
 
-impl NodeInterface for Token {
+impl NodeInterface for BaseNode {
     fn kind(&self) -> SyntaxKind {
-        self._node.kind
+        self.kind
     }
 }
 
-impl From<Token> for Node {
-    fn from(token: Token) -> Self {
-        Node::Token(token)
+impl From<BaseNode> for Node {
+    fn from(base_node: BaseNode) -> Self {
+        Node::BaseNode(base_node)
     }
 }
 
@@ -115,6 +110,7 @@ impl From<Identifier> for Expression {
 
 #[derive(Debug)]
 pub enum Expression {
+    TokenExpression(BaseNode),
     Identifier(Identifier),
     BinaryExpression(BinaryExpression),
     LiteralLikeNode(LiteralLikeNode),
@@ -123,6 +119,7 @@ pub enum Expression {
 impl NodeInterface for Expression {
     fn kind(&self) -> SyntaxKind {
         match self {
+            Expression::TokenExpression(token_expression) => token_expression.kind(),
             Expression::Identifier(identifier) => identifier.kind(),
             Expression::BinaryExpression(binary_expression) => binary_expression.kind(),
             Expression::LiteralLikeNode(literal_like_node) => literal_like_node.kind(),
@@ -133,6 +130,12 @@ impl NodeInterface for Expression {
 impl From<Expression> for Node {
     fn from(expression: Expression) -> Self {
         Node::Expression(expression)
+    }
+}
+
+impl From<BaseNode> for Expression {
+    fn from(base_node: BaseNode) -> Self {
+        Expression::TokenExpression(base_node)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub use compiler::types::{
     DiagnosticWithDetachedLocation, EmptyStatement, ExitStatus, Expression, ExpressionStatement,
     Identifier, LiteralLikeNode, ModuleResolutionHost, Node, NodeArray, NodeArrayOrVec,
     NodeFactory, NodeInterface, NumericLiteral, ParsedCommandLine, Path, Program, SourceFile,
-    Statement, StructureIsReused, SyntaxKind, Token,
+    Statement, StructureIsReused, SyntaxKind,
 };
 pub use compiler::utilities::{
     create_detached_diagnostic, get_binary_operator_precedence, object_allocator,


### PR DESCRIPTION
In this PR:
- support parsing a multiplication of integer literals and/or boolean literals

To test:
If you have a file named eg `tmp.tsx` in the repo root directory whose contents are just a multiplication of an integer literal and a boolean literal eg `12 * true` (no trailing newline) and run `cargo run tmp.tsx` you should see debug-logging of a single `SourceFile` whose `statements` contains a single `ExpressionStatement` whose `expression` is a `BinaryExpression` with `left` as `NumericLiteral` with `text: "12"`, `operator_token` as `BaseNode` with `kind: AsteriskToken`, and `right` as `TokenExpression` with `kind: TrueKeyword`