### PR TITLE
Generate other node interfaces

### DIFF
--- a/local-macros/src/lib.rs
+++ b/local-macros/src/lib.rs
@@ -37,16 +37,15 @@ impl AstTypeArgs {
 
     fn interfaces_vec(&self) -> Vec<String> {
         let mut vec = vec!["ReadonlyTextRange".to_string(), "NodeInterface".to_string()];
-        vec.append(&mut self.interfaces.as_ref().map_or_else(
-            || vec![],
-            |interfaces_str| {
-                interfaces_str
+        if let Some(interfaces_str) = self.interfaces.as_ref() {
+            vec.append(
+                &mut interfaces_str
                     .split(",")
                     .into_iter()
                     .map(|chunk| chunk.trim().to_string())
-                    .collect()
-            },
-        ));
+                    .collect(),
+            );
+        }
         vec
     }
 }

--- a/local-macros/src/lib.rs
+++ b/local-macros/src/lib.rs
@@ -190,68 +190,67 @@ fn get_enum_interface_impl(
     variant_names: &[&Ident],
     ast_type_name: &Ident,
 ) -> TokenStream2 {
-    let variant_names_ref = &variant_names;
     match interface_name {
         "NodeInterface" => {
             quote! {
                 impl crate::NodeInterface for #ast_type_name {
                     fn node_wrapper(&self) -> ::std::rc::Rc<crate::Node> {
                         match self {
-                            #(#ast_type_name::#variant_names_ref(nested) => nested.node_wrapper()),*
+                            #(#ast_type_name::#variant_names(nested) => nested.node_wrapper()),*
                         }
                     }
 
                     fn set_node_wrapper(&self, wrapper: ::std::rc::Rc<crate::Node>) {
                         match self {
-                            #(#ast_type_name::#variant_names_ref(nested) => nested.set_node_wrapper(wrapper)),*
+                            #(#ast_type_name::#variant_names(nested) => nested.set_node_wrapper(wrapper)),*
                         }
                     }
 
                     fn kind(&self) -> crate::SyntaxKind {
                         match self {
-                            #(#ast_type_name::#variant_names_ref(nested) => nested.kind()),*
+                            #(#ast_type_name::#variant_names(nested) => nested.kind()),*
                         }
                     }
 
                     fn parent(&self) -> ::std::rc::Rc<crate::Node> {
                         match self {
-                            #(#ast_type_name::#variant_names_ref(nested) => nested.parent()),*
+                            #(#ast_type_name::#variant_names(nested) => nested.parent()),*
                         }
                     }
 
                     fn set_parent(&self, parent: ::std::rc::Rc<crate::Node>) {
                         match self {
-                            #(#ast_type_name::#variant_names_ref(nested) => nested.set_parent(parent)),*
+                            #(#ast_type_name::#variant_names(nested) => nested.set_parent(parent)),*
                         }
                     }
 
                     fn maybe_symbol(&self) -> ::std::option::Option<::std::rc::Rc<crate::Symbol>> {
                         match self {
-                            #(#ast_type_name::#variant_names_ref(nested) => nested.maybe_symbol()),*
+                            #(#ast_type_name::#variant_names(nested) => nested.maybe_symbol()),*
                         }
                     }
 
                     fn symbol(&self) -> ::std::rc::Rc<crate::Symbol> {
                         match self {
-                            #(#ast_type_name::#variant_names_ref(nested) => nested.symbol()),*
+                            #(#ast_type_name::#variant_names(nested) => nested.symbol()),*
                         }
                     }
 
                     fn set_symbol(&self, symbol: ::std::rc::Rc<crate::Symbol>) {
                         match self {
-                            #(#ast_type_name::#variant_names_ref(nested) => nested.set_symbol(symbol)),*
+                            #(#ast_type_name::#variant_names(nested) => nested.set_symbol(symbol)),*
                         }
                     }
 
                     fn locals(&self) -> ::std::cell::RefMut<crate::SymbolTable> {
                         match self {
-                            #(#ast_type_name::#variant_names_ref(nested) => nested.locals()),*
+                            #(#ast_type_name::#variant_names(nested) => nested.locals()),*
                         }
                     }
 
                     fn set_locals(&self, locals: crate::SymbolTable) {
                         match self {
-                            #(#ast_type_name::#variant_names_ref(nested) => nested.set_locals(locals)),*
+                            #(#ast_type_name::#variant_names(nested) => nested.set_locals(locals)),*
                         }
                     }
                 }
@@ -262,25 +261,25 @@ fn get_enum_interface_impl(
                 impl crate::ReadonlyTextRange for #ast_type_name {
                     fn pos(&self) -> usize {
                         match self {
-                            #(#ast_type_name::#variant_names_ref(nested) => nested.pos()),*
+                            #(#ast_type_name::#variant_names(nested) => nested.pos()),*
                         }
                     }
 
                     fn set_pos(&self, pos: usize) {
                         match self {
-                            #(#ast_type_name::#variant_names_ref(nested) => nested.set_pos(pos)),*
+                            #(#ast_type_name::#variant_names(nested) => nested.set_pos(pos)),*
                         }
                     }
 
                     fn end(&self) -> usize {
                         match self {
-                            #(#ast_type_name::#variant_names_ref(nested) => nested.end()),*
+                            #(#ast_type_name::#variant_names(nested) => nested.end()),*
                         }
                     }
 
                     fn set_end(&self, end: usize) {
                         match self {
-                            #(#ast_type_name::#variant_names_ref(nested) => nested.set_end(end)),*
+                            #(#ast_type_name::#variant_names(nested) => nested.set_end(end)),*
                         }
                     }
                 }
@@ -291,7 +290,7 @@ fn get_enum_interface_impl(
                 impl crate::LiteralLikeNodeInterface for #ast_type_name {
                     fn text(&self) -> &str {
                         match self {
-                            #(#ast_type_name::#variant_names_ref(nested) => nested.text()),*
+                            #(#ast_type_name::#variant_names(nested) => nested.text()),*
                         }
                     }
                 }

--- a/local-macros/src/lib.rs
+++ b/local-macros/src/lib.rs
@@ -149,6 +149,154 @@ fn get_struct_interface_impl(
                 }
             }
         }
+        "BindingLikeDeclarationInterface" => {
+            quote! {
+                impl crate::BindingLikeDeclarationInterface for #ast_type_name {}
+            }
+        }
+        "HasTypeInterface" => {
+            quote! {
+                impl crate::HasTypeInterface for #ast_type_name {
+                    fn type_(&self) -> ::std::option::Option<::std::rc::Rc<crate::Node>> {
+                        self._variable_like_declaration.type_()
+                    }
+
+                    fn set_type(&mut self, type_: ::std::rc::Rc<crate::Node>) {
+                        self._variable_like_declaration.set_type(type_);
+                    }
+                }
+            }
+        }
+        "VariableLikeDeclarationInterface" => {
+            quote! {
+                impl crate::VariableLikeDeclarationInterface for #ast_type_name {}
+            }
+        }
+        "LiteralLikeNodeInterface" => {
+            quote! {
+                impl crate::LiteralLikeNodeInterface for #ast_type_name {
+                    fn text(&self) -> &str {
+                        self._literal_like_node.text()
+                    }
+                }
+            }
+        }
+        _ => panic!("Unknown interface: {}", interface_name),
+    }
+}
+
+fn get_enum_interface_impl(
+    interface_name: &str,
+    variant_names: &[&Ident],
+    ast_type_name: &Ident,
+) -> TokenStream2 {
+    let variant_names_ref = &variant_names;
+    match interface_name {
+        "NodeInterface" => {
+            quote! {
+                impl crate::NodeInterface for #ast_type_name {
+                    fn node_wrapper(&self) -> ::std::rc::Rc<crate::Node> {
+                        match self {
+                            #(#ast_type_name::#variant_names_ref(nested) => nested.node_wrapper()),*
+                        }
+                    }
+
+                    fn set_node_wrapper(&self, wrapper: ::std::rc::Rc<crate::Node>) {
+                        match self {
+                            #(#ast_type_name::#variant_names_ref(nested) => nested.set_node_wrapper(wrapper)),*
+                        }
+                    }
+
+                    fn kind(&self) -> crate::SyntaxKind {
+                        match self {
+                            #(#ast_type_name::#variant_names_ref(nested) => nested.kind()),*
+                        }
+                    }
+
+                    fn parent(&self) -> ::std::rc::Rc<crate::Node> {
+                        match self {
+                            #(#ast_type_name::#variant_names_ref(nested) => nested.parent()),*
+                        }
+                    }
+
+                    fn set_parent(&self, parent: ::std::rc::Rc<crate::Node>) {
+                        match self {
+                            #(#ast_type_name::#variant_names_ref(nested) => nested.set_parent(parent)),*
+                        }
+                    }
+
+                    fn maybe_symbol(&self) -> ::std::option::Option<::std::rc::Rc<crate::Symbol>> {
+                        match self {
+                            #(#ast_type_name::#variant_names_ref(nested) => nested.maybe_symbol()),*
+                        }
+                    }
+
+                    fn symbol(&self) -> ::std::rc::Rc<crate::Symbol> {
+                        match self {
+                            #(#ast_type_name::#variant_names_ref(nested) => nested.symbol()),*
+                        }
+                    }
+
+                    fn set_symbol(&self, symbol: ::std::rc::Rc<crate::Symbol>) {
+                        match self {
+                            #(#ast_type_name::#variant_names_ref(nested) => nested.set_symbol(symbol)),*
+                        }
+                    }
+
+                    fn locals(&self) -> ::std::cell::RefMut<crate::SymbolTable> {
+                        match self {
+                            #(#ast_type_name::#variant_names_ref(nested) => nested.locals()),*
+                        }
+                    }
+
+                    fn set_locals(&self, locals: crate::SymbolTable) {
+                        match self {
+                            #(#ast_type_name::#variant_names_ref(nested) => nested.set_locals(locals)),*
+                        }
+                    }
+                }
+            }
+        }
+        "ReadonlyTextRange" => {
+            quote! {
+                impl crate::ReadonlyTextRange for #ast_type_name {
+                    fn pos(&self) -> usize {
+                        match self {
+                            #(#ast_type_name::#variant_names_ref(nested) => nested.pos()),*
+                        }
+                    }
+
+                    fn set_pos(&self, pos: usize) {
+                        match self {
+                            #(#ast_type_name::#variant_names_ref(nested) => nested.set_pos(pos)),*
+                        }
+                    }
+
+                    fn end(&self) -> usize {
+                        match self {
+                            #(#ast_type_name::#variant_names_ref(nested) => nested.end()),*
+                        }
+                    }
+
+                    fn set_end(&self, end: usize) {
+                        match self {
+                            #(#ast_type_name::#variant_names_ref(nested) => nested.set_end(end)),*
+                        }
+                    }
+                }
+            }
+        }
+        "LiteralLikeNodeInterface" => {
+            quote! {
+                impl crate::LiteralLikeNodeInterface for #ast_type_name {
+                    fn text(&self) -> &str {
+                        match self {
+                            #(#ast_type_name::#variant_names_ref(nested) => nested.text()),*
+                        }
+                    }
+                }
+            }
+        }
         _ => panic!("Unknown interface: {}", interface_name),
     }
 }
