### PR TITLE
Parse + bind interface declaration

### DIFF
--- a/local-macros/src/lib.rs
+++ b/local-macros/src/lib.rs
@@ -296,6 +296,23 @@ fn get_enum_interface_impl(
                 }
             }
         }
+        "NamedDeclarationInterface" => {
+            quote! {
+                impl crate::NamedDeclarationInterface for #ast_type_name {
+                    fn name(&self) -> ::std::rc::Rc<crate::Node> {
+                        match self {
+                            #(#ast_type_name::#variant_names(nested) => nested.name()),*
+                        }
+                    }
+
+                    fn set_name(&mut self, name: ::std::rc::Rc<crate::Node>) {
+                        match self {
+                            #(#ast_type_name::#variant_names(nested) => nested.set_name(name)),*
+                        }
+                    }
+                }
+            }
+        }
         _ => panic!("Unknown interface: {}", interface_name),
     }
 }

--- a/local-macros/src/lib.rs
+++ b/local-macros/src/lib.rs
@@ -92,6 +92,10 @@ fn get_struct_interface_impl(
                         self.#first_field_name.set_symbol(symbol);
                     }
 
+                    fn maybe_locals(&self) -> ::std::cell::RefMut<::std::option::Option<crate::SymbolTable>> {
+                        self.#first_field_name.maybe_locals()
+                    }
+
                     fn locals(&self) -> ::std::cell::RefMut<crate::SymbolTable> {
                         self.#first_field_name.locals()
                     }
