### PR TITLE
Emit type error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12,5 +18,6 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 name = "tsc-rust"
 version = "0.1.0"
 dependencies = [
+ "bitflags",
  "lazy_static",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bitflags = "1.3.2"
 lazy_static = "1.4.0"

--- a/src/compiler/binder.rs
+++ b/src/compiler/binder.rs
@@ -1,0 +1,57 @@
+#![allow(non_upper_case_globals)]
+
+use std::rc::Rc;
+
+use crate::{Node, SourceFile};
+
+// lazy_static! {
+//     static ref binder: BinderType = create_binder();
+// }
+
+pub fn bind_source_file(file: Rc<SourceFile>) {
+    // binder.call(file);
+    create_binder().call(file);
+}
+
+struct BinderType {
+    file: Option<Rc<SourceFile>>,
+    parent: Option<Rc<Node>>,
+}
+
+fn create_binder() -> BinderType {
+    BinderType {
+        file: None,
+        parent: None,
+    }
+}
+
+impl BinderType {
+    fn call(&self, f: Rc<SourceFile>) {
+        self.bind_source_file(f);
+    }
+
+    fn file(&self) -> Rc<SourceFile> {
+        self.file.unwrap().clone()
+    }
+
+    fn bind_source_file(&self, f: Rc<SourceFile>) {
+        self.file = Some(f);
+
+        if true {
+            self.bind(self.file());
+        }
+
+        self.file = None;
+        self.parent = None;
+    }
+
+    fn bind(&self, node: Option<Rc<Node>>) {
+        let node = match node {
+            None => {
+                return;
+            }
+            Some(node) => node,
+        };
+        set_parent(node);
+    }
+}

--- a/src/compiler/binder.rs
+++ b/src/compiler/binder.rs
@@ -2,7 +2,7 @@
 
 use std::rc::Rc;
 
-use crate::{Node, SourceFile};
+use crate::{set_parent, Node, SourceFile};
 
 // lazy_static! {
 //     static ref binder: BinderType = create_binder();
@@ -26,19 +26,19 @@ fn create_binder() -> BinderType {
 }
 
 impl BinderType {
-    fn call(&self, f: Rc<SourceFile>) {
+    fn call(&mut self, f: Rc<SourceFile>) {
         self.bind_source_file(f);
     }
 
     fn file(&self) -> Rc<SourceFile> {
-        self.file.unwrap().clone()
+        self.file.as_ref().unwrap().clone()
     }
 
-    fn bind_source_file(&self, f: Rc<SourceFile>) {
+    fn bind_source_file(&mut self, f: Rc<SourceFile>) {
         self.file = Some(f);
 
         if true {
-            self.bind(self.file());
+            self.bind(Some(Rc::new(self.file().into())));
         }
 
         self.file = None;
@@ -52,6 +52,12 @@ impl BinderType {
             }
             Some(node) => node,
         };
-        set_parent(node);
+        set_parent(
+            &*node,
+            match &self.parent {
+                None => None,
+                Some(parent) => Some(parent.clone()),
+            },
+        );
     }
 }

--- a/src/compiler/binder.rs
+++ b/src/compiler/binder.rs
@@ -6,7 +6,7 @@ use std::sync::RwLock;
 
 use crate::{
     for_each, for_each_child, set_parent, Expression, ExpressionStatement, Node, NodeArray,
-    NodeInterface, SourceFile, Statement, SyntaxKind,
+    NodeInterface, Statement, SyntaxKind,
 };
 
 bitflags! {
@@ -25,13 +25,13 @@ bitflags! {
 //     static ref binder: BinderType = create_binder();
 // }
 
-pub fn bind_source_file(file: Rc<SourceFile>) {
+pub fn bind_source_file(file: Rc<Node>) {
     // binder.call(file);
     create_binder().call(file);
 }
 
 struct BinderType {
-    file: RwLock<Option<Rc<SourceFile>>>,
+    file: RwLock<Option<Rc</*SourceFile*/ Node>>>,
     parent: RwLock<Option<Rc<Node>>>,
 }
 
@@ -43,15 +43,15 @@ fn create_binder() -> BinderType {
 }
 
 impl BinderType {
-    fn call(&self, f: Rc<SourceFile>) {
+    fn call(&self, f: Rc<Node>) {
         self.bind_source_file(f);
     }
 
-    fn file(&self) -> Rc<SourceFile> {
+    fn file(&self) -> Rc<Node> {
         self.file.read().unwrap().as_ref().unwrap().clone()
     }
 
-    fn set_file(&self, file: Option<Rc<SourceFile>>) {
+    fn set_file(&self, file: Option<Rc<Node>>) {
         *self.file.write().unwrap() = file;
     }
 
@@ -63,11 +63,11 @@ impl BinderType {
         *self.parent.write().unwrap() = parent;
     }
 
-    fn bind_source_file(&self, f: Rc<SourceFile>) {
+    fn bind_source_file(&self, f: Rc<Node>) {
         self.set_file(Some(f.clone()));
 
         if true {
-            self.bind(Some(Rc::new(self.file().into())));
+            self.bind(Some(self.file()));
         }
 
         self.set_file(None);

--- a/src/compiler/binder.rs
+++ b/src/compiler/binder.rs
@@ -1,8 +1,25 @@
 #![allow(non_upper_case_globals)]
 
+use bitflags::bitflags;
 use std::rc::Rc;
+use std::sync::RwLock;
 
-use crate::{set_parent, Node, SourceFile};
+use crate::{
+    for_each, for_each_child, set_parent, Expression, ExpressionStatement, Node, NodeArray,
+    NodeInterface, SourceFile, Statement, SyntaxKind,
+};
+
+bitflags! {
+    struct ContainerFlags: u32 {
+        const None = 0;
+
+        const IsContainer = 1 << 0;
+
+        const IsControlFlowContainer = 1 << 2;
+
+        const HasLocals = 1 << 5;
+    }
+}
 
 // lazy_static! {
 //     static ref binder: BinderType = create_binder();
@@ -14,50 +31,164 @@ pub fn bind_source_file(file: Rc<SourceFile>) {
 }
 
 struct BinderType {
-    file: Option<Rc<SourceFile>>,
-    parent: Option<Rc<Node>>,
+    file: RwLock<Option<Rc<SourceFile>>>,
+    parent: RwLock<Option<Rc<Node>>>,
 }
 
 fn create_binder() -> BinderType {
     BinderType {
-        file: None,
-        parent: None,
+        file: RwLock::new(None),
+        parent: RwLock::new(None),
     }
 }
 
 impl BinderType {
-    fn call(&mut self, f: Rc<SourceFile>) {
+    fn call(&self, f: Rc<SourceFile>) {
         self.bind_source_file(f);
     }
 
     fn file(&self) -> Rc<SourceFile> {
-        self.file.as_ref().unwrap().clone()
+        self.file.read().unwrap().as_ref().unwrap().clone()
     }
 
-    fn bind_source_file(&mut self, f: Rc<SourceFile>) {
-        self.file = Some(f);
+    fn set_file(&self, file: Option<Rc<SourceFile>>) {
+        *self.file.write().unwrap() = file;
+    }
+
+    fn parent(&self) -> Rc<Node> {
+        self.parent.read().unwrap().as_ref().unwrap().clone()
+    }
+
+    fn set_parent(&self, parent: Option<Rc<Node>>) {
+        *self.parent.write().unwrap() = parent;
+    }
+
+    fn bind_source_file(&self, f: Rc<SourceFile>) {
+        self.set_file(Some(f.clone()));
 
         if true {
             self.bind(Some(Rc::new(self.file().into())));
         }
 
-        self.file = None;
-        self.parent = None;
+        self.set_file(None);
+        self.set_parent(None);
+    }
+
+    fn bind_container(&self, node: Rc<Node>, container_flags: ContainerFlags) {
+        self.bind_children(node);
+    }
+
+    fn bind_each_functions_first(&self, nodes: &NodeArray) {
+        BinderType::bind_each_callback(nodes, |n| {
+            if n.kind() == SyntaxKind::FunctionDeclaration {
+                self.bind(Some(n))
+            }
+        });
+        BinderType::bind_each_callback(nodes, |n| {
+            if n.kind() != SyntaxKind::FunctionDeclaration {
+                self.bind(Some(n))
+            }
+        });
+    }
+
+    fn bind_each(&self, nodes: &NodeArray) {
+        for_each(nodes, |node, _| {
+            self.bind(Some(node.clone()));
+            Option::<()>::None
+        });
+    }
+
+    fn bind_each_callback<TNodeCallback: FnMut(Rc<Node>)>(
+        nodes: &NodeArray,
+        mut bind_function: TNodeCallback,
+    ) {
+        for_each(nodes, |node, _| {
+            bind_function(node.clone());
+            Option::<()>::None
+        });
+    }
+
+    fn bind_each_child(&self, node: Rc<Node>) {
+        for_each_child(
+            node,
+            |node| self.bind(Some(node)),
+            |nodes| self.bind_each(nodes),
+        );
+    }
+
+    fn bind_children(&self, node: Rc<Node>) {
+        match &*node {
+            Node::Statement(statement) => match statement {
+                Statement::ExpressionStatement(expression_statement) => {
+                    self.bind_expression_statement(expression_statement);
+                }
+                _ => unimplemented!(),
+            },
+            Node::Expression(expression) => match expression {
+                Expression::PrefixUnaryExpression(_) => {
+                    self.bind_prefix_unary_expression_flow(node);
+                }
+                _ => unimplemented!(),
+            },
+            Node::SourceFile(source_file) => {
+                self.bind_each_functions_first(&source_file.statements);
+            }
+            Node::BaseNode(_) => panic!("Didn't expect to bind BaseNode?"),
+        };
+    }
+
+    fn bind_expression_statement(&self, node: &ExpressionStatement) {
+        self.bind(Some(node.expression.clone()));
+    }
+
+    fn bind_prefix_unary_expression_flow(&self, node: Rc<Node>) {
+        if false {
+        } else {
+            self.bind_each_child(node);
+        }
+    }
+
+    fn get_container_flags(&self, node: Rc<Node>) -> ContainerFlags {
+        match node.kind() {
+            SyntaxKind::SourceFile => {
+                return ContainerFlags::IsContainer
+                    | ContainerFlags::IsControlFlowContainer
+                    | ContainerFlags::HasLocals;
+            }
+            _ => (),
+        }
+
+        ContainerFlags::None
     }
 
     fn bind(&self, node: Option<Rc<Node>>) {
-        let node = match node {
+        let node = match node.as_ref() {
             None => {
                 return;
             }
-            Some(node) => node,
+            Some(node) => node.clone(),
         };
         set_parent(
             &*node,
-            match &self.parent {
+            match self.parent.read().unwrap().as_ref() {
                 None => None,
                 Some(parent) => Some(parent.clone()),
             },
         );
+
+        if node.kind() > SyntaxKind::LastToken {
+            let save_parent = match *self.parent.read().unwrap() {
+                None => None,
+                Some(ref rc_node) => Some(rc_node.clone()),
+            };
+            self.set_parent(Some(node.clone()));
+            let container_flags = self.get_container_flags(node.clone());
+            if container_flags == ContainerFlags::None {
+                self.bind_children(node);
+            } else {
+                self.bind_container(node, container_flags);
+            }
+            self.set_parent(save_parent);
+        }
     }
 }

--- a/src/compiler/checker.rs
+++ b/src/compiler/checker.rs
@@ -1,4 +1,7 @@
-use crate::{create_diagnostic_collection, for_each, Diagnostic, Node, SourceFile, TypeChecker};
+use crate::{
+    create_diagnostic_collection, for_each, Diagnostic, Expression, ExpressionStatement, Node,
+    SourceFile, Statement, TypeChecker,
+};
 
 pub fn create_type_checker(produce_diagnostics: bool) -> TypeChecker {
     TypeChecker {
@@ -7,7 +10,23 @@ pub fn create_type_checker(produce_diagnostics: bool) -> TypeChecker {
 }
 
 impl TypeChecker {
-    fn check_source_element(&self, node: &Node) {}
+    fn check_source_element(&self, node: &Node) {
+        self.check_source_element_worker(node)
+    }
+
+    fn check_source_element_worker(&self, node: &Node) {
+        match node {
+            Node::Statement(statement) => {
+                match statement {
+                    Statement::ExpressionStatement(expression_statement) => {
+                        return self.check_expression_statement(expression_statement);
+                    }
+                    _ => unimplemented!(),
+                };
+            }
+            _ => unimplemented!(),
+        };
+    }
 
     fn check_source_file(&self, source_file: &SourceFile) {
         self.check_source_file_worker(source_file)
@@ -38,5 +57,22 @@ impl TypeChecker {
                 boxed
             })
             .collect()
+    }
+
+    fn check_expression(&self, node: &Expression) {
+        self.check_expression_worker(node);
+    }
+
+    fn check_expression_worker(&self, node: &Expression) {
+        match node {
+            // Expression::BinaryExpression(binary_expression) => {
+            //     return self.check_binary_expression(binary_expression);
+            // }
+            _ => unimplemented!(),
+        }
+    }
+
+    fn check_expression_statement(&self, node: &ExpressionStatement) {
+        self.check_expression(&node.expression);
     }
 }

--- a/src/compiler/checker.rs
+++ b/src/compiler/checker.rs
@@ -305,10 +305,14 @@ impl TypeChecker {
     }
 
     fn check_prefix_unary_expression(&self, node: &PrefixUnaryExpression) -> Rc<Type> {
-        let operand_type = self.check_expression(&node.operand);
+        let operand_expression = match &*node.operand {
+            Node::Expression(expression) => expression,
+            _ => panic!("Expected Expression"),
+        };
+        let operand_type = self.check_expression(operand_expression);
         match node.operator {
             SyntaxKind::PlusPlusToken => {
-                self.check_arithmetic_operand_type(&node.operand, operand_type.clone(), &Diagnostics::An_arithmetic_operand_must_be_of_type_any_number_bigint_or_an_enum_type);
+                self.check_arithmetic_operand_type(operand_expression, operand_type.clone(), &Diagnostics::An_arithmetic_operand_must_be_of_type_any_number_bigint_or_an_enum_type);
                 return self.get_unary_result_type(&operand_type);
             }
             _ => {
@@ -318,7 +322,7 @@ impl TypeChecker {
     }
 
     fn get_unary_result_type(&self, operand_type: &Type) -> Rc<Type> {
-        self.number_type().clone()
+        self.number_type()
     }
 
     fn check_expression(&self, node: &Expression) -> Rc<Type> {
@@ -344,7 +348,11 @@ impl TypeChecker {
     }
 
     fn check_expression_statement(&self, node: &ExpressionStatement) {
-        self.check_expression(&node.expression);
+        let expression = match &*node.expression {
+            Node::Expression(expression) => expression,
+            _ => panic!("Expected Expression"),
+        };
+        self.check_expression(expression);
     }
 
     fn initialize_type_checker<TTypeCheckerHost: TypeCheckerHost>(&self, host: &TTypeCheckerHost) {

--- a/src/compiler/checker.rs
+++ b/src/compiler/checker.rs
@@ -1,4 +1,4 @@
-use crate::{create_diagnostic_collection, Diagnostic, SourceFile, TypeChecker};
+use crate::{create_diagnostic_collection, for_each, Diagnostic, Node, SourceFile, TypeChecker};
 
 pub fn create_type_checker(produce_diagnostics: bool) -> TypeChecker {
     TypeChecker {
@@ -7,7 +7,20 @@ pub fn create_type_checker(produce_diagnostics: bool) -> TypeChecker {
 }
 
 impl TypeChecker {
-    fn check_source_file(&self, source_file: &SourceFile) {}
+    fn check_source_element(&self, node: &Node) {}
+
+    fn check_source_file(&self, source_file: &SourceFile) {
+        self.check_source_file_worker(source_file)
+    }
+
+    fn check_source_file_worker(&self, node: &SourceFile) {
+        if true {
+            for_each(&node.statements, |statement, _index| {
+                self.check_source_element(statement);
+                Option::<()>::None
+            });
+        }
+    }
 
     pub fn get_diagnostics(&self, source_file: &SourceFile) -> Vec<Box<dyn Diagnostic>> {
         self.get_diagnostics_worker(source_file)

--- a/src/compiler/checker.rs
+++ b/src/compiler/checker.rs
@@ -52,8 +52,8 @@ pub fn create_type_checker(produce_diagnostics: bool) -> TypeChecker {
             IntrinsicType::FreshableIntrinsicType(freshable_intrinsic_type) => {
                 freshable_intrinsic_type
                     .regular_type
-                    .init(&regular_true_type);
-                freshable_intrinsic_type.fresh_type.init(&true_type);
+                    .init(&regular_true_type, true);
+                freshable_intrinsic_type.fresh_type.init(&true_type, true);
             }
             _ => panic!("Expected FreshableIntrinsicType"),
         },
@@ -65,10 +65,10 @@ pub fn create_type_checker(produce_diagnostics: bool) -> TypeChecker {
             IntrinsicType::FreshableIntrinsicType(freshable_intrinsic_type) => {
                 freshable_intrinsic_type
                     .regular_type
-                    .init(&regular_true_type);
+                    .init(&regular_true_type, false);
                 freshable_intrinsic_type
                     .fresh_type
-                    .init(type_checker.true_type.as_ref().unwrap());
+                    .init(type_checker.true_type.as_ref().unwrap(), false);
             }
             _ => panic!("Expected FreshableIntrinsicType"),
         },

--- a/src/compiler/checker.rs
+++ b/src/compiler/checker.rs
@@ -4,14 +4,18 @@ use std::rc::Rc;
 use std::sync::RwLock;
 
 use crate::{
-    create_diagnostic_collection, create_diagnostic_for_node, for_each, object_allocator,
-    BaseIntrinsicType, BaseType, BaseUnionOrIntersectionType, Diagnostic, DiagnosticCollection,
-    DiagnosticMessage, Diagnostics, Expression, ExpressionStatement, FreshableIntrinsicType,
-    IntrinsicType, Node, NodeInterface, PrefixUnaryExpression, RelationComparisonResult,
-    SourceFile, Statement, SyntaxKind, Type, TypeChecker, TypeFlags, TypeInterface, UnionType,
+    bind_source_file, create_diagnostic_collection, create_diagnostic_for_node, for_each,
+    object_allocator, BaseIntrinsicType, BaseType, BaseUnionOrIntersectionType, Diagnostic,
+    DiagnosticCollection, DiagnosticMessage, Diagnostics, Expression, ExpressionStatement,
+    FreshableIntrinsicType, IntrinsicType, Node, NodeInterface, PrefixUnaryExpression,
+    RelationComparisonResult, SourceFile, Statement, SyntaxKind, Type, TypeChecker,
+    TypeCheckerHost, TypeFlags, TypeInterface, UnionType,
 };
 
-pub fn create_type_checker(produce_diagnostics: bool) -> TypeChecker {
+pub fn create_type_checker<TTypeCheckerHost: TypeCheckerHost>(
+    host: &TTypeCheckerHost,
+    produce_diagnostics: bool,
+) -> TypeChecker {
     let mut type_checker = TypeChecker {
         Type: object_allocator.get_type_constructor(),
 
@@ -83,6 +87,7 @@ pub fn create_type_checker(produce_diagnostics: bool) -> TypeChecker {
             ])
             .into(),
     );
+    type_checker.initialize_type_checker(host);
     type_checker
 }
 
@@ -340,5 +345,11 @@ impl TypeChecker {
 
     fn check_expression_statement(&self, node: &ExpressionStatement) {
         self.check_expression(&node.expression);
+    }
+
+    fn initialize_type_checker<TTypeCheckerHost: TypeCheckerHost>(&self, host: &TTypeCheckerHost) {
+        for file in host.get_source_files() {
+            bind_source_file(file);
+        }
     }
 }

--- a/src/compiler/checker.rs
+++ b/src/compiler/checker.rs
@@ -1,0 +1,29 @@
+use crate::{create_diagnostic_collection, Diagnostic, SourceFile, TypeChecker};
+
+pub fn create_type_checker(produce_diagnostics: bool) -> TypeChecker {
+    TypeChecker {
+        diagnostics: create_diagnostic_collection(),
+    }
+}
+
+impl TypeChecker {
+    fn check_source_file(&self, source_file: &SourceFile) {}
+
+    pub fn get_diagnostics(&self, source_file: &SourceFile) -> Vec<Box<dyn Diagnostic>> {
+        self.get_diagnostics_worker(source_file)
+    }
+
+    fn get_diagnostics_worker(&self, source_file: &SourceFile) -> Vec<Box<dyn Diagnostic>> {
+        self.check_source_file(source_file);
+
+        let semantic_diagnostics = self.diagnostics.get_diagnostics(&source_file.file_name);
+
+        semantic_diagnostics
+            .into_iter()
+            .map(|diagnostic| {
+                let boxed: Box<dyn Diagnostic> = Box::new(diagnostic);
+                boxed
+            })
+            .collect()
+    }
+}

--- a/src/compiler/checker.rs
+++ b/src/compiler/checker.rs
@@ -1,8 +1,11 @@
+use std::collections::HashMap;
+use std::rc::Rc;
+
 use crate::{
     create_diagnostic_collection, for_each, object_allocator, BaseIntrinsicType, BaseType,
     Diagnostic, DiagnosticMessage, Diagnostics, Expression, ExpressionStatement,
-    FreshableIntrinsicType, Node, NodeInterface, PrefixUnaryExpression, SourceFile, Statement,
-    SyntaxKind, Type, TypeChecker, TypeFlags,
+    FreshableIntrinsicType, Node, NodeInterface, PrefixUnaryExpression, RelationComparisonResult,
+    SourceFile, Statement, SyntaxKind, Type, TypeChecker, TypeFlags,
 };
 
 pub fn create_type_checker(produce_diagnostics: bool) -> TypeChecker {
@@ -15,35 +18,50 @@ pub fn create_type_checker(produce_diagnostics: bool) -> TypeChecker {
         number_or_big_int_type: None,
 
         diagnostics: create_diagnostic_collection(),
+
+        assignable_relation: HashMap::new(),
     };
-    type_checker.number_type =
-        Some(type_checker.create_intrinsic_type(TypeFlags::Number, "number"));
-    type_checker.bigint_type =
-        Some(type_checker.create_intrinsic_type(TypeFlags::BigInt, "bigint"));
-    type_checker.true_type = Some(FreshableIntrinsicType::new(
-        type_checker.create_intrinsic_type(TypeFlags::BooleanLiteral, "true"),
+    type_checker.number_type = Some(Rc::new(
+        type_checker
+            .create_intrinsic_type(TypeFlags::Number, "number")
+            .into(),
     ));
-    type_checker.number_or_big_int_type = Some(type_checker.get_union_type(vec![
-        Box::new(type_checker.number_type()),
-        Box::new(type_checker.bigint_type()),
-    ]));
+    type_checker.bigint_type = Some(Rc::new(
+        type_checker
+            .create_intrinsic_type(TypeFlags::BigInt, "bigint")
+            .into(),
+    ));
+    type_checker.true_type = Some(Rc::new(
+        FreshableIntrinsicType::new(
+            type_checker.create_intrinsic_type(TypeFlags::BooleanLiteral, "true"),
+        )
+        .into(),
+    ));
+    type_checker.number_or_big_int_type = Some(
+        type_checker
+            .get_union_type(vec![
+                type_checker.number_type().clone(),
+                type_checker.bigint_type().clone(),
+            ])
+            .into(),
+    );
     type_checker
 }
 
 impl TypeChecker {
-    fn number_type(&self) -> BaseIntrinsicType {
-        self.number_type.as_ref().unwrap().clone()
+    fn number_type(&self) -> Rc<Type> {
+        self.number_type.unwrap().clone()
     }
 
-    fn bigint_type(&self) -> BaseIntrinsicType {
-        self.bigint_type.as_ref().unwrap().clone()
+    fn bigint_type(&self) -> Rc<Type> {
+        self.bigint_type.unwrap().clone()
     }
 
-    fn true_type(&self) -> FreshableIntrinsicType {
-        self.true_type.as_ref().unwrap().clone()
+    fn true_type(&self) -> Rc<Type> {
+        self.true_type.unwrap().clone()
     }
 
-    fn number_or_big_int_type(&self) -> Box<dyn Type> {
+    fn number_or_big_int_type(&self) -> Rc<Type> {
         self.number_or_big_int_type.unwrap().clone()
     }
 
@@ -58,7 +76,19 @@ impl TypeChecker {
         type_
     }
 
-    fn get_union_type(&self, types: Vec<Box<dyn Type>>) -> Box<dyn Type> {}
+    fn get_union_type(&self, types: Vec<Rc<Type>>) -> Rc<Type> {}
+
+    fn is_type_assignable_to(&self, source: Rc<Type>, target: Rc<Type>) -> bool {
+        self.is_type_related_to(source, target, &self.assignable_relation)
+    }
+
+    fn is_type_related_to(
+        &self,
+        source: Rc<Type>,
+        target: Rc<Type>,
+        relation: &HashMap<String, RelationComparisonResult>,
+    ) -> bool {
+    }
 
     fn check_source_element(&self, node: &Node) {
         self.check_source_element_worker(node)
@@ -112,7 +142,7 @@ impl TypeChecker {
     fn check_arithmetic_operand_type(
         &self,
         operand: /*&Node*/ &Expression,
-        type_: &Box<dyn Type>,
+        type_: Rc<Type>,
         diagnostic: &DiagnosticMessage,
     ) -> bool {
         if !self.is_type_assignable_to(type_, self.number_or_big_int_type()) {
@@ -122,11 +152,11 @@ impl TypeChecker {
         true
     }
 
-    fn check_prefix_unary_expression(&self, node: &PrefixUnaryExpression) -> Box<dyn Type> {
+    fn check_prefix_unary_expression(&self, node: &PrefixUnaryExpression) -> Rc<Type> {
         let operand_type = self.check_expression(&node.operand);
         match node.operator {
             SyntaxKind::PlusPlusToken => {
-                self.check_arithmetic_operand_type(&node.operand, &operand_type, &Diagnostics::An_arithmetic_operand_must_be_of_type_any_number_bigint_or_an_enum_type);
+                self.check_arithmetic_operand_type(&node.operand, operand_type, &Diagnostics::An_arithmetic_operand_must_be_of_type_any_number_bigint_or_an_enum_type);
                 return self.get_unary_result_type(&operand_type);
             }
             _ => {
@@ -135,19 +165,19 @@ impl TypeChecker {
         }
     }
 
-    fn get_unary_result_type(&self, operand_type: &Box<dyn Type>) -> Box<dyn Type> {
-        Box::new(self.number_type().clone())
+    fn get_unary_result_type(&self, operand_type: &Type) -> Rc<Type> {
+        self.number_type().clone()
     }
 
-    fn check_expression(&self, node: &Expression) -> Box<dyn Type> {
+    fn check_expression(&self, node: &Expression) -> Rc<Type> {
         self.check_expression_worker(node)
     }
 
-    fn check_expression_worker(&self, node: &Expression) -> Box<dyn Type> {
+    fn check_expression_worker(&self, node: &Expression) -> Rc<Type> {
         match node {
             Expression::TokenExpression(token_expression) => match token_expression.kind() {
                 SyntaxKind::TrueKeyword => {
-                    return Box::new(self.true_type().clone());
+                    return self.true_type().clone();
                 }
                 _ => unimplemented!(),
             },

--- a/src/compiler/checker.rs
+++ b/src/compiler/checker.rs
@@ -1,15 +1,47 @@
 use crate::{
-    create_diagnostic_collection, for_each, Diagnostic, Expression, ExpressionStatement, Node,
-    SourceFile, Statement, TypeChecker,
+    create_diagnostic_collection, for_each, object_allocator, BaseIntrinsicType, BaseType,
+    Diagnostic, DiagnosticMessage, Diagnostics, Expression, ExpressionStatement,
+    FreshableIntrinsicType, Node, NodeInterface, PrefixUnaryExpression, SourceFile, Statement,
+    SyntaxKind, Type, TypeChecker, TypeFlags,
 };
 
 pub fn create_type_checker(produce_diagnostics: bool) -> TypeChecker {
-    TypeChecker {
+    let mut type_checker = TypeChecker {
+        Type: object_allocator.get_type_constructor(),
+
+        number_type: None,
+        true_type: None,
+
         diagnostics: create_diagnostic_collection(),
-    }
+    };
+    type_checker.number_type =
+        Some(type_checker.create_intrinsic_type(TypeFlags::Number, "number"));
+    type_checker.true_type = Some(FreshableIntrinsicType::new(
+        type_checker.create_intrinsic_type(TypeFlags::BooleanLiteral, "true"),
+    ));
+    type_checker
 }
 
 impl TypeChecker {
+    fn number_type(&self) -> BaseIntrinsicType {
+        self.number_type.as_ref().unwrap().clone()
+    }
+
+    fn true_type(&self) -> FreshableIntrinsicType {
+        self.true_type.as_ref().unwrap().clone()
+    }
+
+    fn create_type(&self, flags: TypeFlags) -> BaseType {
+        let result = (self.Type)(flags);
+        result
+    }
+
+    fn create_intrinsic_type(&self, kind: TypeFlags, intrinsic_name: &str) -> BaseIntrinsicType {
+        let type_ = self.create_type(kind);
+        let type_ = BaseIntrinsicType::new(type_);
+        type_
+    }
+
     fn check_source_element(&self, node: &Node) {
         self.check_source_element_worker(node)
     }
@@ -59,12 +91,51 @@ impl TypeChecker {
             .collect()
     }
 
-    fn check_expression(&self, node: &Expression) {
-        self.check_expression_worker(node);
+    fn check_arithmetic_operand_type(
+        &self,
+        operand: /*&Node*/ &Expression,
+        type_: &Box<dyn Type>,
+        diagnostic: &DiagnosticMessage,
+    ) -> bool {
+        // if !self.is_type_assignable_to(type_, self.number_or_big_int_type()) {
+        //     self.error_and_maybe_suggest_await(operand, diagnostic);
+        //     return false;
+        // }
+        true
     }
 
-    fn check_expression_worker(&self, node: &Expression) {
+    fn check_prefix_unary_expression(&self, node: &PrefixUnaryExpression) -> Box<dyn Type> {
+        let operand_type = self.check_expression(&node.operand);
+        match node.operator {
+            SyntaxKind::PlusPlusToken => {
+                self.check_arithmetic_operand_type(&node.operand, &operand_type, &Diagnostics::An_arithmetic_operand_must_be_of_type_any_number_bigint_or_an_enum_type);
+                return self.get_unary_result_type(&operand_type);
+            }
+            _ => {
+                unimplemented!();
+            }
+        }
+    }
+
+    fn get_unary_result_type(&self, operand_type: &Box<dyn Type>) -> Box<dyn Type> {
+        Box::new(self.number_type().clone())
+    }
+
+    fn check_expression(&self, node: &Expression) -> Box<dyn Type> {
+        self.check_expression_worker(node)
+    }
+
+    fn check_expression_worker(&self, node: &Expression) -> Box<dyn Type> {
         match node {
+            Expression::TokenExpression(token_expression) => match token_expression.kind() {
+                SyntaxKind::TrueKeyword => {
+                    return Box::new(self.true_type().clone());
+                }
+                _ => unimplemented!(),
+            },
+            Expression::PrefixUnaryExpression(prefix_unary_expression) => {
+                return self.check_prefix_unary_expression(prefix_unary_expression);
+            }
             // Expression::BinaryExpression(binary_expression) => {
             //     return self.check_binary_expression(binary_expression);
             // }

--- a/src/compiler/checker.rs
+++ b/src/compiler/checker.rs
@@ -50,8 +50,10 @@ pub fn create_type_checker(produce_diagnostics: bool) -> TypeChecker {
     match &*true_type {
         Type::IntrinsicType(intrinsic_type) => match intrinsic_type {
             IntrinsicType::FreshableIntrinsicType(freshable_intrinsic_type) => {
-                freshable_intrinsic_type.regular_type = Some(Rc::downgrade(&regular_true_type));
-                freshable_intrinsic_type.fresh_type = Some(Rc::downgrade(&true_type));
+                freshable_intrinsic_type
+                    .regular_type
+                    .init(&regular_true_type);
+                freshable_intrinsic_type.fresh_type.init(&true_type);
             }
             _ => panic!("Expected FreshableIntrinsicType"),
         },
@@ -61,8 +63,12 @@ pub fn create_type_checker(produce_diagnostics: bool) -> TypeChecker {
     match &*regular_true_type {
         Type::IntrinsicType(intrinsic_type) => match intrinsic_type {
             IntrinsicType::FreshableIntrinsicType(freshable_intrinsic_type) => {
-                freshable_intrinsic_type.regular_type = Some(Rc::downgrade(&regular_true_type));
-                freshable_intrinsic_type.fresh_type = Some(Rc::downgrade(&true_type));
+                freshable_intrinsic_type
+                    .regular_type
+                    .init(&regular_true_type);
+                freshable_intrinsic_type
+                    .fresh_type
+                    .init(type_checker.true_type.as_ref().unwrap());
             }
             _ => panic!("Expected FreshableIntrinsicType"),
         },

--- a/src/compiler/checker.rs
+++ b/src/compiler/checker.rs
@@ -47,7 +47,7 @@ pub fn create_type_checker(produce_diagnostics: bool) -> TypeChecker {
         )
         .into(),
     );
-    match *true_type {
+    match &*true_type {
         Type::IntrinsicType(intrinsic_type) => match intrinsic_type {
             IntrinsicType::FreshableIntrinsicType(freshable_intrinsic_type) => {
                 freshable_intrinsic_type.regular_type = Some(Rc::downgrade(&regular_true_type));
@@ -58,7 +58,7 @@ pub fn create_type_checker(produce_diagnostics: bool) -> TypeChecker {
         _ => panic!("Expected IntrinsicType"),
     }
     type_checker.true_type = Some(true_type);
-    match *regular_true_type {
+    match &*regular_true_type {
         Type::IntrinsicType(intrinsic_type) => match intrinsic_type {
             IntrinsicType::FreshableIntrinsicType(freshable_intrinsic_type) => {
                 freshable_intrinsic_type.regular_type = Some(Rc::downgrade(&regular_true_type));
@@ -82,19 +82,19 @@ pub fn create_type_checker(produce_diagnostics: bool) -> TypeChecker {
 
 impl TypeChecker {
     fn number_type(&self) -> Rc<Type> {
-        self.number_type.unwrap().clone()
+        self.number_type.as_ref().unwrap().clone()
     }
 
     fn bigint_type(&self) -> Rc<Type> {
-        self.bigint_type.unwrap().clone()
+        self.bigint_type.as_ref().unwrap().clone()
     }
 
     fn true_type(&self) -> Rc<Type> {
-        self.true_type.unwrap().clone()
+        self.true_type.as_ref().unwrap().clone()
     }
 
     fn number_or_big_int_type(&self) -> Rc<Type> {
-        self.number_or_big_int_type.unwrap().clone()
+        self.number_or_big_int_type.as_ref().unwrap().clone()
     }
 
     fn diagnostics(&self) -> &RwLock<DiagnosticCollection> {
@@ -154,13 +154,13 @@ impl TypeChecker {
     }
 
     fn get_union_type(&self, types: Vec<Rc<Type>>) -> Rc<Type> {
-        let type_set: Vec<Rc<Type>> = vec![];
+        let mut type_set: Vec<Rc<Type>> = vec![];
         self.add_types_to_union(&mut type_set, /*TypeFlags::empty(), */ &types);
         self.get_union_type_from_sorted_list(type_set)
     }
 
     fn get_union_type_from_sorted_list(&self, types: Vec<Rc<Type>>) -> Rc<Type> {
-        let type_: Option<Rc<Type>> = None;
+        let mut type_: Option<Rc<Type>> = None;
         if type_.is_none() {
             let base_type = self.create_type(TypeFlags::Union);
             type_ = Some(Rc::new(
@@ -180,7 +180,7 @@ impl TypeChecker {
         if !type_.flags().intersects(TypeFlags::Literal) {
             return false;
         }
-        match *type_ {
+        match &*type_ {
             Type::IntrinsicType(intrinsic_type) => match intrinsic_type {
                 IntrinsicType::FreshableIntrinsicType(freshable_intrinsic_type) => {
                     ptr::eq(&*type_, freshable_intrinsic_type.fresh_type().as_ptr())
@@ -197,12 +197,12 @@ impl TypeChecker {
 
     fn is_type_related_to(
         &self,
-        source: Rc<Type>,
+        mut source: Rc<Type>,
         target: Rc<Type>,
         relation: &HashMap<String, RelationComparisonResult>,
     ) -> bool {
-        if self.is_fresh_literal_type(source) {
-            source = match *source {
+        if self.is_fresh_literal_type(source.clone()) {
+            source = match &*source {
                 Type::IntrinsicType(intrinsic_type) => match intrinsic_type {
                     IntrinsicType::FreshableIntrinsicType(freshable_intrinsic_type) => {
                         freshable_intrinsic_type.regular_type().upgrade().unwrap()
@@ -297,7 +297,7 @@ impl TypeChecker {
         let operand_type = self.check_expression(&node.operand);
         match node.operator {
             SyntaxKind::PlusPlusToken => {
-                self.check_arithmetic_operand_type(&node.operand, operand_type, &Diagnostics::An_arithmetic_operand_must_be_of_type_any_number_bigint_or_an_enum_type);
+                self.check_arithmetic_operand_type(&node.operand, operand_type.clone(), &Diagnostics::An_arithmetic_operand_must_be_of_type_any_number_bigint_or_an_enum_type);
                 return self.get_unary_result_type(&operand_type);
             }
             _ => {

--- a/src/compiler/core.rs
+++ b/src/compiler/core.rs
@@ -8,6 +8,21 @@ pub fn for_each<TItem, TReturn>(
         .find_map(|(index, item)| callback(item, index))
 }
 
+fn some<TItem>(array: &[TItem], predicate: Option<Box<dyn FnMut(&TItem) -> bool>>) -> bool {
+    predicate.map_or(!array.is_empty(), |predicate| array.iter().any(predicate))
+}
+
+pub fn concatenate<TItem>(mut array1: Vec<TItem>, mut array2: Vec<TItem>) -> Vec<TItem> {
+    if !some(&array2, None) {
+        return array1;
+    }
+    if !some(&array1, None) {
+        return array2;
+    }
+    array1.append(&mut array2);
+    array1
+}
+
 pub fn last_or_undefined<TItem>(array: &[TItem]) -> Option<&TItem> {
     array.last()
 }

--- a/src/compiler/core.rs
+++ b/src/compiler/core.rs
@@ -1,3 +1,5 @@
+use crate::SortedArray;
+
 pub fn for_each<
     TCollection: IntoIterator,
     TReturn,
@@ -25,6 +27,14 @@ pub fn concatenate<TItem>(mut array1: Vec<TItem>, mut array2: Vec<TItem>) -> Vec
     }
     array1.append(&mut array2);
     array1
+}
+
+pub fn insert_sorted<TItem>(array: &mut SortedArray<TItem>, insert: TItem) {
+    if array.is_empty() {
+        array.push(insert);
+        return;
+    }
+    unimplemented!()
 }
 
 pub fn last_or_undefined<TItem>(array: &[TItem]) -> Option<&TItem> {

--- a/src/compiler/core.rs
+++ b/src/compiler/core.rs
@@ -1,9 +1,13 @@
-pub fn for_each<TItem, TReturn>(
-    array: &[TItem],
-    callback: &mut dyn FnMut(&TItem, usize) -> Option<TReturn>,
+pub fn for_each<
+    TCollection: IntoIterator,
+    TReturn,
+    TCallback: FnMut(TCollection::Item, usize) -> Option<TReturn>,
+>(
+    array: TCollection,
+    mut callback: TCallback,
 ) -> Option<TReturn> {
     array
-        .iter()
+        .into_iter()
         .enumerate()
         .find_map(|(index, item)| callback(item, index))
 }

--- a/src/compiler/core_public.rs
+++ b/src/compiler/core_public.rs
@@ -1,0 +1,9 @@
+pub struct SortedArray<TItem> {
+    pub _vec: Vec<TItem>,
+}
+
+impl<TItem> SortedArray<TItem> {
+    pub fn new(vec: Vec<TItem>) -> Self {
+        Self { _vec: vec }
+    }
+}

--- a/src/compiler/core_public.rs
+++ b/src/compiler/core_public.rs
@@ -6,4 +6,12 @@ impl<TItem> SortedArray<TItem> {
     pub fn new(vec: Vec<TItem>) -> Self {
         Self { _vec: vec }
     }
+
+    pub fn push(&mut self, item: TItem) {
+        self._vec.push(item);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self._vec.is_empty()
+    }
 }

--- a/src/compiler/diagnostic_information_map_generated.rs
+++ b/src/compiler/diagnostic_information_map_generated.rs
@@ -36,4 +36,11 @@ impl Diagnostics {
         "Expression_expected_1109",
         "Expression expected.",
     );
+    pub const An_arithmetic_operand_must_be_of_type_any_number_bigint_or_an_enum_type:
+        DiagnosticMessage = diag(
+        2356,
+        DiagnosticCategory::Error,
+        "An_arithmetic_operand_must_be_of_type_any_number_bigint_or_an_enum_type_2356",
+        "An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type.",
+    );
 }

--- a/src/compiler/factory/node_factory.rs
+++ b/src/compiler/factory/node_factory.rs
@@ -128,6 +128,7 @@ impl NodeFactory {
         let node = SourceFile {
             _node: node,
             statements: self.create_node_array(statements),
+            file_name: "".to_string(),
         };
         node
     }

--- a/src/compiler/factory/node_factory.rs
+++ b/src/compiler/factory/node_factory.rs
@@ -1,7 +1,7 @@
 use crate::{
     BaseLiteralLikeNode, BaseNode, BaseNodeFactory, BinaryExpression, EmptyStatement, Expression,
     ExpressionStatement, Identifier, Node, NodeArray, NodeArrayOrVec, NodeFactory, NumericLiteral,
-    SourceFile, SyntaxKind,
+    PrefixUnaryExpression, SourceFile, SyntaxKind,
 };
 
 impl NodeFactory {
@@ -84,6 +84,17 @@ impl NodeFactory {
         kind: SyntaxKind,
     ) -> BaseNode {
         let node = self.create_base_node(base_factory, kind);
+        node
+    }
+
+    pub fn create_prefix_unary_expression<TBaseNodeFactory: BaseNodeFactory>(
+        &self,
+        base_factory: &TBaseNodeFactory,
+        operator: SyntaxKind,
+        operand: Expression,
+    ) -> PrefixUnaryExpression {
+        let node = self.create_base_expression(base_factory, SyntaxKind::PrefixUnaryExpression);
+        let node = PrefixUnaryExpression::new(node, operator, operand);
         node
     }
 

--- a/src/compiler/factory/node_factory.rs
+++ b/src/compiler/factory/node_factory.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use crate::{
     BaseLiteralLikeNode, BaseNode, BaseNodeFactory, BinaryExpression, EmptyStatement, Expression,
     ExpressionStatement, Identifier, Node, NodeArray, NodeArrayOrVec, NodeFactory, NumericLiteral,
@@ -126,7 +128,7 @@ impl NodeFactory {
     ) -> ExpressionStatement {
         ExpressionStatement {
             _node: self.create_base_node(base_factory, SyntaxKind::ExpressionStatement),
-            expression,
+            expression: Rc::new(expression.into()),
         }
     }
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1,5 +1,7 @@
+pub mod checker;
 pub mod command_line_parser;
 pub mod core;
+pub mod core_public;
 pub mod debug;
 pub mod diagnostic_information_map_generated;
 pub mod factory;

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -12,4 +12,5 @@ pub mod scanner;
 pub mod sys;
 pub mod types;
 pub mod utilities;
+pub mod utilities_public;
 pub mod watch;

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1,3 +1,4 @@
+pub mod binder;
 pub mod checker;
 pub mod command_line_parser;
 pub mod core;

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -31,6 +31,12 @@ impl NodeInterface for MissingNode {
             MissingNode::Identifier(identifier) => identifier.parent(),
         }
     }
+
+    fn set_parent(&self, parent: Rc<Node>) {
+        match self {
+            MissingNode::Identifier(identifier) => identifier.set_parent(parent),
+        }
+    }
 }
 
 #[allow(non_snake_case)]

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -70,7 +70,7 @@ impl ReadonlyTextRange for MissingNode {
         }
     }
 
-    fn set_pos(&mut self, pos: usize) {
+    fn set_pos(&self, pos: usize) {
         match self {
             MissingNode::Identifier(identifier) => identifier.set_pos(pos),
         }
@@ -82,7 +82,7 @@ impl ReadonlyTextRange for MissingNode {
         }
     }
 
-    fn set_end(&mut self, end: usize) {
+    fn set_end(&self, end: usize) {
         match self {
             MissingNode::Identifier(identifier) => identifier.set_end(end),
         }

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -188,10 +188,14 @@ impl ParserType {
 
     fn create_source_file<TNodes: Into<NodeArrayOrVec>>(
         &self,
-        _file_name: &str,
+        file_name: &str,
         statements: TNodes,
     ) -> SourceFile {
-        self.factory.create_source_file(self, statements)
+        let mut source_file = self.factory.create_source_file(self, statements);
+
+        source_file.file_name = file_name.to_string();
+
+        source_file
     }
 
     fn parse_error_at_current_token(&mut self, message: &DiagnosticMessage) {

--- a/src/compiler/program.rs
+++ b/src/compiler/program.rs
@@ -191,7 +191,7 @@ pub fn create_program(root_names_or_options: CreateProgramOptions) -> impl Progr
         });
 
         files = processing_other_files_present;
-        println!("{:?}", files);
+        println!("files: {:?}", files);
         processing_other_files = None;
     }
 

--- a/src/compiler/program.rs
+++ b/src/compiler/program.rs
@@ -161,7 +161,7 @@ pub fn create_program(root_names_or_options: CreateProgramOptions) -> impl Progr
             host: &host,
             current_directory: &current_directory,
         };
-        for_each(root_names, &mut |name, _index| {
+        for_each(root_names, |name, _index| {
             process_root_file(&mut helper_context, name);
             Option::<()>::None
         });

--- a/src/compiler/program.rs
+++ b/src/compiler/program.rs
@@ -59,15 +59,15 @@ impl ProgramConcrete {
 
     fn get_diagnostics_helper(
         &mut self,
-        get_diagnostics: fn(&mut ProgramConcrete, &SourceFile) -> Vec<Box<dyn Diagnostic>>,
-    ) -> Vec<Box<dyn Diagnostic>> {
+        get_diagnostics: fn(&mut ProgramConcrete, &SourceFile) -> Vec<Rc<Diagnostic>>,
+    ) -> Vec<Rc<Diagnostic>> {
         self.get_source_files()
             .iter()
             .flat_map(|source_file| get_diagnostics(self, source_file))
             .collect()
     }
 
-    fn get_program_diagnostics(&self, source_file: &SourceFile) -> Vec<Box<dyn Diagnostic>> {
+    fn get_program_diagnostics(&self, source_file: &SourceFile) -> Vec<Rc<Diagnostic>> {
         vec![]
     }
 
@@ -81,7 +81,7 @@ impl ProgramConcrete {
     fn get_semantic_diagnostics_for_file(
         &mut self,
         source_file: &SourceFile,
-    ) -> Vec<Box<dyn Diagnostic>> {
+    ) -> Vec<Rc<Diagnostic>> {
         concatenate(
             filter_semantic_diagnostics(self.get_bind_and_check_diagnostics_for_file(source_file)),
             self.get_program_diagnostics(source_file),
@@ -91,7 +91,7 @@ impl ProgramConcrete {
     fn get_bind_and_check_diagnostics_for_file(
         &mut self,
         source_file: &SourceFile,
-    ) -> Vec<Box<dyn Diagnostic>> {
+    ) -> Vec<Rc<Diagnostic>> {
         self.get_and_cache_diagnostics(
             source_file,
             ProgramConcrete::get_bind_and_check_diagnostics_for_file_no_cache,
@@ -101,7 +101,7 @@ impl ProgramConcrete {
     fn get_bind_and_check_diagnostics_for_file_no_cache(
         &mut self,
         source_file: &SourceFile,
-    ) -> Vec<Box<dyn Diagnostic>> {
+    ) -> Vec<Rc<Diagnostic>> {
         // self.run_with_cancellation_token(|| {
         let type_checker = self.get_diagnostics_producing_type_checker();
 
@@ -119,15 +119,15 @@ impl ProgramConcrete {
     fn get_and_cache_diagnostics(
         &mut self,
         source_file: &SourceFile,
-        get_diagnostics: fn(&mut ProgramConcrete, &SourceFile) -> Vec<Box<dyn Diagnostic>>,
-    ) -> Vec<Box<dyn Diagnostic>> {
+        get_diagnostics: fn(&mut ProgramConcrete, &SourceFile) -> Vec<Rc<Diagnostic>>,
+    ) -> Vec<Rc<Diagnostic>> {
         let result = get_diagnostics(self, source_file);
         result
     }
 }
 
 impl Program for ProgramConcrete {
-    fn get_semantic_diagnostics(&mut self) -> Vec<Box<dyn Diagnostic>> {
+    fn get_semantic_diagnostics(&mut self) -> Vec<Rc<Diagnostic>> {
         self.get_diagnostics_helper(ProgramConcrete::get_semantic_diagnostics_for_file)
     }
 
@@ -174,7 +174,7 @@ pub fn create_program(root_names_or_options: CreateProgramOptions) -> impl Progr
     ProgramConcrete::new(files)
 }
 
-fn filter_semantic_diagnostics(diagnostic: Vec<Box<dyn Diagnostic>>) -> Vec<Box<dyn Diagnostic>> {
+fn filter_semantic_diagnostics(diagnostic: Vec<Rc<Diagnostic>>) -> Vec<Rc<Diagnostic>> {
     diagnostic
 }
 

--- a/src/compiler/scanner.rs
+++ b/src/compiler/scanner.rs
@@ -56,6 +56,10 @@ pub struct Scanner {
 }
 
 impl Scanner {
+    pub fn get_start_pos(&self) -> usize {
+        self.start_pos()
+    }
+
     pub fn get_text_pos(&self) -> usize {
         self.pos()
     }

--- a/src/compiler/scanner.rs
+++ b/src/compiler/scanner.rs
@@ -103,6 +103,16 @@ impl Scanner {
                     self.set_pos(self.pos() + 1);
                     return self.set_token(SyntaxKind::AsteriskToken);
                 }
+                CharacterCodes::plus => {
+                    if let Some(next_char) = self.text().chars().nth(self.pos() + 1) {
+                        if next_char == CharacterCodes::plus {
+                            self.set_pos(self.pos() + 2);
+                            return self.set_token(SyntaxKind::PlusPlusToken);
+                        }
+                        unimplemented!();
+                    }
+                    unimplemented!();
+                }
                 CharacterCodes::_0
                 | CharacterCodes::_1
                 | CharacterCodes::_2

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -933,6 +933,7 @@ pub struct DiagnosticMessage {
     pub message: &'static str,
 }
 
+#[derive(Debug)]
 pub enum Diagnostic {
     DiagnosticWithLocation(DiagnosticWithLocation),
     DiagnosticWithDetachedLocation(DiagnosticWithDetachedLocation),
@@ -940,7 +941,7 @@ pub enum Diagnostic {
 
 pub trait DiagnosticInterface: DiagnosticRelatedInformationInterface {}
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct BaseDiagnostic {
     _diagnostic_related_information: BaseDiagnosticRelatedInformation,
 }
@@ -1010,7 +1011,7 @@ pub trait DiagnosticRelatedInformationInterface {
     fn length(&self) -> usize;
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct BaseDiagnosticRelatedInformation {
     pub file: Option<Rc<SourceFile>>,
     pub start: usize,
@@ -1031,7 +1032,7 @@ impl DiagnosticRelatedInformationInterface for BaseDiagnosticRelatedInformation 
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct DiagnosticWithLocation {
     pub _diagnostic: BaseDiagnostic,
 }
@@ -1064,6 +1065,7 @@ impl From<DiagnosticWithLocation> for Diagnostic {
     }
 }
 
+#[derive(Debug)]
 pub struct DiagnosticWithDetachedLocation {
     pub _diagnostic: BaseDiagnostic,
     pub file_name: String,

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -2,7 +2,7 @@
 
 use bitflags::bitflags;
 use std::collections::HashMap;
-use std::rc::Rc;
+use std::rc::{Rc, Weak};
 
 use crate::SortedArray;
 
@@ -402,7 +402,12 @@ bitflags! {
     pub struct TypeFlags: u32 {
         const Number = 1 << 3;
         const BigInt = 1 << 6;
+        const StringLiteral = 1 << 7;
+        const NumberLiteral = 1 << 8;
         const BooleanLiteral = 1 << 9;
+        const BigIntLiteral = 1 << 11;
+
+        const Literal = Self::StringLiteral.bits | Self::NumberLiteral.bits | Self::BigIntLiteral.bits | Self::BooleanLiteral.bits;
     }
 }
 
@@ -495,12 +500,14 @@ impl From<BaseIntrinsicType> for Type {
 #[derive(Clone)]
 pub struct FreshableIntrinsicType {
     _intrinsic_type: BaseIntrinsicType,
+    pub fresh_type: Option<Weak<Type>>,
 }
 
 impl FreshableIntrinsicType {
     pub fn new(intrinsic_type: BaseIntrinsicType) -> Self {
         Self {
             _intrinsic_type: intrinsic_type,
+            fresh_type: None,
         }
     }
 }

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -1,3 +1,6 @@
+#![allow(non_upper_case_globals)]
+
+use bitflags::bitflags;
 use std::collections::HashMap;
 use std::rc::Rc;
 
@@ -377,9 +380,69 @@ pub enum ExitStatus {
     DiagnosticsPresent_OutputsGenerated,
 }
 
+#[allow(non_snake_case)]
 pub struct TypeChecker {
+    pub Type: fn(TypeFlags) -> BaseType,
+    pub number_type: Option<BaseIntrinsicType>,
+    pub true_type: Option<FreshableIntrinsicType>,
     pub diagnostics: DiagnosticCollection,
 }
+
+bitflags! {
+    pub struct TypeFlags: u32 {
+        const Number = 1 << 3;
+        const BooleanLiteral = 1 << 9;
+    }
+}
+
+pub trait Type {
+    fn flags(&self) -> TypeFlags;
+}
+
+#[derive(Clone)]
+pub struct BaseType {
+    pub flags: TypeFlags,
+}
+
+pub trait IntrinsicType: Type {}
+
+#[derive(Clone)]
+pub struct BaseIntrinsicType {
+    _type: BaseType,
+}
+
+impl BaseIntrinsicType {
+    pub fn new(type_: BaseType) -> Self {
+        Self { _type: type_ }
+    }
+}
+
+impl Type for BaseIntrinsicType {
+    fn flags(&self) -> TypeFlags {
+        self._type.flags
+    }
+}
+
+#[derive(Clone)]
+pub struct FreshableIntrinsicType {
+    _intrinsic_type: BaseIntrinsicType,
+}
+
+impl FreshableIntrinsicType {
+    pub fn new(intrinsic_type: BaseIntrinsicType) -> Self {
+        Self {
+            _intrinsic_type: intrinsic_type,
+        }
+    }
+}
+
+impl Type for FreshableIntrinsicType {
+    fn flags(&self) -> TypeFlags {
+        self._intrinsic_type._type.flags
+    }
+}
+
+impl IntrinsicType for FreshableIntrinsicType {}
 
 #[derive(Debug)]
 pub struct ParsedCommandLine {

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -85,7 +85,7 @@ impl NodeInterface for BaseNode {
     }
 
     fn parent(&self) -> Rc<Node> {
-        self.parent.unwrap().upgrade().unwrap()
+        self.parent.clone().unwrap().upgrade().unwrap()
     }
 }
 
@@ -617,11 +617,11 @@ impl FreshableIntrinsicType {
     }
 
     pub fn fresh_type(&self) -> Weak<Type> {
-        self.fresh_type.unwrap()
+        self.fresh_type.as_ref().unwrap().clone()
     }
 
     pub fn regular_type(&self) -> Weak<Type> {
-        self.regular_type.unwrap()
+        self.regular_type.as_ref().unwrap().clone()
     }
 }
 
@@ -911,7 +911,7 @@ pub struct BaseDiagnosticRelatedInformation {
 
 impl DiagnosticRelatedInformationInterface for BaseDiagnosticRelatedInformation {
     fn file(&self) -> Option<Rc<SourceFile>> {
-        self.file
+        self.file.clone()
     }
 
     fn start(&self) -> usize {
@@ -991,6 +991,11 @@ pub enum DiagnosticCategory {
 }
 
 pub struct NodeFactory {}
+
+pub struct TextSpan {
+    pub start: usize,
+    pub length: usize,
+}
 
 pub struct DiagnosticCollection {
     pub file_diagnostics: HashMap<String, SortedArray<Rc<Diagnostic>>>,

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -577,7 +577,7 @@ pub enum ExitStatus {
 }
 
 pub trait TypeCheckerHost: ModuleSpecifierResolutionHost {
-    fn get_source_files(&self) -> Vec<Rc<SourceFile>>;
+    fn get_source_files(&self) -> Vec<Rc<Node>>;
 }
 
 #[allow(non_snake_case)]

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -18,9 +18,11 @@ pub enum SyntaxKind {
     NumericLiteral,
     SemicolonToken,
     AsteriskToken,
+    PlusPlusToken,
     Identifier,
     FalseKeyword,
     TrueKeyword,
+    PrefixUnaryExpression,
     BinaryExpression,
     EmptyStatement,
     ExpressionStatement,
@@ -138,6 +140,7 @@ impl From<Identifier> for Expression {
 pub enum Expression {
     TokenExpression(BaseNode),
     Identifier(Identifier),
+    PrefixUnaryExpression(PrefixUnaryExpression),
     BinaryExpression(BinaryExpression),
     LiteralLikeNode(LiteralLikeNode),
 }
@@ -147,6 +150,9 @@ impl NodeInterface for Expression {
         match self {
             Expression::TokenExpression(token_expression) => token_expression.kind(),
             Expression::Identifier(identifier) => identifier.kind(),
+            Expression::PrefixUnaryExpression(prefix_unary_expression) => {
+                prefix_unary_expression.kind()
+            }
             Expression::BinaryExpression(binary_expression) => binary_expression.kind(),
             Expression::LiteralLikeNode(literal_like_node) => literal_like_node.kind(),
         }
@@ -162,6 +168,35 @@ impl From<Expression> for Node {
 impl From<BaseNode> for Expression {
     fn from(base_node: BaseNode) -> Self {
         Expression::TokenExpression(base_node)
+    }
+}
+
+#[derive(Debug)]
+pub struct PrefixUnaryExpression {
+    pub _node: BaseNode,
+    pub operator: SyntaxKind,
+    pub operand: Box<Expression>,
+}
+
+impl PrefixUnaryExpression {
+    pub fn new(base_node: BaseNode, operator: SyntaxKind, operand: Expression) -> Self {
+        Self {
+            _node: base_node,
+            operator,
+            operand: Box::new(operand),
+        }
+    }
+}
+
+impl NodeInterface for PrefixUnaryExpression {
+    fn kind(&self) -> SyntaxKind {
+        self._node.kind
+    }
+}
+
+impl From<PrefixUnaryExpression> for Expression {
+    fn from(prefix_unary_expression: PrefixUnaryExpression) -> Self {
+        Expression::PrefixUnaryExpression(prefix_unary_expression)
     }
 }
 
@@ -432,6 +467,7 @@ impl CharacterCodes {
     pub const Z: char = 'Z';
 
     pub const asterisk: char = '*';
+    pub const plus: char = '+';
     pub const semicolon: char = ';';
     pub const slash: char = '/';
 }

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::rc::{Rc, Weak};
 use std::sync::RwLock;
 
-use crate::SortedArray;
+use crate::{SortedArray, WeakSelf};
 
 pub struct Path(String);
 
@@ -603,25 +603,25 @@ impl From<BaseIntrinsicType> for Type {
 #[derive(Clone)]
 pub struct FreshableIntrinsicType {
     _intrinsic_type: BaseIntrinsicType,
-    pub fresh_type: Option<Weak<Type>>,
-    pub regular_type: Option<Weak<Type>>,
+    pub fresh_type: WeakSelf<Type>,
+    pub regular_type: WeakSelf<Type>,
 }
 
 impl FreshableIntrinsicType {
     pub fn new(intrinsic_type: BaseIntrinsicType) -> Self {
         Self {
             _intrinsic_type: intrinsic_type,
-            fresh_type: None,
-            regular_type: None,
+            fresh_type: WeakSelf::new(),
+            regular_type: WeakSelf::new(),
         }
     }
 
     pub fn fresh_type(&self) -> Weak<Type> {
-        self.fresh_type.as_ref().unwrap().clone()
+        self.fresh_type.get()
     }
 
     pub fn regular_type(&self) -> Weak<Type> {
-        self.regular_type.as_ref().unwrap().clone()
+        self.regular_type.get()
     }
 }
 

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -1,4 +1,7 @@
+use std::collections::HashMap;
 use std::rc::Rc;
+
+use crate::SortedArray;
 
 pub struct Path(String);
 
@@ -295,11 +298,13 @@ impl From<ExpressionStatement> for Statement {
 pub struct SourceFile {
     pub _node: BaseNode,
     pub statements: NodeArray,
+
+    pub file_name: String,
 }
 
 pub trait Program {
-    fn get_source_files(&self) -> &[Rc<SourceFile>];
-    fn get_semantic_diagnostics(&self) -> Vec<Box<dyn Diagnostic>>;
+    fn get_source_files(&self) -> Vec<Rc<SourceFile>>;
+    fn get_semantic_diagnostics(&mut self) -> Vec<Box<dyn Diagnostic>>;
 }
 
 #[derive(Eq, PartialEq)]
@@ -312,6 +317,10 @@ pub enum ExitStatus {
     Success,
     #[allow(non_camel_case_types)]
     DiagnosticsPresent_OutputsGenerated,
+}
+
+pub struct TypeChecker {
+    pub diagnostics: DiagnosticCollection,
 }
 
 #[derive(Debug)]
@@ -425,6 +434,17 @@ pub trait Diagnostic: DiagnosticRelatedInformation {}
 
 pub trait DiagnosticRelatedInformation {}
 
+#[derive(Clone)]
+pub struct DiagnosticWithLocation {
+    pub file: Rc<SourceFile>,
+    pub start: usize,
+    pub length: usize,
+}
+
+impl DiagnosticRelatedInformation for DiagnosticWithLocation {}
+
+impl Diagnostic for DiagnosticWithLocation {}
+
 pub struct DiagnosticWithDetachedLocation {
     pub file_name: String,
     pub start: usize,
@@ -443,3 +463,7 @@ pub enum DiagnosticCategory {
 }
 
 pub struct NodeFactory {}
+
+pub struct DiagnosticCollection {
+    pub file_diagnostics: HashMap<String, SortedArray<DiagnosticWithLocation>>,
+}

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -74,6 +74,29 @@ impl NodeArray {
     pub fn new(nodes: Vec<Node>) -> Self {
         NodeArray { _nodes: nodes }
     }
+
+    pub fn iter(&self) -> NodeArrayIter {
+        NodeArrayIter(Box::new(self._nodes.iter()))
+    }
+}
+
+pub struct NodeArrayIter<'node_array>(Box<dyn Iterator<Item = &'node_array Node> + 'node_array>);
+
+impl<'node_array> Iterator for NodeArrayIter<'node_array> {
+    type Item = &'node_array Node;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl<'node_array> IntoIterator for &'node_array NodeArray {
+    type Item = &'node_array Node;
+    type IntoIter = NodeArrayIter<'node_array>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
 }
 
 pub enum NodeArrayOrVec {

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -680,8 +680,8 @@ impl From<UnionOrIntersectionType> for Type {
 
 #[derive(Clone)]
 pub struct BaseUnionOrIntersectionType {
-    _type: BaseType,
-    types: Vec<Rc<Type>>,
+    pub _type: BaseType,
+    pub types: Vec<Rc<Type>>,
 }
 
 impl TypeInterface for BaseUnionOrIntersectionType {
@@ -843,6 +843,14 @@ pub trait DiagnosticInterface: DiagnosticRelatedInformationInterface {}
 #[derive(Clone)]
 pub struct BaseDiagnostic {
     _diagnostic_related_information: BaseDiagnosticRelatedInformation,
+}
+
+impl BaseDiagnostic {
+    pub fn new(diagnostic_related_information: BaseDiagnosticRelatedInformation) -> Self {
+        Self {
+            _diagnostic_related_information: diagnostic_related_information,
+        }
+    }
 }
 
 impl DiagnosticRelatedInformationInterface for BaseDiagnostic {

--- a/src/compiler/utilities.rs
+++ b/src/compiler/utilities.rs
@@ -93,19 +93,35 @@ impl DiagnosticCollection {
     }
 
     pub fn add(&mut self, diagnostic: Rc<Diagnostic>) {
+        // let diagnostics = self
+        //     .file_diagnostics
+        //     .get_mut(&diagnostic.file().unwrap().file_name)
+        //     .unwrap_or_else(|| {
+        //         let diagnostics: SortedArray<Rc<Diagnostic>> = SortedArray::new(vec![]);
+        //         self.file_diagnostics.insert(
+        //             diagnostic.file().unwrap().file_name.to_string(),
+        //             diagnostics,
+        //         );
+        //         self.file_diagnostics
+        //             .get_mut(&diagnostic.file().unwrap().file_name)
+        //             .unwrap()
+        //     });
+        if let Some(diagnostics) = self
+            .file_diagnostics
+            .get_mut(&diagnostic.file().unwrap().file_name)
+        {
+            insert_sorted(diagnostics, diagnostic);
+            return;
+        }
+        let diagnostics: SortedArray<Rc<Diagnostic>> = SortedArray::new(vec![]);
+        self.file_diagnostics.insert(
+            diagnostic.file().unwrap().file_name.to_string(),
+            diagnostics,
+        );
         let diagnostics = self
             .file_diagnostics
             .get_mut(&diagnostic.file().unwrap().file_name)
-            .unwrap_or_else(|| {
-                let diagnostics: SortedArray<Rc<Diagnostic>> = SortedArray::new(vec![]);
-                self.file_diagnostics.insert(
-                    diagnostic.file().unwrap().file_name.to_string(),
-                    diagnostics,
-                );
-                self.file_diagnostics
-                    .get_mut(&diagnostic.file().unwrap().file_name)
-                    .unwrap()
-            });
+            .unwrap();
         insert_sorted(diagnostics, diagnostic);
     }
 
@@ -172,13 +188,11 @@ pub fn create_detached_diagnostic(
     message: &DiagnosticMessage,
 ) -> DiagnosticWithDetachedLocation {
     DiagnosticWithDetachedLocation {
-        _diagnostic: BaseDiagnostic {
-            _diagnostic_related_information: BaseDiagnosticRelatedInformation {
-                file: None,
-                start,
-                length,
-            },
-        },
+        _diagnostic: BaseDiagnostic::new(BaseDiagnosticRelatedInformation {
+            file: None,
+            start,
+            length,
+        }),
         file_name: file_name.to_string(),
     }
 }
@@ -190,12 +204,10 @@ fn create_file_diagnostic(
     message: &DiagnosticMessage,
 ) -> DiagnosticWithLocation {
     DiagnosticWithLocation {
-        _diagnostic: BaseDiagnostic {
-            _diagnostic_related_information: BaseDiagnosticRelatedInformation {
-                file: Some(file),
-                start,
-                length,
-            },
-        },
+        _diagnostic: BaseDiagnostic::new(BaseDiagnosticRelatedInformation {
+            file: Some(file),
+            start,
+            length,
+        }),
     }
 }

--- a/src/compiler/utilities.rs
+++ b/src/compiler/utilities.rs
@@ -140,17 +140,17 @@ fn Type(flags: TypeFlags) -> BaseType {
 
 #[allow(non_snake_case)]
 fn Node(kind: SyntaxKind) -> BaseNode {
-    BaseNode { kind, parent: None }
+    BaseNode::new(kind)
 }
 
 #[allow(non_snake_case)]
 fn Token(kind: SyntaxKind) -> BaseNode {
-    BaseNode { kind, parent: None }
+    BaseNode::new(kind)
 }
 
 #[allow(non_snake_case)]
 fn Identifier(kind: SyntaxKind) -> BaseNode {
-    BaseNode { kind, parent: None }
+    BaseNode::new(kind)
 }
 
 pub struct ObjectAllocator {}
@@ -210,4 +210,11 @@ fn create_file_diagnostic(
             length,
         }),
     }
+}
+
+fn set_parent<TNode: NodeInterface>(child: &TNode, parent: Option<Rc<Node>>) -> &TNode {
+    if let Some(parent) = parent {
+        child.set_parent(parent.clone());
+    }
+    child
 }

--- a/src/compiler/utilities.rs
+++ b/src/compiler/utilities.rs
@@ -2,11 +2,36 @@
 
 use std::cmp::Ordering;
 use std::collections::HashMap;
+use std::rc::Rc;
 
 use crate::{
-    BaseNode, BaseType, DiagnosticCollection, DiagnosticMessage, DiagnosticWithDetachedLocation,
-    DiagnosticWithLocation, SortedArray, SyntaxKind, TypeFlags,
+    BaseDiagnostic, BaseDiagnosticRelatedInformation, BaseNode, BaseType, Diagnostic,
+    DiagnosticCollection, DiagnosticMessage, DiagnosticRelatedInformationInterface,
+    DiagnosticWithDetachedLocation, DiagnosticWithLocation, Node, NodeInterface, SortedArray,
+    SourceFile, SyntaxKind, TypeFlags,
 };
+
+fn get_source_file_of_node<TNode: NodeInterface>(node: &TNode) -> Rc<SourceFile> {
+    if node.kind() == SyntaxKind::SourceFile {
+        unimplemented!()
+    }
+    let parent = node.parent();
+    while parent.kind() != SyntaxKind::SourceFile {
+        parent = parent.parent();
+    }
+    match *parent {
+        Node::SourceFile(source_file) => source_file.clone(),
+        _ => panic!("Expected SourceFile"),
+    }
+}
+
+pub fn create_diagnostic_for_node<TNode: NodeInterface>(
+    node: &TNode,
+    message: &DiagnosticMessage,
+) -> DiagnosticWithLocation {
+    let source_file = get_source_file_of_node(node);
+    create_diagnostic_for_node_in_source_file(source_file, node, message)
+}
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum OperatorPrecedence {
@@ -47,11 +72,27 @@ pub fn create_diagnostic_collection() -> DiagnosticCollection {
 impl DiagnosticCollection {
     pub fn new() -> Self {
         DiagnosticCollection {
-            file_diagnostics: HashMap::<String, SortedArray<DiagnosticWithLocation>>::new(),
+            file_diagnostics: HashMap::<String, SortedArray<Rc<Diagnostic>>>::new(),
         }
     }
 
-    pub fn get_diagnostics(&self, file_name: &str) -> Vec<DiagnosticWithLocation> {
+    pub fn add(&mut self, diagnostic: Rc<Diagnostic>) {
+        let diagnostics = self
+            .file_diagnostics
+            .get(&diagnostic.file().unwrap().file_name)
+            .unwrap_or_else(|| {
+                let diagnostics: SortedArray<Rc<Diagnostic>> = SortedArray::new(vec![]);
+                self.file_diagnostics.insert(
+                    diagnostic.file().unwrap().file_name.to_string(),
+                    diagnostics,
+                );
+                self.file_diagnostics
+                    .get(&diagnostic.file().unwrap().file_name)
+                    .unwrap()
+            });
+    }
+
+    pub fn get_diagnostics(&self, file_name: &str) -> Vec<Rc<Diagnostic>> {
         self.file_diagnostics
             .get(file_name)
             .map(|sorted_array| sorted_array._vec.clone())
@@ -66,17 +107,17 @@ fn Type(flags: TypeFlags) -> BaseType {
 
 #[allow(non_snake_case)]
 fn Node(kind: SyntaxKind) -> BaseNode {
-    BaseNode { kind }
+    BaseNode { kind, parent: None }
 }
 
 #[allow(non_snake_case)]
 fn Token(kind: SyntaxKind) -> BaseNode {
-    BaseNode { kind }
+    BaseNode { kind, parent: None }
 }
 
 #[allow(non_snake_case)]
 fn Identifier(kind: SyntaxKind) -> BaseNode {
-    BaseNode { kind }
+    BaseNode { kind, parent: None }
 }
 
 pub struct ObjectAllocator {}
@@ -114,9 +155,13 @@ pub fn create_detached_diagnostic(
     _message: &DiagnosticMessage,
 ) -> DiagnosticWithDetachedLocation {
     DiagnosticWithDetachedLocation {
-        start,
-        length,
-
+        _diagnostic: BaseDiagnostic {
+            _diagnostic_related_information: BaseDiagnosticRelatedInformation {
+                file: None,
+                start,
+                length,
+            },
+        },
         file_name: file_name.to_string(),
     }
 }

--- a/src/compiler/utilities.rs
+++ b/src/compiler/utilities.rs
@@ -1,8 +1,12 @@
 #![allow(non_upper_case_globals)]
 
 use std::cmp::Ordering;
+use std::collections::HashMap;
 
-use crate::{BaseNode, DiagnosticMessage, DiagnosticWithDetachedLocation, SyntaxKind};
+use crate::{
+    BaseNode, DiagnosticCollection, DiagnosticMessage, DiagnosticWithDetachedLocation,
+    DiagnosticWithLocation, SortedArray, SyntaxKind,
+};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum OperatorPrecedence {
@@ -34,6 +38,25 @@ pub fn get_binary_operator_precedence(kind: SyntaxKind) -> OperatorPrecedence {
         _ => (),
     }
     OperatorPrecedence::Invalid
+}
+
+pub fn create_diagnostic_collection() -> DiagnosticCollection {
+    DiagnosticCollection::new()
+}
+
+impl DiagnosticCollection {
+    pub fn new() -> Self {
+        DiagnosticCollection {
+            file_diagnostics: HashMap::<String, SortedArray<DiagnosticWithLocation>>::new(),
+        }
+    }
+
+    pub fn get_diagnostics(&self, file_name: &str) -> Vec<DiagnosticWithLocation> {
+        self.file_diagnostics
+            .get(file_name)
+            .map(|sorted_array| sorted_array._vec.clone())
+            .unwrap_or(vec![])
+    }
 }
 
 #[allow(non_snake_case)]

--- a/src/compiler/utilities.rs
+++ b/src/compiler/utilities.rs
@@ -212,7 +212,7 @@ fn create_file_diagnostic(
     }
 }
 
-fn set_parent<TNode: NodeInterface>(child: &TNode, parent: Option<Rc<Node>>) -> &TNode {
+pub fn set_parent<TNode: NodeInterface>(child: &TNode, parent: Option<Rc<Node>>) -> &TNode {
     if let Some(parent) = parent {
         child.set_parent(parent.clone());
     }

--- a/src/compiler/utilities.rs
+++ b/src/compiler/utilities.rs
@@ -4,8 +4,8 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 
 use crate::{
-    BaseNode, DiagnosticCollection, DiagnosticMessage, DiagnosticWithDetachedLocation,
-    DiagnosticWithLocation, SortedArray, SyntaxKind,
+    BaseNode, BaseType, DiagnosticCollection, DiagnosticMessage, DiagnosticWithDetachedLocation,
+    DiagnosticWithLocation, SortedArray, SyntaxKind, TypeFlags,
 };
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -60,6 +60,11 @@ impl DiagnosticCollection {
 }
 
 #[allow(non_snake_case)]
+fn Type(flags: TypeFlags) -> BaseType {
+    BaseType { flags }
+}
+
+#[allow(non_snake_case)]
 fn Node(kind: SyntaxKind) -> BaseNode {
     BaseNode { kind }
 }
@@ -91,6 +96,10 @@ impl ObjectAllocator {
 
     pub fn get_source_file_constructor(&self) -> fn(SyntaxKind) -> BaseNode {
         Node
+    }
+
+    pub fn get_type_constructor(&self) -> fn(TypeFlags) -> BaseType {
+        Type
     }
 }
 

--- a/src/compiler/utilities_public.rs
+++ b/src/compiler/utilities_public.rs
@@ -1,0 +1,9 @@
+use crate::TextSpan;
+
+fn create_text_span(start: usize, length: usize) -> TextSpan {
+    TextSpan { start, length }
+}
+
+pub fn create_text_span_from_bounds(start: usize, end: usize) -> TextSpan {
+    create_text_span(start, end - start)
+}

--- a/src/compiler/watch.rs
+++ b/src/compiler/watch.rs
@@ -5,7 +5,7 @@ struct EmitFilesAndReportErrorsReturn {
 }
 
 fn emit_files_and_report_errors<TProgram: Program>(
-    program: TProgram,
+    mut program: TProgram,
 ) -> EmitFilesAndReportErrorsReturn {
     let diagnostics = program.get_semantic_diagnostics();
 

--- a/src/compiler/watch.rs
+++ b/src/compiler/watch.rs
@@ -18,6 +18,7 @@ pub fn emit_files_and_report_errors_and_get_exit_status<TProgram: Program>(
     program: TProgram,
 ) -> ExitStatus {
     let EmitFilesAndReportErrorsReturn { diagnostics } = emit_files_and_report_errors(program);
+    println!("diagnostics: {:?}", diagnostics);
     if !diagnostics.is_empty() {
         return ExitStatus::DiagnosticsPresent_OutputsGenerated;
     }

--- a/src/compiler/watch.rs
+++ b/src/compiler/watch.rs
@@ -1,7 +1,9 @@
+use std::rc::Rc;
+
 use crate::{Diagnostic, ExitStatus, Program};
 
 struct EmitFilesAndReportErrorsReturn {
-    diagnostics: Vec<Box<dyn Diagnostic>>,
+    diagnostics: Vec<Rc<Diagnostic>>,
 }
 
 fn emit_files_and_report_errors<TProgram: Program>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,10 @@ mod compiler;
 mod execute_command_line;
 mod rust_helpers;
 
+pub use compiler::checker::create_type_checker;
 pub use compiler::command_line_parser::parse_command_line;
 pub use compiler::core::{concatenate, for_each, last_or_undefined};
+pub use compiler::core_public::SortedArray;
 pub use compiler::debug::Debug_;
 pub use compiler::diagnostic_information_map_generated::Diagnostics;
 pub use compiler::factory::base_node_factory::BaseNodeFactory;
@@ -18,15 +20,15 @@ pub use compiler::scanner::{create_scanner, Scanner};
 pub use compiler::sys::{get_sys, System};
 pub use compiler::types::{
     BaseLiteralLikeNode, BaseNode, BinaryExpression, CharacterCodes, CompilerHost,
-    CreateProgramOptions, Diagnostic, DiagnosticCategory, DiagnosticMessage,
-    DiagnosticWithDetachedLocation, EmptyStatement, ExitStatus, Expression, ExpressionStatement,
-    Identifier, LiteralLikeNode, ModuleResolutionHost, Node, NodeArray, NodeArrayOrVec,
-    NodeFactory, NodeInterface, NumericLiteral, ParsedCommandLine, Path, Program, SourceFile,
-    Statement, StructureIsReused, SyntaxKind,
+    CreateProgramOptions, Diagnostic, DiagnosticCategory, DiagnosticCollection, DiagnosticMessage,
+    DiagnosticWithDetachedLocation, DiagnosticWithLocation, EmptyStatement, ExitStatus, Expression,
+    ExpressionStatement, Identifier, LiteralLikeNode, ModuleResolutionHost, Node, NodeArray,
+    NodeArrayOrVec, NodeFactory, NodeInterface, NumericLiteral, ParsedCommandLine, Path, Program,
+    SourceFile, Statement, StructureIsReused, SyntaxKind, TypeChecker,
 };
 pub use compiler::utilities::{
-    create_detached_diagnostic, get_binary_operator_precedence, object_allocator,
-    OperatorPrecedence,
+    create_detached_diagnostic, create_diagnostic_collection, get_binary_operator_precedence,
+    object_allocator, OperatorPrecedence,
 };
 pub use compiler::watch::emit_files_and_report_errors_and_get_exit_status;
 pub use execute_command_line::execute_command_line::execute_command_line;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,13 +19,13 @@ pub use compiler::program::create_program;
 pub use compiler::scanner::{create_scanner, Scanner};
 pub use compiler::sys::{get_sys, System};
 pub use compiler::types::{
-    BaseLiteralLikeNode, BaseNode, BinaryExpression, CharacterCodes, CompilerHost,
-    CreateProgramOptions, Diagnostic, DiagnosticCategory, DiagnosticCollection, DiagnosticMessage,
-    DiagnosticWithDetachedLocation, DiagnosticWithLocation, EmptyStatement, ExitStatus, Expression,
-    ExpressionStatement, Identifier, LiteralLikeNode, ModuleResolutionHost, Node, NodeArray,
-    NodeArrayOrVec, NodeFactory, NodeInterface, NumericLiteral, ParsedCommandLine, Path,
-    PrefixUnaryExpression, Program, SourceFile, Statement, StructureIsReused, SyntaxKind,
-    TypeChecker,
+    BaseIntrinsicType, BaseLiteralLikeNode, BaseNode, BaseType, BinaryExpression, CharacterCodes,
+    CompilerHost, CreateProgramOptions, Diagnostic, DiagnosticCategory, DiagnosticCollection,
+    DiagnosticMessage, DiagnosticWithDetachedLocation, DiagnosticWithLocation, EmptyStatement,
+    ExitStatus, Expression, ExpressionStatement, FreshableIntrinsicType, Identifier, IntrinsicType,
+    LiteralLikeNode, ModuleResolutionHost, Node, NodeArray, NodeArrayOrVec, NodeFactory,
+    NodeInterface, NumericLiteral, ParsedCommandLine, Path, PrefixUnaryExpression, Program,
+    SourceFile, Statement, StructureIsReused, SyntaxKind, Type, TypeChecker, TypeFlags,
 };
 pub use compiler::utilities::{
     create_detached_diagnostic, create_diagnostic_collection, get_binary_operator_precedence,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,13 +27,14 @@ pub use compiler::types::{
     DiagnosticWithLocation, EmptyStatement, ExitStatus, Expression, ExpressionStatement,
     FreshableIntrinsicType, Identifier, IntrinsicType, LiteralLikeNode, ModuleResolutionHost,
     ModuleSpecifierResolutionHost, Node, NodeArray, NodeArrayOrVec, NodeFactory, NodeInterface,
-    NumericLiteral, ParsedCommandLine, Path, PrefixUnaryExpression, Program,
+    NumericLiteral, ParsedCommandLine, Path, PrefixUnaryExpression, Program, ReadonlyTextRange,
     RelationComparisonResult, SourceFile, Statement, StructureIsReused, SyntaxKind, TextSpan, Type,
     TypeChecker, TypeCheckerHost, TypeFlags, TypeInterface, UnionType,
 };
 pub use compiler::utilities::{
     create_detached_diagnostic, create_diagnostic_collection, create_diagnostic_for_node,
-    get_binary_operator_precedence, object_allocator, set_parent, OperatorPrecedence,
+    get_binary_operator_precedence, object_allocator, set_parent, set_text_range_pos_end,
+    OperatorPrecedence,
 };
 pub use compiler::utilities_public::create_text_span_from_bounds;
 pub use compiler::watch::emit_files_and_report_errors_and_get_exit_status;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,9 @@ pub use compiler::types::{
     CreateProgramOptions, Diagnostic, DiagnosticCategory, DiagnosticCollection, DiagnosticMessage,
     DiagnosticWithDetachedLocation, DiagnosticWithLocation, EmptyStatement, ExitStatus, Expression,
     ExpressionStatement, Identifier, LiteralLikeNode, ModuleResolutionHost, Node, NodeArray,
-    NodeArrayOrVec, NodeFactory, NodeInterface, NumericLiteral, ParsedCommandLine, Path, Program,
-    SourceFile, Statement, StructureIsReused, SyntaxKind, TypeChecker,
+    NodeArrayOrVec, NodeFactory, NodeInterface, NumericLiteral, ParsedCommandLine, Path,
+    PrefixUnaryExpression, Program, SourceFile, Statement, StructureIsReused, SyntaxKind,
+    TypeChecker,
 };
 pub use compiler::utilities::{
     create_detached_diagnostic, create_diagnostic_collection, get_binary_operator_precedence,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub use compiler::debug::Debug_;
 pub use compiler::diagnostic_information_map_generated::Diagnostics;
 pub use compiler::factory::base_node_factory::BaseNodeFactory;
 pub use compiler::factory::node_factory::create_node_factory;
-pub use compiler::parser::create_source_file;
+pub use compiler::parser::{create_source_file, for_each_child};
 pub use compiler::path::{normalize_path, to_path};
 pub use compiler::program::create_program;
 pub use compiler::scanner::{create_scanner, Scanner};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub use compiler::types::{
 };
 pub use compiler::utilities::{
     create_detached_diagnostic, create_diagnostic_collection, create_diagnostic_for_node,
-    get_binary_operator_precedence, object_allocator, OperatorPrecedence,
+    get_binary_operator_precedence, object_allocator, set_parent, OperatorPrecedence,
 };
 pub use compiler::utilities_public::create_text_span_from_bounds;
 pub use compiler::watch::emit_files_and_report_errors_and_get_exit_status;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,3 +38,4 @@ pub use compiler::utilities_public::create_text_span_from_bounds;
 pub use compiler::watch::emit_files_and_report_errors_and_get_exit_status;
 pub use execute_command_line::execute_command_line::execute_command_line;
 pub use rust_helpers::is_same_variant;
+pub use rust_helpers::weak_self::WeakSelf;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ mod execute_command_line;
 mod rust_helpers;
 
 pub use compiler::command_line_parser::parse_command_line;
-pub use compiler::core::{for_each, last_or_undefined};
+pub use compiler::core::{concatenate, for_each, last_or_undefined};
 pub use compiler::debug::Debug_;
 pub use compiler::diagnostic_information_map_generated::Diagnostics;
 pub use compiler::factory::base_node_factory::BaseNodeFactory;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,18 +19,19 @@ pub use compiler::program::create_program;
 pub use compiler::scanner::{create_scanner, Scanner};
 pub use compiler::sys::{get_sys, System};
 pub use compiler::types::{
-    BaseIntrinsicType, BaseLiteralLikeNode, BaseNode, BaseType, BinaryExpression, CharacterCodes,
+    BaseDiagnostic, BaseDiagnosticRelatedInformation, BaseIntrinsicType, BaseLiteralLikeNode,
+    BaseNode, BaseType, BaseUnionOrIntersectionType, BinaryExpression, CharacterCodes,
     CompilerHost, CreateProgramOptions, Diagnostic, DiagnosticCategory, DiagnosticCollection,
-    DiagnosticMessage, DiagnosticWithDetachedLocation, DiagnosticWithLocation, EmptyStatement,
-    ExitStatus, Expression, ExpressionStatement, FreshableIntrinsicType, Identifier, IntrinsicType,
-    LiteralLikeNode, ModuleResolutionHost, Node, NodeArray, NodeArrayOrVec, NodeFactory,
-    NodeInterface, NumericLiteral, ParsedCommandLine, Path, PrefixUnaryExpression, Program,
-    RelationComparisonResult, SourceFile, Statement, StructureIsReused, SyntaxKind, Type,
-    TypeChecker, TypeFlags,
+    DiagnosticMessage, DiagnosticRelatedInformationInterface, DiagnosticWithDetachedLocation,
+    DiagnosticWithLocation, EmptyStatement, ExitStatus, Expression, ExpressionStatement,
+    FreshableIntrinsicType, Identifier, IntrinsicType, LiteralLikeNode, ModuleResolutionHost, Node,
+    NodeArray, NodeArrayOrVec, NodeFactory, NodeInterface, NumericLiteral, ParsedCommandLine, Path,
+    PrefixUnaryExpression, Program, RelationComparisonResult, SourceFile, Statement,
+    StructureIsReused, SyntaxKind, Type, TypeChecker, TypeFlags, TypeInterface, UnionType,
 };
 pub use compiler::utilities::{
-    create_detached_diagnostic, create_diagnostic_collection, get_binary_operator_precedence,
-    object_allocator, OperatorPrecedence,
+    create_detached_diagnostic, create_diagnostic_collection, create_diagnostic_for_node,
+    get_binary_operator_precedence, object_allocator, OperatorPrecedence,
 };
 pub use compiler::watch::emit_files_and_report_errors_and_get_exit_status;
 pub use execute_command_line::execute_command_line::execute_command_line;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ mod rust_helpers;
 
 pub use compiler::checker::create_type_checker;
 pub use compiler::command_line_parser::parse_command_line;
-pub use compiler::core::{concatenate, for_each, last_or_undefined};
+pub use compiler::core::{concatenate, for_each, insert_sorted, last_or_undefined};
 pub use compiler::core_public::SortedArray;
 pub use compiler::debug::Debug_;
 pub use compiler::diagnostic_information_map_generated::Diagnostics;
@@ -27,12 +27,14 @@ pub use compiler::types::{
     FreshableIntrinsicType, Identifier, IntrinsicType, LiteralLikeNode, ModuleResolutionHost, Node,
     NodeArray, NodeArrayOrVec, NodeFactory, NodeInterface, NumericLiteral, ParsedCommandLine, Path,
     PrefixUnaryExpression, Program, RelationComparisonResult, SourceFile, Statement,
-    StructureIsReused, SyntaxKind, Type, TypeChecker, TypeFlags, TypeInterface, UnionType,
+    StructureIsReused, SyntaxKind, TextSpan, Type, TypeChecker, TypeFlags, TypeInterface,
+    UnionType,
 };
 pub use compiler::utilities::{
     create_detached_diagnostic, create_diagnostic_collection, create_diagnostic_for_node,
     get_binary_operator_precedence, object_allocator, OperatorPrecedence,
 };
+pub use compiler::utilities_public::create_text_span_from_bounds;
 pub use compiler::watch::emit_files_and_report_errors_and_get_exit_status;
 pub use execute_command_line::execute_command_line::execute_command_line;
 pub use rust_helpers::is_same_variant;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,8 @@ pub use compiler::types::{
     ExitStatus, Expression, ExpressionStatement, FreshableIntrinsicType, Identifier, IntrinsicType,
     LiteralLikeNode, ModuleResolutionHost, Node, NodeArray, NodeArrayOrVec, NodeFactory,
     NodeInterface, NumericLiteral, ParsedCommandLine, Path, PrefixUnaryExpression, Program,
-    SourceFile, Statement, StructureIsReused, SyntaxKind, Type, TypeChecker, TypeFlags,
+    RelationComparisonResult, SourceFile, Statement, StructureIsReused, SyntaxKind, Type,
+    TypeChecker, TypeFlags,
 };
 pub use compiler::utilities::{
     create_detached_diagnostic, create_diagnostic_collection, get_binary_operator_precedence,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod compiler;
 mod execute_command_line;
 mod rust_helpers;
 
+pub use compiler::binder::bind_source_file;
 pub use compiler::checker::create_type_checker;
 pub use compiler::command_line_parser::parse_command_line;
 pub use compiler::core::{concatenate, for_each, insert_sorted, last_or_undefined};
@@ -24,11 +25,11 @@ pub use compiler::types::{
     CompilerHost, CreateProgramOptions, Diagnostic, DiagnosticCategory, DiagnosticCollection,
     DiagnosticMessage, DiagnosticRelatedInformationInterface, DiagnosticWithDetachedLocation,
     DiagnosticWithLocation, EmptyStatement, ExitStatus, Expression, ExpressionStatement,
-    FreshableIntrinsicType, Identifier, IntrinsicType, LiteralLikeNode, ModuleResolutionHost, Node,
-    NodeArray, NodeArrayOrVec, NodeFactory, NodeInterface, NumericLiteral, ParsedCommandLine, Path,
-    PrefixUnaryExpression, Program, RelationComparisonResult, SourceFile, Statement,
-    StructureIsReused, SyntaxKind, TextSpan, Type, TypeChecker, TypeFlags, TypeInterface,
-    UnionType,
+    FreshableIntrinsicType, Identifier, IntrinsicType, LiteralLikeNode, ModuleResolutionHost,
+    ModuleSpecifierResolutionHost, Node, NodeArray, NodeArrayOrVec, NodeFactory, NodeInterface,
+    NumericLiteral, ParsedCommandLine, Path, PrefixUnaryExpression, Program,
+    RelationComparisonResult, SourceFile, Statement, StructureIsReused, SyntaxKind, TextSpan, Type,
+    TypeChecker, TypeCheckerHost, TypeFlags, TypeInterface, UnionType,
 };
 pub use compiler::utilities::{
     create_detached_diagnostic, create_diagnostic_collection, create_diagnostic_for_node,

--- a/src/rust_helpers/mod.rs
+++ b/src/rust_helpers/mod.rs
@@ -1,5 +1,7 @@
 use std::mem;
 
+pub mod weak_self;
+
 pub fn is_same_variant<TEnum>(value: &TEnum, other_value: &TEnum) -> bool {
     mem::discriminant(value) == mem::discriminant(other_value)
 }

--- a/src/rust_helpers/weak_self.rs
+++ b/src/rust_helpers/weak_self.rs
@@ -27,9 +27,11 @@ impl<T: ?Sized> WeakSelf<T> {
     /// Initialize the WeakSelf<T> with an Rc.
     ///
     /// Note: content must point be the only existing Rc, otherwise this method will panic
-    pub fn init(&self, content: &Rc<T>) {
-        if Rc::strong_count(content) != 1 || Rc::weak_count(content) != 0 {
-            panic!("Exclusive access to Rc<T> is required while initializing WeakSelf<T>");
+    pub fn init(&self, content: &Rc<T>, require_exclusive_access: bool) {
+        if require_exclusive_access {
+            if Rc::strong_count(content) != 1 || Rc::weak_count(content) != 0 {
+                panic!("Exclusive access to Rc<T> is required while initializing WeakSelf<T>");
+            }
         }
         let weak = Rc::downgrade(content);
         unsafe {

--- a/src/rust_helpers/weak_self.rs
+++ b/src/rust_helpers/weak_self.rs
@@ -1,0 +1,77 @@
+// copied from https://github.com/eun-ice/weak-self
+
+use std::cell::UnsafeCell;
+use std::fmt;
+use std::rc::{Rc, Weak};
+
+pub struct WeakSelf<T: ?Sized> {
+    cell: UnsafeCell<Option<Weak<T>>>,
+}
+
+impl<T: ?Sized> Clone for WeakSelf<T> {
+    fn clone(&self) -> Self {
+        WeakSelf {
+            cell: UnsafeCell::new(Some(self.get())),
+        }
+    }
+}
+
+impl<T: ?Sized> WeakSelf<T> {
+    /// Constructs a new empty WeakSelf<T>
+    pub fn new() -> WeakSelf<T> {
+        WeakSelf {
+            cell: UnsafeCell::new(None),
+        }
+    }
+
+    /// Initialize the WeakSelf<T> with an Rc.
+    ///
+    /// Note: content must point be the only existing Rc, otherwise this method will panic
+    pub fn init(&self, content: &Rc<T>) {
+        if Rc::strong_count(content) != 1 || Rc::weak_count(content) != 0 {
+            panic!("Exclusive access to Rc<T> is required while initializing WeakSelf<T>");
+        }
+        let weak = Rc::downgrade(content);
+        unsafe {
+            *self.cell.get() = Some(weak);
+        }
+    }
+
+    /// get Some Weak<T> pointer to the content, or None if not yet initialized
+    pub fn try_get(&self) -> Option<&Weak<T>> {
+        unsafe {
+            match *self.cell.get() {
+                Some(ref weak) => Some(&weak),
+                None => None,
+            }
+        }
+    }
+
+    /// get a Weak<T> pointer to the content, or panic if not yet initialized
+    pub fn get(&self) -> Weak<T> {
+        self.try_get()
+            .expect("expected WeakSelf to be initialized")
+            .clone()
+    }
+}
+
+unsafe impl<T: ?Sized + Sync + Send> Sync for WeakSelf<T> {}
+
+unsafe impl<T: ?Sized + Sync + Send> Send for WeakSelf<T> {}
+
+impl<T: ?Sized + fmt::Debug> fmt::Debug for WeakSelf<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.try_get() {
+            None => {
+                write!(f, "Empty WeakSelf<T>")
+            }
+            Some(weak) => fmt::Debug::fmt(weak, f),
+        }
+    }
+}
+
+impl<T: ?Sized> Default for WeakSelf<T> {
+    fn default() -> Self {
+        WeakSelf::new()
+    }
+}


### PR DESCRIPTION
In this PR:
- emit a type error when parsing + type-checking the prefix unary expression `++true`

To test:
If you have a file named eg `tmp.tsx` in the repo root directory whose contents are just `++true` (no trailing newline) and run `cargo run tmp.tsx` you should see debug-logging of the `SourceFile` and then a single `DiagnosticWithLocation` associated with the `SourceFile` whose `file_name` is `"tmp.tsx"` and with location data `start: 2, length: 4` (ie the location of the `true` operand)