@@ -197,110 +345,23 @@ pub fn ast_type(attr: TokenStream, item: TokenStream) -> TokenStream {
             interface_impls
         }
         Enum(DataEnum { variants, .. }) => {
-            let variant_names = variants.iter().map(|variant| &variant.ident);
-            let variant_names_2 = variant_names.clone();
-            let variant_names_3 = variant_names.clone();
-            let variant_names_4 = variant_names.clone();
-            let variant_names_5 = variant_names.clone();
-            let variant_names_6 = variant_names.clone();
-            let variant_names_7 = variant_names.clone();
-            let variant_names_8 = variant_names.clone();
-            let variant_names_9 = variant_names.clone();
-            let variant_names_10 = variant_names.clone();
-            let variant_names_11 = variant_names.clone();
-            let variant_names_12 = variant_names.clone();
-            let variant_names_13 = variant_names.clone();
-            let variant_names_14 = variant_names.clone();
+            let variant_names = variants
+                .iter()
+                .map(|variant| &variant.ident)
+                .collect::<Vec<_>>();
 
-            quote! {
-                impl crate::NodeInterface for #ast_type_name {
-                    fn node_wrapper(&self) -> ::std::rc::Rc<crate::Node> {
-                        match self {
-                            #(#ast_type_name::#variant_names_13(nested) => nested.node_wrapper()),*
-                        }
-                    }
+            let mut interface_impls: TokenStream2 = quote! {};
+            for interface in args.interfaces_vec() {
+                let interface_impl =
+                    get_enum_interface_impl(&interface, &variant_names, &ast_type_name);
+                interface_impls = quote! {
+                    #interface_impls
 
-                    fn set_node_wrapper(&self, wrapper: ::std::rc::Rc<crate::Node>) {
-                        match self {
-                            #(#ast_type_name::#variant_names_14(nested) => nested.set_node_wrapper(wrapper)),*
-                        }
-                    }
-
-                    fn kind(&self) -> crate::SyntaxKind {
-                        match self {
-                            #(#ast_type_name::#variant_names(nested) => nested.kind()),*
-                        }
-                    }
-
-                    fn parent(&self) -> ::std::rc::Rc<crate::Node> {
-                        match self {
-                            #(#ast_type_name::#variant_names_2(nested_2) => nested_2.parent()),*
-                        }
-                    }
-
-                    fn set_parent(&self, parent: ::std::rc::Rc<crate::Node>) {
-                        match self {
-                            #(#ast_type_name::#variant_names_3(nested_3) => nested_3.set_parent(parent)),*
-                        }
-                    }
-
-                    fn maybe_symbol(&self) -> ::std::option::Option<::std::rc::Rc<crate::Symbol>> {
-                        match self {
-                            #(#ast_type_name::#variant_names_12(nested_12) => nested_12.maybe_symbol()),*
-                        }
-                    }
-
-                    fn symbol(&self) -> ::std::rc::Rc<crate::Symbol> {
-                        match self {
-                            #(#ast_type_name::#variant_names_4(nested_4) => nested_4.symbol()),*
-                        }
-                    }
-
-                    fn set_symbol(&self, symbol: ::std::rc::Rc<crate::Symbol>) {
-                        match self {
-                            #(#ast_type_name::#variant_names_5(nested_5) => nested_5.set_symbol(symbol)),*
-                        }
-                    }
-
-                    fn locals(&self) -> ::std::cell::RefMut<crate::SymbolTable> {
-                        match self {
-                            #(#ast_type_name::#variant_names_6(nested_6) => nested_6.locals()),*
-                        }
-                    }
-
-                    fn set_locals(&self, locals: crate::SymbolTable) {
-                        match self {
-                            #(#ast_type_name::#variant_names_7(nested_7) => nested_7.set_locals(locals)),*
-                        }
-                    }
-                }
-
-                impl crate::ReadonlyTextRange for #ast_type_name {
-                    fn pos(&self) -> usize {
-                        match self {
-                            #(#ast_type_name::#variant_names_8(nested_8) => nested_8.pos()),*
-                        }
-                    }
-
-                    fn set_pos(&self, pos: usize) {
-                        match self {
-                            #(#ast_type_name::#variant_names_9(nested_9) => nested_9.set_pos(pos)),*
-                        }
-                    }
-
-                    fn end(&self) -> usize {
-                        match self {
-                            #(#ast_type_name::#variant_names_10(nested_10) => nested_10.end()),*
-                        }
-                    }
-
-                    fn set_end(&self, end: usize) {
-                        match self {
-                            #(#ast_type_name::#variant_names_11(nested_11) => nested_11.set_end(end)),*
-                        }
-                    }
-                }
+                    #interface_impl
+                };
             }
