### PR TITLE
Conditionally emit type error

### DIFF
--- a/src/compiler/program.rs
+++ b/src/compiler/program.rs
@@ -53,7 +53,7 @@ impl ProgramConcrete {
         }
     }
 
-    fn get_diagnostics_producing_type_checker(&mut self) -> &TypeChecker {
+    fn get_diagnostics_producing_type_checker(&mut self) -> &mut TypeChecker {
         // self.diagnostics_producing_type_checker
         //     .get_or_insert_with(|| create_type_checker(self, true))
 
@@ -66,7 +66,7 @@ impl ProgramConcrete {
         if self.diagnostics_producing_type_checker.is_none() {
             self.diagnostics_producing_type_checker = Some(create_type_checker(self, true));
         }
-        self.diagnostics_producing_type_checker.as_ref().unwrap()
+        self.diagnostics_producing_type_checker.as_mut().unwrap()
     }
 
     fn get_diagnostics_helper(

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -934,7 +934,7 @@ bitflags! {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Type {
     IntrinsicType(IntrinsicType),
     LiteralType(LiteralType),
@@ -957,7 +957,7 @@ pub trait TypeInterface {
     fn flags(&self) -> TypeFlags;
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct BaseType {
     pub flags: TypeFlags,
 }
@@ -970,7 +970,7 @@ impl TypeInterface for BaseType {
 
 pub trait IntrinsicTypeInterface: TypeInterface {}
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum IntrinsicType {
     BaseIntrinsicType(BaseIntrinsicType),
     FreshableIntrinsicType(FreshableIntrinsicType),
@@ -995,7 +995,7 @@ impl From<IntrinsicType> for Type {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct BaseIntrinsicType {
     _type: BaseType,
 }
@@ -1026,7 +1026,7 @@ impl From<BaseIntrinsicType> for Type {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct FreshableIntrinsicType {
     _intrinsic_type: BaseIntrinsicType,
     pub fresh_type: WeakSelf<Type>,
@@ -1085,7 +1085,7 @@ pub trait LiteralTypeInterface: TypeInterface {
     fn set_regular_type(&self, regular_type: &Rc<Type>);
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum LiteralType {
     NumberLiteralType(NumberLiteralType),
 }
@@ -1148,7 +1148,7 @@ impl From<LiteralType> for Type {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct BaseLiteralType {
     _type: BaseType,
     fresh_type: WeakSelf<Type>,
@@ -1197,7 +1197,7 @@ impl LiteralTypeInterface for BaseLiteralType {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct NumberLiteralType {
     _literal_type: BaseLiteralType,
     value: Number,
@@ -1285,7 +1285,7 @@ pub trait UnionOrIntersectionTypeInterface: TypeInterface {
     fn types(&self) -> &[Rc<Type>];
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum UnionOrIntersectionType {
     UnionType(UnionType),
 }
@@ -1312,7 +1312,7 @@ impl From<UnionOrIntersectionType> for Type {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct BaseUnionOrIntersectionType {
     pub _type: BaseType,
     pub types: Vec<Rc<Type>>,
@@ -1330,7 +1330,7 @@ impl UnionOrIntersectionTypeInterface for BaseUnionOrIntersectionType {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct UnionType {
     pub _union_or_intersection_type: BaseUnionOrIntersectionType,
 }
@@ -1357,6 +1357,14 @@ impl From<UnionType> for Type {
     fn from(union_type: UnionType) -> Self {
         Type::UnionOrIntersectionType(UnionOrIntersectionType::UnionType(union_type))
     }
+}
+
+#[derive(Eq, PartialEq)]
+pub enum Ternary {
+    False = 0,
+    Unknown = 1,
+    Maybe = 3,
+    True = -1,
 }
 
 #[derive(Debug)]

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -919,6 +919,7 @@ pub struct TypeChecker {
 bitflags! {
     pub struct TypeFlags: u32 {
         const Number = 1 << 3;
+        const Enum = 1 << 5;
         const BigInt = 1 << 6;
         const StringLiteral = 1 << 7;
         const NumberLiteral = 1 << 8;
@@ -929,6 +930,7 @@ bitflags! {
         const Intersection = 1 << 21;
 
         const Literal = Self::StringLiteral.bits | Self::NumberLiteral.bits | Self::BigIntLiteral.bits | Self::BooleanLiteral.bits;
+        const NumberLike = Self::Number.bits | Self::NumberLiteral.bits | Self::Enum.bits;
         const StructuredType = Self::Object.bits | Self::Union.bits | Self::Intersection.bits;
         const StructuredOrInstantiable = Self::StructuredType.bits /*| Self::Instantiable.bits */;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,8 @@ pub use compiler::types::{
     ModuleSpecifierResolutionHost, Node, NodeArray, NodeArrayOrVec, NodeFactory, NodeInterface,
     NumberLiteralType, NumericLiteral, ParsedCommandLine, Path, PrefixUnaryExpression, Program,
     ReadonlyTextRange, RelationComparisonResult, SourceFile, Statement, StructureIsReused,
-    SyntaxKind, TextSpan, Type, TypeChecker, TypeCheckerHost, TypeFlags, TypeInterface, UnionType,
+    SyntaxKind, Ternary, TextSpan, Type, TypeChecker, TypeCheckerHost, TypeFlags, TypeInterface,
+    UnionOrIntersectionType, UnionOrIntersectionTypeInterface, UnionType,
 };
 pub use compiler::utilities::{
     create_detached_diagnostic, create_diagnostic_collection, create_diagnostic_for_node,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,15 +21,16 @@ pub use compiler::scanner::{create_scanner, Scanner};
 pub use compiler::sys::{get_sys, System};
 pub use compiler::types::{
     BaseDiagnostic, BaseDiagnosticRelatedInformation, BaseIntrinsicType, BaseLiteralLikeNode,
-    BaseNode, BaseType, BaseUnionOrIntersectionType, BinaryExpression, CharacterCodes,
-    CompilerHost, CreateProgramOptions, Diagnostic, DiagnosticCategory, DiagnosticCollection,
-    DiagnosticMessage, DiagnosticRelatedInformationInterface, DiagnosticWithDetachedLocation,
-    DiagnosticWithLocation, EmptyStatement, ExitStatus, Expression, ExpressionStatement,
-    FreshableIntrinsicType, Identifier, IntrinsicType, LiteralLikeNode, ModuleResolutionHost,
+    BaseLiteralType, BaseNode, BaseType, BaseUnionOrIntersectionType, BinaryExpression,
+    CharacterCodes, CompilerHost, CreateProgramOptions, Diagnostic, DiagnosticCategory,
+    DiagnosticCollection, DiagnosticMessage, DiagnosticRelatedInformationInterface,
+    DiagnosticWithDetachedLocation, DiagnosticWithLocation, EmptyStatement, ExitStatus, Expression,
+    ExpressionStatement, FreshableIntrinsicType, Identifier, IntrinsicType, LiteralLikeNode,
+    LiteralLikeNodeInterface, LiteralTypeInterface, ModuleResolutionHost,
     ModuleSpecifierResolutionHost, Node, NodeArray, NodeArrayOrVec, NodeFactory, NodeInterface,
-    NumericLiteral, ParsedCommandLine, Path, PrefixUnaryExpression, Program, ReadonlyTextRange,
-    RelationComparisonResult, SourceFile, Statement, StructureIsReused, SyntaxKind, TextSpan, Type,
-    TypeChecker, TypeCheckerHost, TypeFlags, TypeInterface, UnionType,
+    NumberLiteralType, NumericLiteral, ParsedCommandLine, Path, PrefixUnaryExpression, Program,
+    ReadonlyTextRange, RelationComparisonResult, SourceFile, Statement, StructureIsReused,
+    SyntaxKind, TextSpan, Type, TypeChecker, TypeCheckerHost, TypeFlags, TypeInterface, UnionType,
 };
 pub use compiler::utilities::{
     create_detached_diagnostic, create_diagnostic_collection, create_diagnostic_for_node,
@@ -40,4 +41,5 @@ pub use compiler::utilities_public::create_text_span_from_bounds;
 pub use compiler::watch::emit_files_and_report_errors_and_get_exit_status;
 pub use execute_command_line::execute_command_line::execute_command_line;
 pub use rust_helpers::is_same_variant;
+pub use rust_helpers::number::Number;
 pub use rust_helpers::weak_self::WeakSelf;

--- a/src/rust_helpers/mod.rs
+++ b/src/rust_helpers/mod.rs
@@ -1,5 +1,6 @@
 use std::mem;
 
+pub mod number;
 pub mod weak_self;
 
 pub fn is_same_variant<TEnum>(value: &TEnum, other_value: &TEnum) -> bool {

--- a/src/rust_helpers/number.rs
+++ b/src/rust_helpers/number.rs
@@ -1,0 +1,40 @@
+use std::hash;
+
+#[derive(Clone, Copy)]
+pub struct Number(f64);
+
+impl Number {
+    fn new(value: f64) -> Self {
+        if value.is_nan() {
+            panic!("Tried to initialize Number with NaN: {}", value);
+        }
+        Self(value)
+    }
+
+    fn key(&self) -> u64 {
+        self.0.to_bits()
+    }
+}
+
+impl hash::Hash for Number {
+    fn hash<THasher>(&self, state: &mut THasher)
+    where
+        THasher: hash::Hasher,
+    {
+        self.key().hash(state)
+    }
+}
+
+impl PartialEq for Number {
+    fn eq(&self, other: &Number) -> bool {
+        self.key() == other.key()
+    }
+}
+
+impl Eq for Number {}
+
+impl From<&str> for Number {
+    fn from(str: &str) -> Self {
+        Number::new(str.parse::<f64>().unwrap())
+    }
+}

--- a/src/rust_helpers/number.rs
+++ b/src/rust_helpers/number.rs
@@ -1,6 +1,6 @@
 use std::hash;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Number(f64);
 
 impl Number {


### PR DESCRIPTION
In this PR:
- don't emit a type error when parsing + type-checking the prefix unary expression `++1`

To test:
If you have a file named eg `tmp.tsx` in the repo root directory whose contents are just `++true` (no trailing newline) and run `cargo run tmp.tsx` you should see debug-logging of the `SourceFile` and then a single `DiagnosticWithLocation` associated with the `SourceFile` whose `file_name` is `"tmp.tsx"` and with location data `start: 2, length: 4` (ie the location of the `true` operand). If you modify `tmp.tsx` to contain `++1` (no trailing newline) and run `cargo run tmp.tsx` you should see debug-logging of the `SourceFile` and an empty diagnostics array

Based on `emit-diagnostics`