@@ -239,6 +243,12 @@ fn get_enum_interface_impl(
                     fn set_symbol(&self, symbol: ::std::rc::Rc<crate::Symbol>) {
                         match self {
                             #(#ast_type_name::#variant_names(nested) => nested.set_symbol(symbol)),*
+                        }
+                    }
+
+                    fn maybe_locals(&self) -> ::std::cell::RefMut<::std::option::Option<crate::SymbolTable>> {
+                        match self {
+                            #(#ast_type_name::#variant_names(nested) => nested.maybe_locals()),*
                         }
                     }
 

--- a/src/compiler/binder.rs
+++ b/src/compiler/binder.rs
@@ -153,6 +153,18 @@ impl BinderType {
         );
         symbol.set_declarations(declarations);
 
+        if symbol_flags.intersects(
+            SymbolFlags::Class
+                | SymbolFlags::Interface
+                | SymbolFlags::TypeLiteral
+                | SymbolFlags::ObjectLiteral,
+        ) {
+            let mut members = symbol.maybe_members();
+            if members.is_none() {
+                *members = Some(create_symbol_table());
+            }
+        }
+
         if symbol_flags.intersects(SymbolFlags::Value) {
             set_value_declaration(&*symbol, node);
         }

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -55,6 +55,10 @@ pub fn for_each_child<TNodeCallback: FnMut(Option<Rc<Node>>), TNodesCallback: Fn
         return;
     }
     match node {
+        Node::TypeElement(TypeElement::PropertySignature(property_signature)) => {
+            visit_node(&mut cb_node, Some(property_signature.name()));
+            visit_node(&mut cb_node, property_signature.type_())
+        }
         Node::VariableDeclaration(variable_declaration) => {
             visit_node(&mut cb_node, Some(variable_declaration.name()));
             visit_node(&mut cb_node, variable_declaration.type_());
@@ -772,7 +776,7 @@ impl ParserType {
             let type_ = self.parse_type_annotation();
             node = self
                 .factory
-                .create_property_signature(self, name.into(), type_.map(Into::into))
+                .create_property_signature(self, name.wrap(), type_.map(Into::into))
                 .into();
         }
         self.parse_type_member_semicolon();

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -58,25 +58,27 @@ pub fn for_each_child<TNodeCallback: FnMut(Option<Rc<Node>>), TNodesCallback: Fn
         Node::VariableDeclaration(variable_declaration) => {
             visit_node(&mut cb_node, Some(variable_declaration.name()));
             visit_node(&mut cb_node, variable_declaration.type_());
-            return visit_node(&mut cb_node, variable_declaration.initializer());
+            visit_node(&mut cb_node, variable_declaration.initializer())
         }
         Node::TypeNode(TypeNode::ArrayTypeNode(array_type)) => {
-            return visit_node(&mut cb_node, Some(array_type.element_type.clone()));
+            visit_node(&mut cb_node, Some(array_type.element_type.clone()))
         }
         Node::Expression(Expression::ArrayLiteralExpression(array_literal_expression)) => {
-            return visit_nodes(&mut cb_node, cb_nodes, &array_literal_expression.elements);
+            visit_nodes(&mut cb_node, cb_nodes, &array_literal_expression.elements)
         }
         Node::Expression(Expression::PrefixUnaryExpression(prefix_unary_expression)) => {
-            return visit_node(&mut cb_node, Some(prefix_unary_expression.operand.clone()));
+            visit_node(&mut cb_node, Some(prefix_unary_expression.operand.clone()))
         }
-        Node::Statement(Statement::VariableStatement(variable_statement)) => {
-            return visit_node(
-                &mut cb_node,
-                Some(variable_statement.declaration_list.clone()),
-            );
-        }
+        Node::Statement(Statement::VariableStatement(variable_statement)) => visit_node(
+            &mut cb_node,
+            Some(variable_statement.declaration_list.clone()),
+        ),
         Node::VariableDeclarationList(variable_declaration_list) => {
-            return visit_nodes(cb_node, cb_nodes, &variable_declaration_list.declarations);
+            visit_nodes(cb_node, cb_nodes, &variable_declaration_list.declarations)
+        }
+        Node::Statement(Statement::InterfaceDeclaration(interface_declaration)) => {
+            visit_node(&mut cb_node, Some(interface_declaration.name()));
+            visit_nodes(cb_node, cb_nodes, &interface_declaration.members)
         }
         _ => unimplemented!(),
     }
@@ -136,6 +138,12 @@ impl NodeInterface for MissingNode {
     fn set_symbol(&self, symbol: Rc<Symbol>) {
         match self {
             MissingNode::Identifier(identifier) => identifier.set_symbol(symbol),
+        }
+    }
+
+    fn maybe_locals(&self) -> RefMut<Option<SymbolTable>> {
+        match self {
+            MissingNode::Identifier(identifier) => identifier.maybe_locals(),
         }
     }
 

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -649,6 +649,7 @@ impl ParserType {
             return true;
         }
         match kind {
+            ParsingContext::TypeMembers => self.token() == SyntaxKind::CloseBraceToken,
             ParsingContext::VariableDeclarations => self.is_variable_declarator_list_terminator(),
             ParsingContext::ArrayLiteralMembers => self.token() == SyntaxKind::CloseBracketToken,
             _ => false,
@@ -713,6 +714,8 @@ impl ParserType {
 
                 continue;
             }
+
+            unimplemented!()
         }
 
         self.create_node_array(list)
@@ -796,6 +799,7 @@ impl ParserType {
         let members: NodeArray;
         if self.parse_expected(SyntaxKind::OpenBraceToken, None) {
             members = self.parse_list(ParsingContext::TypeMembers, ParserType::parse_type_member);
+            self.parse_expected(SyntaxKind::CloseBraceToken, None);
         } else {
             unimplemented!()
         }

--- a/src/compiler/scanner.rs
+++ b/src/compiler/scanner.rs
@@ -7,11 +7,16 @@ use std::iter::FromIterator;
 
 use crate::{CharacterCodes, SyntaxKind, TokenFlags};
 
+pub fn token_is_identifier_or_keyword(token: SyntaxKind) -> bool {
+    token >= SyntaxKind::Identifier
+}
+
 lazy_static! {
     static ref text_to_keyword_obj: HashMap<String, SyntaxKind> =
         HashMap::from_iter(IntoIter::new([
             ("const".to_string(), SyntaxKind::ConstKeyword),
             ("false".to_string(), SyntaxKind::FalseKeyword),
+            ("interface".to_string(), SyntaxKind::InterfaceKeyword),
             ("number".to_string(), SyntaxKind::NumberKeyword),
             ("true".to_string(), SyntaxKind::TrueKeyword),
         ]));

--- a/src/compiler/scanner.rs
+++ b/src/compiler/scanner.rs
@@ -210,6 +210,14 @@ impl Scanner {
                     self.set_pos(self.pos() + 1);
                     return self.set_token(SyntaxKind::CloseBracketToken);
                 }
+                CharacterCodes::open_brace => {
+                    self.set_pos(self.pos() + 1);
+                    return self.set_token(SyntaxKind::OpenBraceToken);
+                }
+                CharacterCodes::close_brace => {
+                    self.set_pos(self.pos() + 1);
+                    return self.set_token(SyntaxKind::CloseBraceToken);
+                }
                 _ch => {
                     let identifier_kind = self.scan_identifier(ch);
                     if let Some(identifier_kind) = identifier_kind {

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -141,6 +141,7 @@ impl Node {
             Node::Statement(Statement::InterfaceDeclaration(interface_declaration)) => {
                 interface_declaration
             }
+            Node::TypeElement(type_element) => type_element,
             _ => panic!("Expected named declaration"),
         }
     }

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -907,6 +907,7 @@ pub struct Symbol {
     pub escaped_name: __String,
     declarations: RefCell<Option<Vec<Rc<Node /*Declaration*/>>>>, // TODO: should be Vec<Weak<Node>> instead of Vec<Rc<Node>>?
     value_declaration: RefCell<Option<Weak<Node>>>,
+    members: RefCell<Option<SymbolTable>>,
 }
 
 impl Symbol {
@@ -916,6 +917,7 @@ impl Symbol {
             escaped_name: name,
             declarations: RefCell::new(None),
             value_declaration: RefCell::new(None),
+            members: RefCell::new(None),
         }
     }
 
@@ -941,6 +943,10 @@ impl Symbol {
 
     pub fn set_value_declaration<TNode: NodeInterface>(&self, node: &TNode) {
         *self.value_declaration.borrow_mut() = Some(Rc::downgrade(&node.node_wrapper()));
+    }
+
+    pub fn members(&self) -> RefMut<SymbolTable> {
+        RefMut::map(self.members.borrow_mut(), |option| option.as_mut().unwrap())
     }
 }
 

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -34,12 +34,14 @@ pub enum SyntaxKind {
     NoSubstitutionTemplateLiteral,
     OpenBraceToken,
     CloseBraceToken,
+    OpenParenToken,
     OpenBracketToken,
     CloseBracketToken,
     DotToken,
     DotDotDotToken,
     SemicolonToken,
     CommaToken,
+    LessThanToken,
     AsteriskToken,
     PlusPlusToken,
     ExclamationToken,
@@ -1563,10 +1565,12 @@ impl CharacterCodes {
     pub const Z: char = 'Z';
 
     pub const asterisk: char = '*';
+    pub const close_brace: char = '}';
     pub const close_bracket: char = ']';
     pub const colon: char = ':';
     pub const comma: char = ',';
     pub const equals: char = '=';
+    pub const open_brace: char = '{';
     pub const open_bracket: char = '[';
     pub const plus: char = '+';
     pub const semicolon: char = ';';

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -945,6 +945,10 @@ impl Symbol {
         *self.value_declaration.borrow_mut() = Some(Rc::downgrade(&node.node_wrapper()));
     }
 
+    pub fn maybe_members(&self) -> RefMut<Option<SymbolTable>> {
+        self.members.borrow_mut()
+    }
+
     pub fn members(&self) -> RefMut<SymbolTable> {
         RefMut::map(self.members.borrow_mut(), |option| option.as_mut().unwrap())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,28 +23,31 @@ pub use compiler::factory::node_tests::is_variable_declaration;
 pub use compiler::parser::{create_source_file, for_each_child};
 pub use compiler::path::{normalize_path, to_path};
 pub use compiler::program::create_program;
-pub use compiler::scanner::{create_scanner, token_to_string, Scanner};
+pub use compiler::scanner::{
+    create_scanner, token_is_identifier_or_keyword, token_to_string, Scanner,
+};
 pub use compiler::sys::{get_sys, System};
 pub use compiler::types::{
     ArrayLiteralExpression, ArrayTypeNode, BaseBindingLikeDeclaration, BaseDiagnostic,
-    BaseDiagnosticRelatedInformation, BaseIntrinsicType, BaseLiteralLikeNode, BaseLiteralType,
+    BaseDiagnosticRelatedInformation, BaseGenericNamedDeclaration,
+    BaseInterfaceOrClassLikeDeclaration, BaseIntrinsicType, BaseLiteralLikeNode, BaseLiteralType,
     BaseNamedDeclaration, BaseNode, BaseType, BaseUnionOrIntersectionType,
     BaseVariableLikeDeclaration, BinaryExpression, BindingLikeDeclarationInterface, CharacterCodes,
     CompilerHost, CreateProgramOptions, Diagnostic, DiagnosticCategory, DiagnosticCollection,
     DiagnosticMessage, DiagnosticMessageChain, DiagnosticRelatedInformationInterface,
     DiagnosticWithDetachedLocation, DiagnosticWithLocation, EmitHint, EmitTextWriter,
     EmptyStatement, ExitStatus, Expression, ExpressionStatement, FreshableIntrinsicType,
-    HasExpressionInitializerInterface, HasTypeInterface, Identifier, IntrinsicType,
-    KeywordTypeNode, LiteralLikeNode, LiteralLikeNodeInterface, LiteralTypeInterface,
-    LiteralTypeNode, ModuleResolutionHost, ModuleSpecifierResolutionHost,
+    HasExpressionInitializerInterface, HasTypeInterface, Identifier, InterfaceDeclaration,
+    IntrinsicType, KeywordTypeNode, LiteralLikeNode, LiteralLikeNodeInterface,
+    LiteralTypeInterface, LiteralTypeNode, ModuleResolutionHost, ModuleSpecifierResolutionHost,
     NamedDeclarationInterface, Node, NodeArray, NodeArrayOrVec, NodeFactory, NodeFlags,
     NodeInterface, NumberLiteralType, NumericLiteral, ParsedCommandLine, Path,
-    PrefixUnaryExpression, Printer, PrinterOptions, Program, ReadonlyTextRange,
+    PrefixUnaryExpression, Printer, PrinterOptions, Program, PropertySignature, ReadonlyTextRange,
     RelationComparisonResult, SourceFile, Statement, StructureIsReused, Symbol, SymbolFlags,
     SymbolTable, SymbolTracker, SymbolWriter, SyntaxKind, Ternary, TextSpan, TokenFlags, Type,
-    TypeChecker, TypeCheckerHost, TypeFlags, TypeInterface, TypeNode, UnionOrIntersectionType,
-    UnionOrIntersectionTypeInterface, UnionType, VariableDeclaration, VariableDeclarationList,
-    VariableLikeDeclarationInterface, VariableStatement, __String,
+    TypeChecker, TypeCheckerHost, TypeElement, TypeFlags, TypeInterface, TypeNode,
+    UnionOrIntersectionType, UnionOrIntersectionTypeInterface, UnionType, VariableDeclaration,
+    VariableDeclarationList, VariableLikeDeclarationInterface, VariableStatement, __String,
 };
 pub use compiler::utilities::{
     chain_diagnostic_messages, create_detached_diagnostic, create_diagnostic_collection,


### PR DESCRIPTION
In this PR:
- parse and bind a simple interface declaration like:
```
interface Foo {
  bar: number
}
```

To test:
If you run `cargo run tmp.tsx` against a source file whose contents are:
```
interface Foo {
  bar: number
}
```
then you should see debug-logging of a `SourceFile` whose only statement is an `InterfaceDeclaration` with `name: "Foo"` and `members:` contains a `PropertySignature` with `name: "bar"` and `type_:` a `KeywordTypeNode` with `kind: NumberKeyword`. And in the `post-binding:` debug-logging you should see that the `locals` symbol table on the `SourceFile` contains a `Symbol` for `"Foo"`, which itself has a nested `members` symbol table containing a `Symbol` for `"bar"`. Then it should panic during type-checking

Based on `array-literal-declaration`