+
+            interface_impls
         }
         _ => panic!("Expected struct or enum"),
     };

--- a/local-macros/src/lib.rs
+++ b/local-macros/src/lib.rs
@@ -136,6 +136,19 @@ fn get_struct_interface_impl(
                 }
             }
         }
+        "HasExpressionInitializerInterface" => {
+            quote! {
+                impl crate::HasExpressionInitializerInterface for #ast_type_name {
+                    fn initializer(&self) -> ::std::option::Option<::std::rc::Rc<crate::Node>> {
+                        self.#first_field_name.initializer()
+                    }
+
+                    fn set_initializer(&mut self, initializer: ::std::rc::Rc<crate::Node>) {
+                        self.#first_field_name.set_initializer(initializer);
+                    }
+                }
+            }
+        }
         _ => panic!("Unknown interface: {}", interface_name),
     }
 }

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -416,7 +416,10 @@ pub trait VariableLikeDeclarationInterface:
 }
 
 #[derive(Debug)]
-#[ast_type(impl_from = false)]
+#[ast_type(
+    impl_from = false,
+    interfaces = "NamedDeclarationInterface, HasExpressionInitializerInterface"
+)]
 pub struct BaseVariableLikeDeclaration {
     _binding_like_declaration: BaseBindingLikeDeclaration,
     type_: Option<Rc<Node>>,
@@ -431,26 +434,6 @@ impl BaseVariableLikeDeclaration {
             _binding_like_declaration: base_binding_like_declaration,
             type_,
         }
-    }
-}
-
-impl NamedDeclarationInterface for BaseVariableLikeDeclaration {
-    fn name(&self) -> Rc<Node> {
-        self._binding_like_declaration.name()
-    }
-
-    fn set_name(&mut self, name: Rc<Node>) {
-        self._binding_like_declaration.set_name(name);
-    }
-}
-
-impl HasExpressionInitializerInterface for BaseVariableLikeDeclaration {
-    fn initializer(&self) -> Option<Rc<Node>> {
-        self._binding_like_declaration.initializer()
-    }
-
-    fn set_initializer(&mut self, initializer: Rc<Node>) {
-        self._binding_like_declaration.set_initializer(initializer);
     }
 }
 
