### PR TITLE
Use RefCell/Cell's instead of RwLock/atomic's

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,31 +9,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
-name = "libc"
-version = "0.2.112"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "local-macros"
@@ -42,40 +21,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "lock_api"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
 ]
 
 [[package]]
@@ -97,27 +42,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "smallvec"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
-
-[[package]]
 name = "syn"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,7 +59,6 @@ dependencies = [
  "bitflags",
  "lazy_static",
  "local-macros",
- "parking_lot",
 ]
 
 [[package]]
@@ -143,25 +66,3 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,4 @@ edition = "2018"
 [dependencies]
 bitflags = "1.3.2"
 lazy_static = "1.4.0"
-parking_lot = "0.11.2"
 local-macros = { path = "local-macros" }

--- a/local-macros/src/lib.rs
+++ b/local-macros/src/lib.rs
@@ -46,7 +46,7 @@ pub fn ast_type(_attr: TokenStream, item: TokenStream) -> TokenStream {
                         self.#first_field_name.set_symbol(symbol);
                     }
 
-                    fn locals(&self) -> ::parking_lot::MappedRwLockWriteGuard<crate::SymbolTable> {
+                    fn locals(&self) -> ::std::cell::RefMut<crate::SymbolTable> {
                         self.#first_field_name.locals()
                     }
 
@@ -119,7 +119,7 @@ pub fn ast_type(_attr: TokenStream, item: TokenStream) -> TokenStream {
                         }
                     }
 
