### PR TITLE
Multiple statements

### DIFF
--- a/src/compiler/binder.rs
+++ b/src/compiler/binder.rs
@@ -48,19 +48,19 @@ impl BinderType {
     }
 
     fn file(&self) -> Rc<Node> {
-        self.file.read().unwrap().as_ref().unwrap().clone()
+        self.file.try_read().unwrap().as_ref().unwrap().clone()
     }
 
     fn set_file(&self, file: Option<Rc<Node>>) {
-        *self.file.write().unwrap() = file;
+        *self.file.try_write().unwrap() = file;
     }
 
     fn parent(&self) -> Rc<Node> {
-        self.parent.read().unwrap().as_ref().unwrap().clone()
+        self.parent.try_read().unwrap().as_ref().unwrap().clone()
     }
 
     fn set_parent(&self, parent: Option<Rc<Node>>) {
-        *self.parent.write().unwrap() = parent;
+        *self.parent.try_write().unwrap() = parent;
     }
 
     fn bind_source_file(&self, f: Rc<Node>) {
@@ -170,14 +170,14 @@ impl BinderType {
         };
         set_parent(
             &*node,
-            match self.parent.read().unwrap().as_ref() {
+            match self.parent.try_read().unwrap().as_ref() {
                 None => None,
                 Some(parent) => Some(parent.clone()),
             },
         );
 
         if node.kind() > SyntaxKind::LastToken {
-            let save_parent = match *self.parent.read().unwrap() {
+            let save_parent = match *self.parent.try_read().unwrap() {
                 None => None,
                 Some(ref rc_node) => Some(rc_node.clone()),
             };

--- a/src/compiler/checker.rs
+++ b/src/compiler/checker.rs
@@ -146,7 +146,10 @@ impl TypeChecker {
         message: &DiagnosticMessage,
     ) -> Rc<Diagnostic> {
         let diagnostic = self.create_error(location, message);
-        self.diagnostics().write().unwrap().add(diagnostic.clone());
+        self.diagnostics()
+            .try_write()
+            .unwrap()
+            .add(diagnostic.clone());
         diagnostic
     }
 
@@ -401,7 +404,7 @@ impl TypeChecker {
 
         let semantic_diagnostics = self
             .diagnostics()
-            .read()
+            .try_read()
             .unwrap()
             .get_diagnostics(&source_file.file_name);
 

--- a/src/compiler/core_public.rs
+++ b/src/compiler/core_public.rs
@@ -1,5 +1,5 @@
 pub struct SortedArray<TItem> {
-    pub _vec: Vec<TItem>,
+    _vec: Vec<TItem>,
 }
 
 impl<TItem> SortedArray<TItem> {
@@ -13,5 +13,17 @@ impl<TItem> SortedArray<TItem> {
 
     pub fn is_empty(&self) -> bool {
         self._vec.is_empty()
+    }
+}
+
+impl<TItem: Clone> From<SortedArray<TItem>> for Vec<TItem> {
+    fn from(sorted_array: SortedArray<TItem>) -> Self {
+        sorted_array._vec
+    }
+}
+
+impl<TItem: Clone> From<&SortedArray<TItem>> for Vec<TItem> {
+    fn from(sorted_array: &SortedArray<TItem>) -> Self {
+        sorted_array._vec.clone()
     }
 }

--- a/src/compiler/program.rs
+++ b/src/compiler/program.rs
@@ -191,7 +191,7 @@ pub fn create_program(root_names_or_options: CreateProgramOptions) -> impl Progr
         });
 
         files = processing_other_files_present;
-        println!("files: {:?}", files);
+        println!("files: {:#?}", files);
         processing_other_files = None;
     }
 

--- a/src/compiler/program.rs
+++ b/src/compiler/program.rs
@@ -206,15 +206,15 @@ fn process_root_file(helper_context: &mut CreateProgramHelperContext, file_name:
     process_source_file(helper_context, &normalize_path(file_name));
 }
 
-fn get_source_file_from_reference_worker(
+fn get_source_file_from_reference_worker<TClosure: FnMut(&str) -> Option<Rc<Node>>>(
     file_name: &str,
-    get_source_file: &mut dyn FnMut(&str) -> Option<Rc<Node>>,
+    mut get_source_file: TClosure,
 ) -> Option<Rc<Node>> {
     get_source_file(file_name)
 }
 
 fn process_source_file(helper_context: &mut CreateProgramHelperContext, file_name: &str) {
-    get_source_file_from_reference_worker(file_name, &mut |file_name| {
+    get_source_file_from_reference_worker(file_name, |file_name| {
         find_source_file(helper_context, file_name)
     });
 }

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -163,7 +163,7 @@ impl NodeInterface for BaseNode {
 
     fn parent(&self) -> Rc<Node> {
         self.parent
-            .read()
+            .try_read()
             .unwrap()
             .clone()
             .unwrap()
@@ -172,7 +172,7 @@ impl NodeInterface for BaseNode {
     }
 
     fn set_parent(&self, parent: Rc<Node>) {
-        *self.parent.write().unwrap() = Some(Rc::downgrade(&parent));
+        *self.parent.try_write().unwrap() = Some(Rc::downgrade(&parent));
     }
 }
 

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -28,6 +28,7 @@ pub enum SyntaxKind {
     Unknown,
     EndOfFileToken,
     NumericLiteral,
+    CloseBraceToken,
     SemicolonToken,
     AsteriskToken,
     PlusPlusToken,
@@ -626,6 +627,13 @@ impl LiteralLikeNodeInterface for LiteralLikeNode {
         match self {
             LiteralLikeNode::NumericLiteral(numeric_literal) => numeric_literal.text(),
         }
+    }
+}
+
+bitflags! {
+    pub struct TokenFlags: u32 {
+        const None = 0;
+        const PrecedingLineBreak = 1 << 0;
     }
 }
 
@@ -1383,6 +1391,8 @@ pub struct CharacterCodes;
 #[allow(non_upper_case_globals)]
 impl CharacterCodes {
     pub const max_ascii_character: char = '';
+
+    pub const lineFeed: char = '\n';
 
     pub const space: char = ' ';
 

--- a/src/compiler/utilities.rs
+++ b/src/compiler/utilities.rs
@@ -133,7 +133,7 @@ impl DiagnosticCollection {
     pub fn get_diagnostics(&self, file_name: &str) -> Vec<Rc<Diagnostic>> {
         self.file_diagnostics
             .get(file_name)
-            .map(|sorted_array| sorted_array._vec.clone())
+            .map(|sorted_array| sorted_array.into())
             .unwrap_or(vec![])
     }
 }

--- a/src/compiler/watch.rs
+++ b/src/compiler/watch.rs
@@ -18,7 +18,7 @@ pub fn emit_files_and_report_errors_and_get_exit_status<TProgram: Program>(
     program: TProgram,
 ) -> ExitStatus {
     let EmitFilesAndReportErrorsReturn { diagnostics } = emit_files_and_report_errors(program);
-    println!("diagnostics: {:?}", diagnostics);
+    println!("diagnostics: {:#?}", diagnostics);
     if !diagnostics.is_empty() {
         return ExitStatus::DiagnosticsPresent_OutputsGenerated;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,8 @@ pub use compiler::types::{
     ModuleSpecifierResolutionHost, Node, NodeArray, NodeArrayOrVec, NodeFactory, NodeInterface,
     NumberLiteralType, NumericLiteral, ParsedCommandLine, Path, PrefixUnaryExpression, Program,
     ReadonlyTextRange, RelationComparisonResult, SourceFile, Statement, StructureIsReused,
-    SyntaxKind, Ternary, TextSpan, Type, TypeChecker, TypeCheckerHost, TypeFlags, TypeInterface,
-    UnionOrIntersectionType, UnionOrIntersectionTypeInterface, UnionType,
+    SyntaxKind, Ternary, TextSpan, TokenFlags, Type, TypeChecker, TypeCheckerHost, TypeFlags,
+    TypeInterface, UnionOrIntersectionType, UnionOrIntersectionTypeInterface, UnionType,
 };
 pub use compiler::utilities::{
     create_detached_diagnostic, create_diagnostic_collection, create_diagnostic_for_node,


### PR DESCRIPTION
In this PR:
- handle newlines/multiple statements

To test:
If you have a file named eg `tmp.tsx` in the repo root directory whose contents are something like (trailing newline is fine):
```
++1; 2;
++true
3
```
and run `cargo run tmp.tsx` you should see debug-logging of the `SourceFile` with four `ExpressionStatement`'s and then a single `DiagnosticWithLocation` whose `start`/`length` should correspond to the position of the `true` literal (in this example, `start: 10, length: 4`)

Based on `plusplus-number`