@@ -469,7 +452,7 @@ impl HasTypeInterface for BaseVariableLikeDeclaration {
 impl VariableLikeDeclarationInterface for BaseVariableLikeDeclaration {}
 
 #[derive(Debug)]
-#[ast_type]
+#[ast_type(interfaces = "NamedDeclarationInterface, HasExpressionInitializerInterface")]
 pub struct VariableDeclaration {
     _variable_like_declaration: BaseVariableLikeDeclaration,
 }
@@ -479,26 +462,6 @@ impl VariableDeclaration {
         Self {
             _variable_like_declaration: base_variable_like_declaration,
         }
-    }
-}
-
-impl NamedDeclarationInterface for VariableDeclaration {
-    fn name(&self) -> Rc<Node> {
-        self._variable_like_declaration.name()
-    }
-
-    fn set_name(&mut self, name: Rc<Node>) {
-        self._variable_like_declaration.set_name(name);
-    }
-}
-
-impl HasExpressionInitializerInterface for VariableDeclaration {
-    fn initializer(&self) -> Option<Rc<Node>> {
-        self._variable_like_declaration.initializer()
-    }
-
-    fn set_initializer(&mut self, initializer: Rc<Node>) {
-        self._variable_like_declaration.set_initializer(initializer);
     }
 }
 

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -418,7 +418,7 @@ pub trait VariableLikeDeclarationInterface:
 #[derive(Debug)]
 #[ast_type(
     impl_from = false,