-                    fn locals(&self) -> ::parking_lot::MappedRwLockWriteGuard<crate::SymbolTable> {
+                    fn locals(&self) -> ::std::cell::RefMut<crate::SymbolTable> {
                         match self {
                             #(#ast_type_name::#variant_names_6(nested_6) => nested_6.locals()),*
                         }

--- a/src/compiler/checker.rs
+++ b/src/compiler/checker.rs
@@ -1,5 +1,5 @@
 use bitflags::bitflags;
-use parking_lot::RwLock;
+use std::cell::{RefCell, RefMut};
 use std::collections::HashMap;
 use std::ptr;
 use std::rc::Rc;
@@ -41,7 +41,7 @@ pub fn create_type_checker<TTypeCheckerHost: TypeCheckerHost>(
         regular_true_type: None,
         number_or_big_int_type: None,
 
-        diagnostics: RwLock::new(create_diagnostic_collection()),
+        diagnostics: RefCell::new(create_diagnostic_collection()),
 
         assignable_relation: HashMap::new(),
     };
@@ -124,8 +124,8 @@ impl TypeChecker {
         self.number_or_big_int_type.as_ref().unwrap().clone()
     }
 
-    fn diagnostics(&self) -> &RwLock<DiagnosticCollection> {
-        &self.diagnostics
+    fn diagnostics(&self) -> RefMut<DiagnosticCollection> {
+        self.diagnostics.borrow_mut()
     }
 
     fn create_error<TNode: NodeInterface>(
@@ -146,10 +146,7 @@ impl TypeChecker {
         message: &DiagnosticMessage,
     ) -> Rc<Diagnostic> {
         let diagnostic = self.create_error(location, message);
-        self.diagnostics()
-            .try_write()
-            .unwrap()
-            .add(diagnostic.clone());
+        self.diagnostics().add(diagnostic.clone());
         diagnostic
     }
 
@@ -402,11 +399,7 @@ impl TypeChecker {
     fn get_diagnostics_worker(&mut self, source_file: &SourceFile) -> Vec<Rc<Diagnostic>> {
         self.check_source_file(source_file);
 
-        let semantic_diagnostics = self
-            .diagnostics()
-            .try_read()
-            .unwrap()
-            .get_diagnostics(&source_file.file_name);
+        let semantic_diagnostics = self.diagnostics().get_diagnostics(&source_file.file_name);
 
         semantic_diagnostics
     }

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -1,7 +1,7 @@
 #![allow(non_upper_case_globals)]
 
 use bitflags::bitflags;
-use parking_lot::MappedRwLockWriteGuard;
+use std::cell::RefMut;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
@@ -120,7 +120,7 @@ impl NodeInterface for MissingNode {
         }
     }
 
-    fn locals(&self) -> MappedRwLockWriteGuard<SymbolTable> {
+    fn locals(&self) -> RefMut<SymbolTable> {
         match self {
             MissingNode::Identifier(identifier) => identifier.locals(),
         }

--- a/src/compiler/scanner.rs
+++ b/src/compiler/scanner.rs
@@ -1,9 +1,9 @@
 #![allow(non_upper_case_globals)]
 
 use std::array::IntoIter;
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::iter::FromIterator;
-use std::sync::RwLock;
 
 use crate::{CharacterCodes, SyntaxKind, TokenFlags};
 
@@ -50,13 +50,13 @@ struct ScanNumberReturn {
 pub struct Scanner {
     skip_trivia: bool,
     text: Option<String>,
-    pos: RwLock<Option<usize>>,
+    pos: RefCell<Option<usize>>,
     end: Option<usize>,
-    start_pos: RwLock<Option<usize>>,
-    token_pos: RwLock<Option<usize>>,
-    token: RwLock<Option<SyntaxKind>>,
-    token_value: RwLock<Option<String>>,
-    token_flags: RwLock<Option<TokenFlags>>,
+    start_pos: RefCell<Option<usize>>,
+    token_pos: RefCell<Option<usize>>,
+    token: RefCell<Option<SyntaxKind>>,
+    token_value: RefCell<Option<String>>,
+    token_flags: RefCell<Option<TokenFlags>>,
 }
 
 impl Scanner {
@@ -228,13 +228,13 @@ impl Scanner {
         Scanner {
             skip_trivia,
             text: None,
-            pos: RwLock::new(None),
+            pos: RefCell::new(None),
             end: None,
-            start_pos: RwLock::new(None),
-            token_pos: RwLock::new(None),
-            token: RwLock::new(None),
-            token_value: RwLock::new(None),
-            token_flags: RwLock::new(None),
+            start_pos: RefCell::new(None),
+            token_pos: RefCell::new(None),
+            token: RefCell::new(None),
+            token_value: RefCell::new(None),
+            token_flags: RefCell::new(None),
         }
     }
 
@@ -247,11 +247,11 @@ impl Scanner {
     }
 
     fn pos(&self) -> usize {
-        self.pos.try_read().unwrap().unwrap()
+        self.pos.borrow().unwrap()
     }
 
     fn set_pos(&self, pos: usize) {
-        *self.pos.try_write().unwrap() = Some(pos);
+        *self.pos.borrow_mut() = Some(pos);
     }
 
     fn end(&self) -> usize {
@@ -263,49 +263,44 @@ impl Scanner {
     }
 
     fn start_pos(&self) -> usize {
-        self.start_pos.try_read().unwrap().unwrap()
+        self.start_pos.borrow().unwrap()
     }
 
     fn set_start_pos(&self, start_pos: usize) {
-        *self.start_pos.try_write().unwrap() = Some(start_pos);
+        *self.start_pos.borrow_mut() = Some(start_pos);
     }
 
     fn token_pos(&self) -> usize {
-        self.token_pos.try_read().unwrap().unwrap()
+        self.token_pos.borrow().unwrap()
     }
 
     fn set_token_pos(&self, token_pos: usize) {
-        *self.token_pos.try_write().unwrap() = Some(token_pos);
+        *self.token_pos.borrow_mut() = Some(token_pos);
     }
 
     fn token(&self) -> SyntaxKind {
-        self.token.try_read().unwrap().unwrap()
+        self.token.borrow().unwrap()
     }
 
     fn set_token(&self, token: SyntaxKind) -> SyntaxKind {
-        *self.token.try_write().unwrap() = Some(token);
+        *self.token.borrow_mut() = Some(token);
         token
     }
 
     fn token_value(&self) -> String {
-        self.token_value
-            .try_read()
-            .unwrap()
-            .as_ref()
-            .unwrap()
-            .to_string()
+        self.token_value.borrow().as_ref().unwrap().to_string()
     }
 
     fn set_token_value(&self, token_value: &str) {
-        *self.token_value.try_write().unwrap() = Some(token_value.to_string());
+        *self.token_value.borrow_mut() = Some(token_value.to_string());
     }
 
     fn token_flags(&self) -> TokenFlags {
-        self.token_flags.try_read().unwrap().unwrap()
+        self.token_flags.borrow().unwrap()
     }
 
     fn set_token_flags(&self, token_flags: TokenFlags) {
-        *self.token_flags.try_write().unwrap() = Some(token_flags);
+        *self.token_flags.borrow_mut() = Some(token_flags);
     }
 
     fn is_digit(&self, ch: char) -> bool {

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -1,8 +1,7 @@
 #![allow(non_upper_case_globals)]
 
 use bitflags::bitflags;
-use parking_lot::{RwLock, RwLockReadGuard};
-use std::cell::{RefCell, RefMut};
+use std::cell::{Ref, RefCell, RefMut};
 use std::collections::HashMap;
 use std::rc::{Rc, Weak};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -792,7 +791,7 @@ bitflags! {
 pub struct Symbol {
     pub flags: SymbolFlags,
     pub escaped_name: __String,
-    declarations: RwLock<Option<Vec<Rc<Node /*Declaration*/>>>>,
+    declarations: RefCell<Option<Vec<Rc<Node /*Declaration*/>>>>,
 }
 
 impl Symbol {
@@ -800,16 +799,16 @@ impl Symbol {
         Self {
             flags,
             escaped_name: name,
-            declarations: RwLock::new(None),
+            declarations: RefCell::new(None),
         }
     }
 
-    pub fn maybe_declarations(&self) -> RwLockReadGuard<Option<Vec<Rc<Node>>>> {
-        self.declarations.try_read().unwrap()
+    pub fn maybe_declarations(&self) -> Ref<Option<Vec<Rc<Node>>>> {
+        self.declarations.borrow()
     }
 
     pub fn set_declarations(&self, declarations: Vec<Rc<Node>>) {
-        *self.declarations.try_write().unwrap() = Some(declarations);
+        *self.declarations.borrow_mut() = Some(declarations);
     }
 }
 

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -778,7 +778,7 @@ pub struct TypeChecker {
     pub true_type: Option<Rc<Type>>,
     pub regular_true_type: Option<Rc<Type>>,
     pub number_or_big_int_type: Option<Rc<Type>>,
-    pub diagnostics: RwLock<DiagnosticCollection>,
+    pub diagnostics: RefCell<DiagnosticCollection>,
     pub assignable_relation: HashMap<String, RelationComparisonResult>,
 }
 

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -1,10 +1,9 @@
 #![allow(non_upper_case_globals)]
 
 use bitflags::bitflags;
-use std::cell::{Ref, RefCell, RefMut};
+use std::cell::{Cell, Ref, RefCell, RefMut};
 use std::collections::HashMap;
 use std::rc::{Rc, Weak};
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::{Number, SortedArray, WeakSelf};
 use local_macros::ast_type;
@@ -137,8 +136,8 @@ impl Node {
 pub struct BaseNode {
     pub kind: SyntaxKind,
     pub parent: RefCell<Option<Weak<Node>>>,
-    pub pos: AtomicUsize,
-    pub end: AtomicUsize,
+    pub pos: Cell<usize>,
+    pub end: Cell<usize>,
     pub symbol: RefCell<Option<Weak<Symbol>>>,
     pub locals: RefCell<Option<SymbolTable>>,
 }
@@ -188,19 +187,19 @@ impl NodeInterface for BaseNode {
 
 impl ReadonlyTextRange for BaseNode {
     fn pos(&self) -> usize {
-        self.pos.load(Ordering::Relaxed)
+        self.pos.get()
     }
 
     fn set_pos(&self, pos: usize) {
-        self.pos.store(pos, Ordering::Relaxed);
+        self.pos.set(pos);
     }
 
     fn end(&self) -> usize {
-        self.end.load(Ordering::Relaxed)
+        self.end.get()
     }
 
     fn set_end(&self, end: usize) {
-        self.end.store(end, Ordering::Relaxed);
+        self.end.set(end);
     }
 }
 

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -137,7 +137,7 @@ impl Node {
 #[derive(Debug)]
 pub struct BaseNode {
     pub kind: SyntaxKind,
-    pub parent: RwLock<Option<Weak<Node>>>,
+    pub parent: RefCell<Option<Weak<Node>>>,
     pub pos: AtomicUsize,
     pub end: AtomicUsize,
     pub symbol: RefCell<Option<Weak<Symbol>>>,
@@ -148,7 +148,7 @@ impl BaseNode {
     pub fn new(kind: SyntaxKind, pos: usize, end: usize) -> Self {
         Self {
             kind,
-            parent: RwLock::new(None),
+            parent: RefCell::new(None),
             pos: pos.into(),
             end: end.into(),
             symbol: RefCell::new(None),
@@ -163,17 +163,11 @@ impl NodeInterface for BaseNode {
     }
 
     fn parent(&self) -> Rc<Node> {
-        self.parent
-            .try_read()
-            .unwrap()
-            .clone()
-            .unwrap()
-            .upgrade()
-            .unwrap()
+        self.parent.borrow().clone().unwrap().upgrade().unwrap()
     }
 
     fn set_parent(&self, parent: Rc<Node>) {
-        *self.parent.try_write().unwrap() = Some(Rc::downgrade(&parent));
+        *self.parent.borrow_mut() = Some(Rc::downgrade(&parent));
     }
 
     fn symbol(&self) -> Rc<Symbol> {


### PR DESCRIPTION
In this PR:
- instead of using `RwLock`/`Atomic*`, use `RefCell`/`Cell` since it's apparently cheaper/faster

To test:
Should still behave the same as of #9 

Based on `ast-type-macro-node-enum-types`