### PR TITLE
Parse + bind array literal declaration

### DIFF
--- a/src/compiler/binder.rs
+++ b/src/compiler/binder.rs
@@ -227,34 +227,26 @@ impl BinderType {
 
     fn bind_children(&self, node: &Node) {
         match node {
-            Node::Statement(statement) => match statement {
-                Statement::ExpressionStatement(expression_statement) => {
-                    self.bind_expression_statement(expression_statement);
-                }
-                _ => {
-                    self.bind_each_child(node);
-                }
-            },
-            Node::Expression(expression) => match expression {
-                Expression::PrefixUnaryExpression(_) => {
-                    self.bind_prefix_unary_expression_flow(node);
-                }
-                Expression::BinaryExpression(_) => unimplemented!(),
-                _ => {
-                    self.bind_each_child(node);
-                }
-            },
-            Node::SourceFile(source_file) => {
-                self.bind_each_functions_first(&source_file.statements);
+            Node::Statement(Statement::ExpressionStatement(expression_statement)) => {
+                self.bind_expression_statement(expression_statement);
             }
-            Node::VariableDeclarationList(_) => {
-                self.bind_each_child(node);
+            Node::Expression(Expression::PrefixUnaryExpression(_)) => {
+                self.bind_prefix_unary_expression_flow(node);
             }
+            Node::Expression(Expression::BinaryExpression(_)) => unimplemented!(),
             Node::VariableDeclaration(_) => {
                 self.bind_variable_declaration_flow(node);
             }
-            Node::BaseNode(_) => panic!("Didn't expect to bind BaseNode?"),
-            _ => unimplemented!(),
+            Node::SourceFile(source_file) => {
+                self.bind_each_functions_first(&source_file.statements);
+            }
+            Node::Expression(Expression::ArrayLiteralExpression(_)) => {
+                // self.set_in_assignment_pattern(save_in_assignment_pattern);
+                self.bind_each_child(node);
+            }
+            _ => {
+                self.bind_each_child(node);
+            }
         };
     }
 

--- a/src/compiler/factory/node_factory.rs
+++ b/src/compiler/factory/node_factory.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 
 use crate::{
-    create_base_node_factory, escape_leading_underscores, ArrayLiteralExpression,
+    create_base_node_factory, escape_leading_underscores, ArrayLiteralExpression, ArrayTypeNode,
     BaseBindingLikeDeclaration, BaseLiteralLikeNode, BaseNamedDeclaration, BaseNode,
     BaseNodeFactory, BaseNodeFactoryConcrete, BaseVariableLikeDeclaration, BinaryExpression,
     EmptyStatement, Expression, ExpressionStatement, Identifier, LiteralTypeNode, Node, NodeArray,
@@ -150,6 +150,16 @@ impl NodeFactory {
         token: SyntaxKind,
     ) -> BaseNode {
         self.create_token(base_factory, token)
+    }
+
+    pub fn create_array_type_node<TBaseNodeFactory: BaseNodeFactory>(
+        &self,
+        base_factory: &TBaseNodeFactory,
+        element_type: Rc<Node>,
+    ) -> ArrayTypeNode {
+        let node = self.create_base_node(base_factory, SyntaxKind::ArrayType);
+        let node = ArrayTypeNode::new(node, element_type);
+        node
     }
 
     pub fn create_literal_type_node<TBaseNodeFactory: BaseNodeFactory, TNode: NodeInterface>(

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -652,7 +652,6 @@ impl ParserType {
                 if self.is_list_terminator(kind) {
                     break;
                 }
-                println!("kind: {:?}", kind);
 
                 unimplemented!()
             }
@@ -660,6 +659,8 @@ impl ParserType {
             if self.is_list_terminator(kind) {
                 break;
             }
+
+            unimplemented!()
         }
 
         self.set_parsing_context(save_parsing_context);
@@ -767,6 +768,7 @@ impl ParserType {
                             None,
                         );
                     }
+                    break;
                 }
                 _ => {
                     return type_;
@@ -819,6 +821,8 @@ impl ParserType {
 
     fn is_start_of_left_hand_side_expression(&self) -> bool {
         match self.token() {
+            SyntaxKind::TrueKeyword => true,
+            SyntaxKind::FalseKeyword => true,
             SyntaxKind::NumericLiteral => true,
             SyntaxKind::OpenBracketToken => true,
             _ => self.is_identifier(),

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -652,6 +652,7 @@ impl ParserType {
                 if self.is_list_terminator(kind) {
                     break;
                 }
+                println!("kind: {:?}", kind);
 
                 unimplemented!()
             }
@@ -735,9 +736,43 @@ impl ParserType {
         }
     }
 
+    fn is_start_of_type(&self) -> bool {
+        match self.token() {
+            _ => self.is_identifier(),
+        }
+    }
+
     fn parse_postfix_type_or_higher(&mut self) -> TypeNode {
         let pos = self.get_node_pos();
-        let type_ = self.parse_non_array_type();
+        let mut type_ = self.parse_non_array_type();
+        while !self.scanner().has_preceding_line_break() {
+            match self.token() {
+                SyntaxKind::ExclamationToken => {
+                    unimplemented!()
+                }
+                SyntaxKind::QuestionToken => {
+                    unimplemented!()
+                }
+                SyntaxKind::OpenBracketToken => {
+                    self.parse_expected(SyntaxKind::OpenBracketToken, None);
+                    if self.is_start_of_type() {
+                        unimplemented!()
+                    } else {
+                        self.parse_expected(SyntaxKind::CloseBracketToken, None);
+                        type_ = self.finish_node(
+                            self.factory
+                                .create_array_type_node(self, type_.into())
+                                .into(),
+                            pos,
+                            None,
+                        );
+                    }
+                }
+                _ => {
+                    return type_;
+                }
+            }
+        }
         type_
     }
 

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -59,24 +59,21 @@ pub fn for_each_child<TNodeCallback: FnMut(Option<Rc<Node>>), TNodesCallback: Fn
             visit_node(&mut cb_node, variable_declaration.type_());
             return visit_node(&mut cb_node, variable_declaration.initializer());
         }
-        Node::Expression(expression) => match expression {
-            Expression::ArrayLiteralExpression(array_literal_expression) => {
-                return visit_nodes(&mut cb_node, cb_nodes, &array_literal_expression.elements);
-            }
-            Expression::PrefixUnaryExpression(prefix_unary_expression) => {
-                return visit_node(&mut cb_node, Some(prefix_unary_expression.operand.clone()));
-            }
-            _ => unimplemented!(),
-        },
-        Node::Statement(statement) => match statement {
-            Statement::VariableStatement(variable_statement) => {
-                return visit_node(
-                    &mut cb_node,
-                    Some(variable_statement.declaration_list.clone()),
-                );
-            }
-            _ => unimplemented!(),
-        },
+        Node::TypeNode(TypeNode::ArrayTypeNode(array_type)) => {
+            return visit_node(&mut cb_node, Some(array_type.element_type.clone()));
+        }
+        Node::Expression(Expression::ArrayLiteralExpression(array_literal_expression)) => {
+            return visit_nodes(&mut cb_node, cb_nodes, &array_literal_expression.elements);
+        }
+        Node::Expression(Expression::PrefixUnaryExpression(prefix_unary_expression)) => {
+            return visit_node(&mut cb_node, Some(prefix_unary_expression.operand.clone()));
+        }
+        Node::Statement(Statement::VariableStatement(variable_statement)) => {
+            return visit_node(
+                &mut cb_node,
+                Some(variable_statement.declaration_list.clone()),
+            );
+        }
         Node::VariableDeclarationList(variable_declaration_list) => {
             return visit_nodes(cb_node, cb_nodes, &variable_declaration_list.declarations);
         }

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -763,6 +763,7 @@ pub struct TypeChecker {
     pub regular_false_type: Option<Rc<Type>>,
     pub boolean_type: Option<Rc<Type>>,
     pub number_or_big_int_type: Option<Rc<Type>>,
+    pub global_array_type: Option<Rc<Type /*GenericType*/>>,
     pub diagnostics: RefCell<DiagnosticCollection>,
     pub assignable_relation: HashMap<String, RelationComparisonResult>,
 }
@@ -780,17 +781,22 @@ bitflags! {
         const EnumMember = 1 << 3;
         const Function = 1 << 4;
         const Class = 1 << 5;
+        const Interface = 1 << 6;
         const ConstEnum = 1 << 7;
         const RegularEnum = 1 << 8;
         const ValueModule = 1 << 9;
+        const TypeLiteral = 1 << 11;
         const ObjectLiteral = 1 << 12;
         const Method = 1 << 13;
         const GetAccessor = 1 << 15;
         const SetAccessor = 1 << 16;
+        const TypeParameter = 1 << 18;
+        const TypeAlias = 1 << 19;
 
         const Enum = Self::RegularEnum.bits | Self::ConstEnum.bits;
         const Variable = Self::FunctionScopedVariable.bits | Self::BlockScopedVariable.bits;
         const Value = Self::Variable.bits | Self::Property.bits | Self::EnumMember.bits | Self::ObjectLiteral.bits | Self::Function.bits | Self::Class.bits | Self::Enum.bits | Self::ValueModule.bits | Self::Method.bits | Self::GetAccessor.bits | Self::SetAccessor.bits;
+        const Type = Self::Class.bits | Self::Interface.bits | Self::Enum.bits | Self::EnumMember.bits | Self::TypeLiteral.bits | Self::TypeParameter.bits | Self::TypeAlias.bits;
     }
 }
 

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -41,6 +41,8 @@ pub enum SyntaxKind {
     CommaToken,
     AsteriskToken,
     PlusPlusToken,
+    ExclamationToken,
+    QuestionToken,
     ColonToken,
     EqualsToken,
     Identifier,
@@ -52,6 +54,7 @@ pub enum SyntaxKind {
     WithKeyword,
     NumberKeyword,
     OfKeyword,
+    ArrayType,
     LiteralType,
     ObjectBindingPattern,
     ArrayBindingPattern,
@@ -505,6 +508,7 @@ impl VariableDeclarationList {
 pub enum TypeNode {
     KeywordTypeNode(KeywordTypeNode),
     LiteralTypeNode(LiteralTypeNode),
+    ArrayTypeNode(ArrayTypeNode),
 }
 
 #[derive(Debug)]
@@ -522,6 +526,22 @@ impl KeywordTypeNode {
 impl From<BaseNode> for KeywordTypeNode {
     fn from(base_node: BaseNode) -> Self {
         KeywordTypeNode::new(base_node)
+    }
+}
+
+#[derive(Debug)]
+#[ast_type(ancestors = "TypeNode")]
+pub struct ArrayTypeNode {
+    _node: BaseNode,
+    element_type: Rc<Node /*TypeNode*/>,
+}
+
+impl ArrayTypeNode {
+    pub fn new(base_node: BaseNode, element_type: Rc<Node>) -> Self {
+        Self {
+            _node: base_node,
+            element_type,
+        }
     }
 }
 

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -533,7 +533,7 @@ impl From<BaseNode> for KeywordTypeNode {
 #[ast_type(ancestors = "TypeNode")]
 pub struct ArrayTypeNode {
     _node: BaseNode,
-    element_type: Rc<Node /*TypeNode*/>,
+    pub element_type: Rc<Node /*TypeNode*/>,
 }
 
 impl ArrayTypeNode {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ pub use compiler::program::create_program;
 pub use compiler::scanner::{create_scanner, token_to_string, Scanner};
 pub use compiler::sys::{get_sys, System};
 pub use compiler::types::{
-    ArrayLiteralExpression, BaseBindingLikeDeclaration, BaseDiagnostic,
+    ArrayLiteralExpression, ArrayTypeNode, BaseBindingLikeDeclaration, BaseDiagnostic,
     BaseDiagnosticRelatedInformation, BaseIntrinsicType, BaseLiteralLikeNode, BaseLiteralType,
     BaseNamedDeclaration, BaseNode, BaseType, BaseUnionOrIntersectionType,
     BaseVariableLikeDeclaration, BinaryExpression, BindingLikeDeclarationInterface, CharacterCodes,


### PR DESCRIPTION
In this PR:
- parse and bind an array literal declaration like `const a: number[] = [1, 2, true];`

I started working on the type-checking for this but ran into the fact that the definition of the "global" `Array<>` type (which is needed for resolving the type of `number[]` during type-checking) comes from one of the Typescript lib `.d.ts` files so decided to punt on that for now

To test:
If you run `cargo run tmp.tsx` against a source file containing eg `const a: number[] = [1, 2, true];` it should debug-log a `SourceFile` where the `type_` of the `VariableDeclaration` is an `ArrayTypeNode` whose `element_type` is a `NumberKeyword` `KeywordTypeNode`, should debug-log a `post-binding:` `SourceFile` with initialized `parent` references and then panic during type-checking

Based on `parse-array-literal`