-    interfaces = "NamedDeclarationInterface, HasExpressionInitializerInterface"
+    interfaces = "NamedDeclarationInterface, HasExpressionInitializerInterface, BindingLikeDeclarationInterface"
 )]
 pub struct BaseVariableLikeDeclaration {
     _binding_like_declaration: BaseBindingLikeDeclaration,
@@ -437,8 +437,6 @@ impl BaseVariableLikeDeclaration {
     }
 }
 
-impl BindingLikeDeclarationInterface for BaseVariableLikeDeclaration {}
-
 impl HasTypeInterface for BaseVariableLikeDeclaration {
     fn type_(&self) -> Option<Rc<Node>> {
         self.type_.as_ref().map(Clone::clone)
@@ -452,7 +450,9 @@ impl HasTypeInterface for BaseVariableLikeDeclaration {
 impl VariableLikeDeclarationInterface for BaseVariableLikeDeclaration {}
 
 #[derive(Debug)]
-#[ast_type(interfaces = "NamedDeclarationInterface, HasExpressionInitializerInterface")]
+#[ast_type(
+    interfaces = "NamedDeclarationInterface, HasExpressionInitializerInterface, BindingLikeDeclarationInterface, HasTypeInterface, VariableLikeDeclarationInterface"
+)]
 pub struct VariableDeclaration {
     _variable_like_declaration: BaseVariableLikeDeclaration,
 }
@@ -464,20 +464,6 @@ impl VariableDeclaration {
         }
     }
 }
