### PR TITLE
Store a reference to Rc<Node> wrapper in AST nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "darling"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a340f241d2ceed1deb47ae36c4144b2707ec7dd0b649f894cb39bb595986324"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,6 +65,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 name = "local-macros"
 version = "0.1.0"
 dependencies = [
+ "darling",
  "proc-macro2",
  "quote",
  "syn",
@@ -40,6 +88,12 @@ checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"

--- a/local-macros/Cargo.lock
+++ b/local-macros/Cargo.lock
@@ -3,9 +3,57 @@
 version = 3
 
 [[package]]
+name = "darling"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a340f241d2ceed1deb47ae36c4144b2707ec7dd0b649f894cb39bb595986324"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "local-macros"
 version = "0.1.0"
 dependencies = [
+ "darling",
  "proc-macro2",
  "quote",
  "syn",
@@ -28,6 +76,12 @@ checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"

--- a/local-macros/Cargo.toml
+++ b/local-macros/Cargo.toml
@@ -9,6 +9,7 @@ proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+darling = "0.13.1"
 proc-macro2 = "1.0.34"
 quote = "1.0.10"
 syn = { version = "1.0.82" }

--- a/local-macros/src/lib.rs
+++ b/local-macros/src/lib.rs
@@ -1,10 +1,41 @@
+use darling::FromMeta;
 use proc_macro::TokenStream;
+use proc_macro2::Ident;
 use quote::quote;
 use syn::Data::{Enum, Struct};
-use syn::{parse_macro_input, DataEnum, DeriveInput, Fields, FieldsNamed};
+use syn::{parse_macro_input, AttributeArgs, DataEnum, DeriveInput, Fields, FieldsNamed};
+
+#[derive(Debug, FromMeta)]
+struct AstTypeArgs {
+    #[darling(default)]
+    ancestors: Option<String>,
+    #[darling(default)]
+    impl_from: Option<bool>,
+}
+
+impl AstTypeArgs {
+    fn ancestors_vec(&self) -> Vec<String> {
+        let mut vec = self.ancestors.as_ref().map_or_else(
+            || vec![],
+            |ancestors_str| {
+                ancestors_str
+                    .split(",")
+                    .into_iter()
+                    .map(|chunk| chunk.trim().to_string())
+                    .collect()
+            },
+        );
+        vec.push("Node".to_string());
+        vec
+    }
+
+    fn should_impl_from(&self) -> bool {
+        self.impl_from.unwrap_or(true)
+    }
+}
 
 #[proc_macro_attribute]
-pub fn ast_type(_attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn ast_type(attr: TokenStream, item: TokenStream) -> TokenStream {
     let item_for_parsing = item.clone();
     let DeriveInput {
         ident: ast_type_name,
@@ -195,12 +226,60 @@ pub fn ast_type(_attr: TokenStream, item: TokenStream) -> TokenStream {
         _ => panic!("Expected struct or enum"),
     };
 
+    let attr_args = parse_macro_input!(attr as AttributeArgs);
+    let args = match AstTypeArgs::from_list(&attr_args) {
+        Ok(args) => args,
+        Err(error) => {
+            return TokenStream::from(error.write_errors());
+        }
+    };
+
+    let into_implementations = if args.should_impl_from() {
+        let mut construct_variant = quote! {
+            concrete
+        };
+        let mut previous_variant_name = ast_type_name.clone();
+        let mut into_implementations = quote! {};
+        for ancestor in args.ancestors_vec() {
+            let ancestor_ident = Ident::new(&ancestor, previous_variant_name.span());
+            construct_variant = quote! {
+                crate::#ancestor_ident::#previous_variant_name(#construct_variant)
+            };
+            into_implementations = quote! {
+                #into_implementations
+
+                impl ::std::convert::From<#ast_type_name> for crate::#ancestor_ident {
+                    fn from(concrete: #ast_type_name) -> Self {
+                        #construct_variant
+                    }
+                }
+            };
+            previous_variant_name = ancestor_ident;
+        }
+
+        quote! {
+            #into_implementations
+
+            impl ::std::convert::From<#ast_type_name> for ::std::rc::Rc<crate::Node> {
+                fn from(concrete: #ast_type_name) -> Self {
+                    let rc = ::std::rc::Rc::new(#construct_variant);
+                    crate::NodeInterface::set_node_wrapper(&*rc, rc.clone());
+                    rc
+                }
+            }
+        }
+    } else {
+        quote! {}
+    };
+
     let item_as_proc_macro2_token_stream = proc_macro2::TokenStream::from(item);
 
     quote! {
         #item_as_proc_macro2_token_stream
 
         #node_interface_and_readonly_text_range_implementation
+
+        #into_implementations
     }
     .into()
 }

--- a/local-macros/src/lib.rs
+++ b/local-macros/src/lib.rs
@@ -26,6 +26,14 @@ pub fn ast_type(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
             quote! {
                 impl crate::NodeInterface for #ast_type_name {
+                    fn node_wrapper(&self) -> ::std::rc::Rc<crate::Node> {
+                        self.#first_field_name.node_wrapper()
+                    }
+
+                    fn set_node_wrapper(&self, wrapper: ::std::rc::Rc<crate::Node>) {
+                        self.#first_field_name.set_node_wrapper(wrapper)
+                    }
+
                     fn kind(&self) -> crate::SyntaxKind {
                         self.#first_field_name.kind()
                     }
@@ -91,9 +99,23 @@ pub fn ast_type(_attr: TokenStream, item: TokenStream) -> TokenStream {
             let variant_names_10 = variant_names.clone();
             let variant_names_11 = variant_names.clone();
             let variant_names_12 = variant_names.clone();
+            let variant_names_13 = variant_names.clone();
+            let variant_names_14 = variant_names.clone();
 
             quote! {
                 impl crate::NodeInterface for #ast_type_name {
+                    fn node_wrapper(&self) -> ::std::rc::Rc<crate::Node> {
+                        match self {
+                            #(#ast_type_name::#variant_names_13(nested) => nested.node_wrapper()),*
+                        }
+                    }
+
+                    fn set_node_wrapper(&self, wrapper: ::std::rc::Rc<crate::Node>) {
+                        match self {
+                            #(#ast_type_name::#variant_names_14(nested) => nested.set_node_wrapper(wrapper)),*
+                        }
+                    }
+
                     fn kind(&self) -> crate::SyntaxKind {
                         match self {
                             #(#ast_type_name::#variant_names(nested) => nested.kind()),*

--- a/src/compiler/binder.rs
+++ b/src/compiler/binder.rs
@@ -140,7 +140,7 @@ impl BinderType {
         let name = get_name_of_declaration(node);
         if let Some(name) = name {
             return if is_property_name_literal(&*name) {
-                Some(get_escaped_text_of_identifier_or_literal(name.clone()))
+                Some(get_escaped_text_of_identifier_or_literal(&*name))
             } else {
                 None
             };

--- a/src/compiler/binder.rs
+++ b/src/compiler/binder.rs
@@ -116,21 +116,19 @@ impl BinderType {
         self.Symbol()(flags, name)
     }
 
-    fn add_declaration_to_symbol(
+    fn add_declaration_to_symbol<TNode: NodeInterface>(
         &self,
         symbol: Rc<Symbol>,
-        node: Rc<Node /*Declaration*/>,
+        node: &TNode, /*Declaration*/
         symbol_flags: SymbolFlags,
     ) {
         symbol.set_flags(symbol.flags() | symbol_flags);
 
         node.set_symbol(symbol.clone());
-        let declarations = {
-            append_if_unique(
-                symbol.maybe_declarations().as_ref().map(|vec| vec.clone()),
-                node.clone(),
-            )
-        };
+        let declarations = append_if_unique(
+            symbol.maybe_declarations().as_ref().map(|vec| vec.clone()),
+            node.node_wrapper(),
+        );
         symbol.set_declarations(declarations);
 
         if symbol_flags.intersects(SymbolFlags::Value) {
@@ -138,7 +136,7 @@ impl BinderType {
         }
     }
 
-    fn get_declaration_name(&self, node: Rc<Node>) -> Option<__String> {
+    fn get_declaration_name<TNode: NodeInterface>(&self, node: &TNode) -> Option<__String> {
         let name = get_name_of_declaration(node);
         if let Some(name) = name {
             return if is_property_name_literal(&*name) {
@@ -150,13 +148,13 @@ impl BinderType {
         unimplemented!()
     }
 
-    fn declare_symbol(
+    fn declare_symbol<TNode: NodeInterface>(
         &self,
         symbol_table: &mut SymbolTable,
-        node: Rc<Node /*Declaration*/>,
+        node: &TNode, /*Declaration*/
         includes: SymbolFlags,
     ) -> Rc<Symbol> {
-        let name = self.get_declaration_name(node.clone());
+        let name = self.get_declaration_name(node);
 
         let mut symbol = None;
         match name {
@@ -213,12 +211,12 @@ impl BinderType {
         });
     }
 
-    fn bind_each_callback<TNodeCallback: FnMut(Rc<Node>)>(
+    fn bind_each_callback<TNodeCallback: FnMut(&Node)>(
         nodes: &NodeArray,
         mut bind_function: TNodeCallback,
     ) {
         for_each(nodes, |node, _| {
-            bind_function(node.clone());
+            bind_function(&*node);
             Option::<()>::None
         });
     }
@@ -288,9 +286,9 @@ impl BinderType {
         ContainerFlags::None
     }
 
-    fn declare_symbol_and_add_to_symbol_table(
+    fn declare_symbol_and_add_to_symbol_table<TNode: NodeInterface>(
         &self,
-        node: Rc<Node /*Declaration*/>,
+        node: &TNode, /*Declaration*/
         symbol_flags: SymbolFlags,
     ) -> Option<Rc<Symbol>> {
         match self.container().kind() {
@@ -299,9 +297,9 @@ impl BinderType {
         }
     }
 
-    fn declare_source_file_member(
+    fn declare_source_file_member<TNode: NodeInterface>(
         &self,
-        node: Rc<Node /*Declaration*/>,
+        node: &TNode, /*Declaration*/
         symbol_flags: SymbolFlags,
     ) -> Rc<Symbol> {
         if false {
@@ -348,7 +346,7 @@ impl BinderType {
             if false {
             } else {
                 self.declare_symbol_and_add_to_symbol_table(
-                    node.node_wrapper(),
+                    node,
                     SymbolFlags::FunctionScopedVariable,
                 );
             }

--- a/src/compiler/binder.rs
+++ b/src/compiler/binder.rs
@@ -337,25 +337,18 @@ impl BinderType {
     fn bind_worker(&self, node: Rc<Node>) {
         match &*node {
             Node::VariableDeclaration(variable_declaration) => {
-                return self.bind_variable_declaration_or_binding_element(
-                    variable_declaration,
-                    node.clone(),
-                );
+                return self.bind_variable_declaration_or_binding_element(variable_declaration);
             }
             _ => (),
         }
     }
 
-    fn bind_variable_declaration_or_binding_element(
-        &self,
-        node: &VariableDeclaration,
-        wrapper: Rc<Node>,
-    ) {
+    fn bind_variable_declaration_or_binding_element(&self, node: &VariableDeclaration) {
         if !is_binding_pattern(&*node.name()) {
             if false {
             } else {
                 self.declare_symbol_and_add_to_symbol_table(
-                    wrapper,
+                    node.node_wrapper(),
                     SymbolFlags::FunctionScopedVariable,
                 );
             }

--- a/src/compiler/checker.rs
+++ b/src/compiler/checker.rs
@@ -634,7 +634,7 @@ impl TypeChecker {
                 };
             }
             Node::VariableDeclaration(variable_declaration) => {
-                return self.check_variable_declaration(variable_declaration, node.clone());
+                return self.check_variable_declaration(variable_declaration);
             }
             _ => unimplemented!(),
         };
@@ -737,7 +737,7 @@ impl TypeChecker {
         type_
     }
 
-    fn check_variable_like_declaration(&mut self, node: &VariableDeclaration, wrapper: Rc<Node>) {
+    fn check_variable_like_declaration(&mut self, node: &VariableDeclaration) {
         if true {
             self.check_source_element(node.type_());
         }
@@ -746,6 +746,7 @@ impl TypeChecker {
 
         let type_ = self.convert_auto_to_any(self.get_type_of_symbol(&*symbol));
         let value_declaration = symbol.maybe_value_declaration();
+        let wrapper = node.node_wrapper();
         if value_declaration.is_some()
             && Rc::ptr_eq(
                 &wrapper,
@@ -776,8 +777,8 @@ impl TypeChecker {
         }
     }
 
-    fn check_variable_declaration(&mut self, node: &VariableDeclaration, wrapper: Rc<Node>) {
-        self.check_variable_like_declaration(node, wrapper);
+    fn check_variable_declaration(&mut self, node: &VariableDeclaration) {
+        self.check_variable_like_declaration(node);
     }
 
     fn check_variable_statement(&mut self, node: &VariableStatement) {

--- a/src/compiler/checker.rs
+++ b/src/compiler/checker.rs
@@ -1,4 +1,5 @@
 use bitflags::bitflags;
+use std::borrow::Borrow;
 use std::cell::{Ref, RefCell, RefMut};
 use std::collections::HashMap;
 use std::ptr;
@@ -610,14 +611,15 @@ impl TypeChecker {
         }
     }
 
-    fn check_source_element(&mut self, node: Option<Rc<Node>>) {
+    fn check_source_element<TNodeRef: Borrow<Node>>(&mut self, node: Option<TNodeRef>) {
         if let Some(node) = node {
+            let node = node.borrow();
             self.check_source_element_worker(node);
         }
     }
 
-    fn check_source_element_worker(&mut self, node: Rc<Node>) {
-        match &*node {
+    fn check_source_element_worker(&mut self, node: &Node) {
+        match node {
             Node::TypeNode(type_node) => match type_node {
                 TypeNode::KeywordTypeNode(_) => (),
                 _ => unimplemented!(),
@@ -647,7 +649,7 @@ impl TypeChecker {
     fn check_source_file_worker(&mut self, node: &SourceFile) {
         if true {
             for_each(&node.statements, |statement, _index| {
-                self.check_source_element(Some(statement.clone()));
+                self.check_source_element(Some(&**statement));
                 Option::<()>::None
             });
         }
@@ -790,7 +792,7 @@ impl TypeChecker {
                 _ => panic!("Expected VariableDeclarationList"),
             }
             .declarations,
-            |declaration, _| Some(self.check_source_element(Some(declaration.clone()))),
+            |declaration, _| Some(self.check_source_element(Some(&**declaration))),
         );
     }
 

--- a/src/compiler/checker.rs
+++ b/src/compiler/checker.rs
@@ -806,7 +806,7 @@ impl TypeChecker {
 
     fn initialize_type_checker<TTypeCheckerHost: TypeCheckerHost>(&self, host: &TTypeCheckerHost) {
         for file in host.get_source_files() {
-            bind_source_file(file.clone());
+            bind_source_file(&*file);
             println!("post-binding: {:#?}", file);
         }
     }

--- a/src/compiler/checker.rs
+++ b/src/compiler/checker.rs
@@ -755,7 +755,7 @@ impl TypeChecker {
                 &value_declaration.as_ref().unwrap().upgrade().unwrap(),
             )
         {
-            let initializer = get_effective_initializer(&*wrapper);
+            let initializer = get_effective_initializer(node);
             if let Some(initializer) = initializer {
                 if true {
                     let initializer_type = self.check_expression_cached(match &*initializer {

--- a/src/compiler/factory/node_factory.rs
+++ b/src/compiler/factory/node_factory.rs
@@ -167,7 +167,7 @@ impl NodeFactory {
         declaration_list: VariableDeclarationList,
     ) -> VariableStatement {
         let node = self.create_base_declaration(base_factory, SyntaxKind::VariableStatement);
-        let node = VariableStatement::new(node, Rc::new(declaration_list.into()));
+        let node = VariableStatement::new(node, declaration_list.into());
         node
     }
 
@@ -187,7 +187,7 @@ impl NodeFactory {
     ) -> ExpressionStatement {
         ExpressionStatement {
             _node: self.create_base_node(base_factory, SyntaxKind::ExpressionStatement),
-            expression: Rc::new(expression.into()),
+            expression: expression.into(),
         }
     }
 

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -524,8 +524,12 @@ impl ParserType {
     }
 
     fn create_node_array(&self, elements: Vec<Node>) -> NodeArray {
-        self.factory
-            .create_node_array(elements.into_iter().map(Rc::new).collect::<Vec<Rc<Node>>>())
+        self.factory.create_node_array(
+            elements
+                .into_iter()
+                .map(Into::<Rc<Node>>::into)
+                .collect::<Vec<Rc<Node>>>(),
+        )
     }
 
     fn finish_node<TParsedNode: NodeInterface>(
@@ -1009,7 +1013,7 @@ impl ParserType {
     }
 
     fn parse_identifier_or_pattern(&mut self) -> Rc<Node> {
-        Rc::new(self.parse_binding_identifier().into())
+        self.parse_binding_identifier().into()
     }
 
     fn parse_variable_declaration_no_exclamation(&mut self) -> VariableDeclaration {
@@ -1032,8 +1036,8 @@ impl ParserType {
         let node = self.factory.create_variable_declaration(
             self,
             Some(name),
-            type_.map(|type_| Rc::new(type_.into())),
-            initializer.map(|initializer| Rc::new(initializer.into())),
+            type_.map(|type_| type_.into()),
+            initializer.map(|initializer| initializer.into()),
         );
         self.finish_node(node, pos, None)
     }

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -88,6 +88,18 @@ enum MissingNode {
 }
 
 impl NodeInterface for MissingNode {
+    fn node_wrapper(&self) -> Rc<Node> {
+        match self {
+            MissingNode::Identifier(identifier) => identifier.node_wrapper(),
+        }
+    }
+
+    fn set_node_wrapper(&self, wrapper: Rc<Node>) {
+        match self {
+            MissingNode::Identifier(identifier) => identifier.set_node_wrapper(wrapper),
+        }
+    }
+
     fn kind(&self) -> SyntaxKind {
         match self {
             MissingNode::Identifier(identifier) => identifier.kind(),

--- a/src/compiler/program.rs
+++ b/src/compiler/program.rs
@@ -235,7 +235,7 @@ fn find_source_file_worker(
     let file = helper_context.host.get_source_file(file_name);
 
     file.map(|file| {
-        let file: Rc<Node> = Rc::new(Rc::new(file).into());
+        let file: Rc<Node> = file.into();
         helper_context.processing_other_files.push(file.clone());
         file
     })

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -711,7 +711,9 @@ pub struct SourceFile {
 
 impl From<SourceFile> for Rc<Node> {
     fn from(source_file: SourceFile) -> Self {
-        Rc::new(Node::SourceFile(Rc::new(source_file)))
+        let rc = Rc::new(Node::SourceFile(Rc::new(source_file)));
+        rc.set_node_wrapper(rc.clone());
+        rc
     }
 }
 

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -107,6 +107,12 @@ pub enum Node {
 }
 
 impl Node {
+    pub fn wrap(self) -> Rc<Node> {
+        let rc = Rc::new(self);
+        rc.set_node_wrapper(rc.clone());
+        rc
+    }
+
     pub fn as_named_declaration(&self) -> &dyn NamedDeclarationInterface {
         match self {
             Node::VariableDeclaration(variable_declaration) => variable_declaration,

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -818,8 +818,8 @@ impl Symbol {
         self.value_declaration.borrow()
     }
 
-    pub fn set_value_declaration(&self, node: Rc<Node>) {
-        *self.value_declaration.borrow_mut() = Some(Rc::downgrade(&node));
+    pub fn set_value_declaration<TNode: NodeInterface>(&self, node: &TNode) {
+        *self.value_declaration.borrow_mut() = Some(Rc::downgrade(&node.node_wrapper()));
     }
 }
 

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -95,7 +95,7 @@ pub trait NodeInterface: ReadonlyTextRange {
 }
 
 #[derive(Debug)]
-#[ast_type]
+#[ast_type(impl_from = false)]
 pub enum Node {
     BaseNode(BaseNode),
     VariableDeclaration(VariableDeclaration),
@@ -312,7 +312,7 @@ impl From<Vec<Rc<Node>>> for NodeArrayOrVec {
 }
 
 #[derive(Debug)]
-#[ast_type]
+#[ast_type(ancestors = "Expression")]
 pub struct Identifier {
     _node: BaseNode,
     pub escaped_text: __String,
@@ -343,7 +343,7 @@ pub trait NamedDeclarationInterface: NodeInterface {
 }
 
 #[derive(Debug)]
-#[ast_type]
+#[ast_type(impl_from = false)]
 pub struct BaseNamedDeclaration {
     _node: BaseNode,
     name: Option<Rc<Node>>,
@@ -374,7 +374,7 @@ pub trait BindingLikeDeclarationInterface:
 }
 
 #[derive(Debug)]
-#[ast_type]
+#[ast_type(impl_from = false)]
 pub struct BaseBindingLikeDeclaration {
     _named_declaration: BaseNamedDeclaration,
     initializer: Option<Rc<Node>>,
@@ -420,7 +420,7 @@ pub trait VariableLikeDeclarationInterface:
 }
 
 #[derive(Debug)]
-#[ast_type]
+#[ast_type(impl_from = false)]
 pub struct BaseVariableLikeDeclaration {
     _binding_like_declaration: BaseBindingLikeDeclaration,
     type_: Option<Rc<Node>>,
@@ -520,12 +520,6 @@ impl HasTypeInterface for VariableDeclaration {
 
 impl VariableLikeDeclarationInterface for VariableDeclaration {}
 
-impl From<VariableDeclaration> for Node {
-    fn from(variable_declaration: VariableDeclaration) -> Self {
-        Node::VariableDeclaration(variable_declaration)
-    }
-}
-
 #[derive(Debug)]
 #[ast_type]
 pub struct VariableDeclarationList {
@@ -542,38 +536,14 @@ impl VariableDeclarationList {
     }
 }
 
-impl From<VariableDeclarationList> for Node {
-    fn from(variable_declaration_list: VariableDeclarationList) -> Self {
-        Node::VariableDeclarationList(variable_declaration_list)
-    }
-}
-
-impl From<Identifier> for Expression {
-    fn from(identifier: Identifier) -> Self {
-        Expression::Identifier(identifier)
-    }
-}
-
-impl From<Identifier> for Node {
-    fn from(identifier: Identifier) -> Self {
-        Node::Expression(Expression::Identifier(identifier))
-    }
-}
-
 #[derive(Debug)]
 #[ast_type]
 pub enum TypeNode {
     KeywordTypeNode(KeywordTypeNode),
 }
 
-impl From<TypeNode> for Node {
-    fn from(type_node: TypeNode) -> Self {
-        Node::TypeNode(type_node)
-    }
-}
-
 #[derive(Debug)]
-#[ast_type]
+#[ast_type(ancestors = "TypeNode")]
 pub struct KeywordTypeNode {
     _node: BaseNode,
 }
@@ -581,12 +551,6 @@ pub struct KeywordTypeNode {
 impl KeywordTypeNode {
     pub fn new(base_node: BaseNode) -> Self {
         Self { _node: base_node }
-    }
-}
-
-impl From<KeywordTypeNode> for TypeNode {
-    fn from(keyword_type_node: KeywordTypeNode) -> Self {
-        TypeNode::KeywordTypeNode(keyword_type_node)
     }
 }
 
@@ -606,12 +570,6 @@ pub enum Expression {
     LiteralLikeNode(LiteralLikeNode),
 }
 
-impl From<Expression> for Node {
-    fn from(expression: Expression) -> Self {
-        Node::Expression(expression)
-    }
-}
-
 impl From<BaseNode> for Expression {
     fn from(base_node: BaseNode) -> Self {
         Expression::TokenExpression(base_node)
@@ -619,7 +577,7 @@ impl From<BaseNode> for Expression {
 }
 
 #[derive(Debug)]
-#[ast_type]
+#[ast_type(ancestors = "Expression")]
 pub struct PrefixUnaryExpression {
     pub _node: BaseNode,
     pub operator: SyntaxKind,
@@ -631,19 +589,13 @@ impl PrefixUnaryExpression {
         Self {
             _node: base_node,
             operator,
-            operand: Rc::new(operand.into()),
+            operand: operand.into(),
         }
     }
 }
 
-impl From<PrefixUnaryExpression> for Expression {
-    fn from(prefix_unary_expression: PrefixUnaryExpression) -> Self {
-        Expression::PrefixUnaryExpression(prefix_unary_expression)
-    }
-}
-
 #[derive(Debug)]
-#[ast_type]
+#[ast_type(ancestors = "Expression")]
 pub struct BinaryExpression {
     pub _node: BaseNode,
     pub left: Rc<Node>,
@@ -660,21 +612,15 @@ impl BinaryExpression {
     ) -> Self {
         Self {
             _node: base_node,
-            left: Rc::new(left.into()),
+            left: left.into(),
             operator_token: Box::new(operator_token),
-            right: Rc::new(right.into()),
+            right: right.into(),
         }
     }
 }
 
-impl From<BinaryExpression> for Expression {
-    fn from(binary_expression: BinaryExpression) -> Self {
-        Expression::BinaryExpression(binary_expression)
-    }
-}
-
 #[derive(Debug)]
-#[ast_type]
+#[ast_type(impl_from = false)]
 pub struct BaseLiteralLikeNode {
     pub _node: BaseNode,
     pub text: String,
@@ -685,15 +631,9 @@ pub trait LiteralLikeNodeInterface {
 }
 
 #[derive(Debug)]
-#[ast_type]
+#[ast_type(ancestors = "Expression")]
 pub enum LiteralLikeNode {
     NumericLiteral(NumericLiteral),
-}
-
-impl From<LiteralLikeNode> for Expression {
-    fn from(literal_like_node: LiteralLikeNode) -> Self {
-        Expression::LiteralLikeNode(literal_like_node)
-    }
 }
 
 impl LiteralLikeNodeInterface for LiteralLikeNode {
@@ -712,15 +652,9 @@ bitflags! {
 }
 
 #[derive(Debug)]
-#[ast_type]
+#[ast_type(ancestors = "LiteralLikeNode, Expression")]
 pub struct NumericLiteral {
     pub _literal_like_node: BaseLiteralLikeNode,
-}
-
-impl From<NumericLiteral> for LiteralLikeNode {
-    fn from(numeric_literal: NumericLiteral) -> Self {
-        LiteralLikeNode::NumericLiteral(numeric_literal)
-    }
 }
 
 impl LiteralLikeNodeInterface for NumericLiteral {
@@ -737,26 +671,14 @@ pub enum Statement {
     ExpressionStatement(ExpressionStatement),
 }
 
-impl From<Statement> for Node {
-    fn from(statement: Statement) -> Self {
-        Node::Statement(statement)
-    }
-}
-
 #[derive(Debug)]
-#[ast_type]
+#[ast_type(ancestors = "Statement")]
 pub struct EmptyStatement {
     pub _node: BaseNode,
 }
 
-impl From<EmptyStatement> for Statement {
-    fn from(empty_statement: EmptyStatement) -> Self {
-        Statement::EmptyStatement(empty_statement)
-    }
-}
-
 #[derive(Debug)]
-#[ast_type]
+#[ast_type(ancestors = "Statement")]
 pub struct VariableStatement {
     _node: BaseNode,
     pub declaration_list: Rc</*VariableDeclarationList*/ Node>,
@@ -771,27 +693,15 @@ impl VariableStatement {
     }
 }
 
-impl From<VariableStatement> for Statement {
-    fn from(variable_statement: VariableStatement) -> Self {
-        Statement::VariableStatement(variable_statement)
-    }
-}
-
 #[derive(Debug)]
-#[ast_type]
+#[ast_type(ancestors = "Statement")]
 pub struct ExpressionStatement {
     pub _node: BaseNode,
     pub expression: Rc</*Expression*/ Node>,
 }
 
-impl From<ExpressionStatement> for Statement {
-    fn from(expression_statement: ExpressionStatement) -> Self {
-        Statement::ExpressionStatement(expression_statement)
-    }
-}
-
 #[derive(Debug)]
-#[ast_type]
+#[ast_type(impl_from = false)]
 pub struct SourceFile {
     pub _node: BaseNode,
     pub statements: NodeArray,
@@ -799,9 +709,9 @@ pub struct SourceFile {
     pub file_name: String,
 }
 
-impl From<Rc<SourceFile>> for Node {
-    fn from(source_file: Rc<SourceFile>) -> Self {
-        Node::SourceFile(source_file)
+impl From<SourceFile> for Rc<Node> {
+    fn from(source_file: SourceFile) -> Self {
+        Rc::new(Node::SourceFile(Rc::new(source_file)))
     }
 }
 

--- a/src/compiler/utilities.rs
+++ b/src/compiler/utilities.rs
@@ -85,8 +85,12 @@ fn get_error_span_for_node<TNode: NodeInterface>(
     create_text_span_from_bounds(pos, error_node.end())
 }
 
-pub fn get_effective_initializer(node: &Node, /*HasExpressionInitializer*/) -> Option<Rc<Node>> {
-    node.as_has_expression_initializer().initializer()
+pub fn get_effective_initializer<TNode: NodeInterface>(
+    node: &TNode, /*HasExpressionInitializer*/
+) -> Option<Rc<Node>> {
+    node.node_wrapper()
+        .as_has_expression_initializer()
+        .initializer()
 }
 
 pub fn set_value_declaration<TNode: NodeInterface>(symbol: &Symbol, node: &TNode) {
@@ -108,11 +112,11 @@ pub fn is_property_name_literal<TNode: NodeInterface>(node: &TNode) -> bool {
     }
 }
 
-pub fn get_escaped_text_of_identifier_or_literal(node: Rc<Node>) -> __String {
+pub fn get_escaped_text_of_identifier_or_literal<TNode: NodeInterface>(node: &TNode) -> __String {
     if is_member_name(&*node) {
-        node.as_member_name().escaped_text()
+        node.node_wrapper().as_member_name().escaped_text()
     } else {
-        escape_leading_underscores(node.as_literal_like_node().text())
+        escape_leading_underscores(node.node_wrapper().as_literal_like_node().text())
     }
 }
 

--- a/src/compiler/utilities.rs
+++ b/src/compiler/utilities.rs
@@ -89,7 +89,7 @@ pub fn get_effective_initializer(node: &Node, /*HasExpressionInitializer*/) -> O
     node.as_has_expression_initializer().initializer()
 }
 
-pub fn set_value_declaration(symbol: &Symbol, node: Rc<Node>) {
+pub fn set_value_declaration<TNode: NodeInterface>(symbol: &Symbol, node: &TNode) {
     {
         if !(symbol.maybe_value_declaration().is_none()) {
             return;

--- a/src/compiler/utilities_public.rs
+++ b/src/compiler/utilities_public.rs
@@ -23,11 +23,13 @@ pub fn escape_leading_underscores(identifier: &str) -> __String {
     )
 }
 
-fn get_non_assigned_name_of_declaration(declaration: Rc<Node>) -> Option<Rc<Node>> {
-    Some(declaration.as_named_declaration().name())
+fn get_non_assigned_name_of_declaration<TNode: NodeInterface>(
+    declaration: &TNode,
+) -> Option<Rc<Node>> {
+    Some(declaration.node_wrapper().as_named_declaration().name())
 }
 
-pub fn get_name_of_declaration(declaration: Rc<Node>) -> Option<Rc<Node>> {
+pub fn get_name_of_declaration<TNode: NodeInterface>(declaration: &TNode) -> Option<Rc<Node>> {
     get_non_assigned_name_of_declaration(declaration)
 }
 


### PR DESCRIPTION
The starting point here is basically option (c) from [this comment](https://github.com/helixbass/tsc-rust/pull/5#discussion_r771830998)

In this PR:
- add a `_node_wrapper: RefCell<Option<Weak<Node>>>` field to the shared `BaseNode` struct for holding a weak reference to the "wrapper" `Rc<Node>` to which it belongs, and add `node_wrapper()`/`set_node_wrapper()` to `NodeInterface` (so that effectively you can get a reference to your wrapping `Rc<Node>` from any AST node type/sub-variant)
- to wire up setting that node wrapper reference upon node creation, make the `#[ast_node]` macro generate an `impl From<[node type]> for Rc<Node>` (along with other existing boilerplate "wrapping" `impl From`'s) that encapsulates setting that node wrapper right after it's created (and then always use `.into()` for creating `Rc<Node>`'s during parsing)
- with that in place, stop passing around an additional `wrapper` argument when access to the `Rc<Node>` wrapper is needed, and make a lot of functions not take `Rc<Node>`'s that don't really care about its "`Rc`-ness" (since we can now obtain an `Rc<Node>` wrapper reference from anything implementing `NodeInterface`)

To test:
Things should still behave the same as of #7 (if you do the testing from #9 it'd basically do the same thing as described there but would panic in a slightly different way because of the in-progress work from `variable-declaration-type-checking` (see below))

Based on `variable-declaration-type-checking` (a branch I've been working on but haven't gotten up for review yet)