-
-impl BindingLikeDeclarationInterface for VariableDeclaration {}
-
-impl HasTypeInterface for VariableDeclaration {
-    fn type_(&self) -> Option<Rc<Node>> {
-        self._variable_like_declaration.type_()
-    }
-
-    fn set_type(&mut self, type_: Rc<Node>) {
-        self._variable_like_declaration.set_type(type_);
-    }
-}
-
-impl VariableLikeDeclarationInterface for VariableDeclaration {}
 
 #[derive(Debug)]
 #[ast_type]
@@ -585,22 +571,20 @@ pub struct BaseLiteralLikeNode {
     pub text: String,
 }
 
+impl LiteralLikeNodeInterface for BaseLiteralLikeNode {
+    fn text(&self) -> &str {
+        &self.text
+    }
+}
+
 pub trait LiteralLikeNodeInterface {
     fn text(&self) -> &str;
 }
 
 #[derive(Debug)]
-#[ast_type(ancestors = "Expression")]
+#[ast_type(ancestors = "Expression", interfaces = "LiteralLikeNodeInterface")]
 pub enum LiteralLikeNode {
     NumericLiteral(NumericLiteral),
-}
-
-impl LiteralLikeNodeInterface for LiteralLikeNode {
-    fn text(&self) -> &str {
-        match self {
-            LiteralLikeNode::NumericLiteral(numeric_literal) => numeric_literal.text(),
-        }
-    }
 }
 
 bitflags! {
@@ -611,15 +595,12 @@ bitflags! {
 }
 
 #[derive(Debug)]
-#[ast_type(ancestors = "LiteralLikeNode, Expression")]
+#[ast_type(
+    ancestors = "LiteralLikeNode, Expression",
+    interfaces = "LiteralLikeNodeInterface"
+)]
 pub struct NumericLiteral {
     pub _literal_like_node: BaseLiteralLikeNode,
-}
-
-impl LiteralLikeNodeInterface for NumericLiteral {
-    fn text(&self) -> &str {
-        &self._literal_like_node.text
-    }
 }
 
 #[derive(Debug)]

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -380,7 +380,7 @@ pub trait BindingLikeDeclarationInterface:
 }
 
 #[derive(Debug)]
-#[ast_type(impl_from = false)]
+#[ast_type(impl_from = false, interfaces = "NamedDeclarationInterface")]
 pub struct BaseBindingLikeDeclaration {
     _named_declaration: BaseNamedDeclaration,
     initializer: Option<Rc<Node>>,
@@ -395,16 +395,6 @@ impl BaseBindingLikeDeclaration {
             _named_declaration: base_named_declaration,
             initializer,
         }
-    }
-}
-
-impl NamedDeclarationInterface for BaseBindingLikeDeclaration {
-    fn name(&self) -> Rc<Node> {
-        self._named_declaration.name()
-    }
-
-    fn set_name(&mut self, name: Rc<Node>) {
-        self._named_declaration.set_name(name);
     }
 }
 


### PR DESCRIPTION
In this PR:
- generate other node interfaces via `#[ast_node(interfaces = "...")]`

To test:
Behavior should still be the same as of previous PR

Based on `get-node-wrapper`