### PR TITLE
Parse + bind union of string literals type

### DIFF
--- a/src/compiler/factory/node_tests.rs
+++ b/src/compiler/factory/node_tests.rs
@@ -28,6 +28,10 @@ pub fn is_object_literal_expression<TNode: NodeInterface>(node: &TNode) -> bool 
     node.kind() == SyntaxKind::ObjectLiteralExpression
 }
 
+pub fn is_omitted_expression<TNode: NodeInterface>(node: &TNode) -> bool {
+    node.kind() == SyntaxKind::OmittedExpression
+}
+
 pub fn is_variable_declaration<TNode: NodeInterface>(node: &TNode) -> bool {
     node.kind() == SyntaxKind::VariableDeclaration
 }

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -83,6 +83,12 @@ pub fn for_each_child<TNodeCallback: FnMut(Option<Rc<Node>>), TNodesCallback: Fn
         Node::TypeNode(TypeNode::ArrayTypeNode(array_type)) => {
             visit_node(&mut cb_node, Some(array_type.element_type.clone()))
         }
+        Node::TypeNode(TypeNode::UnionTypeNode(union_type)) => {
+            visit_nodes(&mut cb_node, &mut cb_nodes, Some(&union_type.types))
+        }
+        Node::TypeNode(TypeNode::IntersectionTypeNode(intersection_type)) => {
+            visit_nodes(&mut cb_node, &mut cb_nodes, Some(&intersection_type.types))
+        }
         Node::TypeNode(TypeNode::LiteralTypeNode(literal_type)) => {
             visit_node(&mut cb_node, Some(literal_type.literal.clone()))
         }

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -638,13 +638,26 @@ impl ParserType {
         self.try_parse_semicolon() || self.parse_expected(SyntaxKind::SemicolonToken, None)
     }
 
-    fn create_node_array(&self, elements: Vec<Node>) -> NodeArray {
-        self.factory.create_node_array(
+    fn create_node_array(
+        &self,
+        elements: Vec<Node>,
+        pos: isize,
+        end: Option<isize>,
+        has_trailing_comma: Option<bool>,
+    ) -> NodeArray {
+        let array = self.factory.create_node_array(
             elements
                 .into_iter()
                 .map(Node::wrap)
                 .collect::<Vec<Rc<Node>>>(),
-        )
+            has_trailing_comma,
+        );
+        // set_text_range_pos_end(
+        //     array,
+        //     pos,
+        //     end.unwrap_or_else(|| self.scanner().get_start_pos()),
+        // );
+        array
     }
 
     fn finish_node<TParsedNode: NodeInterface>(
@@ -801,15 +814,18 @@ impl ParserType {
         let mut list: Vec<Node> = vec![];
         let list_pos = self.get_node_pos();
 
+        let mut comma_start: isize = -1;
         loop {
             if self.is_list_element(kind) {
                 let start_pos = self.scanner().get_start_pos();
                 list.push(self.parse_list_element(kind, parse_element).into());
+                comma_start = self.scanner().get_token_pos().try_into().unwrap();
 
                 if self.parse_optional(SyntaxKind::CommaToken) {
                     continue;
                 }
 
+                comma_start = -1;
                 if self.is_list_terminator(kind) {
                     break;
                 }
@@ -825,7 +841,7 @@ impl ParserType {
         }
 
         self.set_parsing_context(save_parsing_context);
-        self.create_node_array(list)
+        self.create_node_array(list, list_pos, None, Some(comma_start >= 0))
     }
 
     fn parse_bracketed_list<TItem: Into<Node>>(
@@ -872,6 +888,7 @@ impl ParserType {
         parse_element: fn(&mut ParserType) -> TItem,
     ) -> NodeArray {
         let mut list = vec![];
+        let list_pos = self.get_node_pos();
 
         while !self.is_list_terminator(kind) {
             if self.is_list_element(kind) {
@@ -883,7 +900,7 @@ impl ParserType {
             unimplemented!()
         }
 
-        self.create_node_array(list)
+        self.create_node_array(list, list_pos, None, None)
     }
 
     fn parse_list_element<TItem: Into<Node>>(
@@ -1171,19 +1188,67 @@ impl ParserType {
         self.parse_postfix_type_or_higher()
     }
 
-    fn parse_union_or_intersection_type(
+    fn parse_function_or_constructor_type_to_error(
+        &self,
+        is_in_union_type: bool,
+    ) -> Option<TypeNode> {
+        None
+    }
+
+    fn parse_union_or_intersection_type<TReturn: Into<TypeNode>>(
         &mut self,
+        operator: SyntaxKind, /*SyntaxKind.BarToken | SyntaxKind.AmpersandToken*/
         parse_constituent_type: fn(&mut ParserType) -> TypeNode,
+        create_type_node: fn(&NodeFactory, &ParserType, NodeArray) -> TReturn,
     ) -> TypeNode {
-        parse_constituent_type(self)
+        let pos = self.get_node_pos();
+        let is_union_type = operator == SyntaxKind::BarToken;
+        let has_leading_operator = self.parse_optional(operator);
+        let mut type_: Option<TypeNode> = Some(if has_leading_operator {
+            self.parse_function_or_constructor_type_to_error(is_union_type)
+                .unwrap_or_else(|| parse_constituent_type(self))
+        } else {
+            parse_constituent_type(self)
+        });
+        if self.token() == operator || has_leading_operator {
+            let mut types: Vec<Node> = vec![type_.take().unwrap().into()];
+            while self.parse_optional(operator) {
+                types.push(
+                    self.parse_function_or_constructor_type_to_error(is_union_type)
+                        .unwrap_or_else(|| parse_constituent_type(self))
+                        .into(),
+                );
+            }
+            type_ = Some(
+                self.finish_node(
+                    create_type_node(
+                        &self.factory,
+                        self,
+                        self.create_node_array(types, pos, None, None),
+                    )
+                    .into(),
+                    pos,
+                    None,
+                ),
+            );
+        }
+        type_.unwrap()
     }
 
     fn parse_intersection_type_or_higher(&mut self) -> TypeNode {
-        self.parse_union_or_intersection_type(ParserType::parse_type_operator_or_higher)
+        self.parse_union_or_intersection_type(
+            SyntaxKind::AmpersandToken,
+            ParserType::parse_type_operator_or_higher,
+            NodeFactory::create_intersection_type_node,
+        )
     }
 
     fn parse_union_type_or_higher(&mut self) -> TypeNode {
-        self.parse_union_or_intersection_type(ParserType::parse_intersection_type_or_higher)
+        self.parse_union_or_intersection_type(
+            SyntaxKind::BarToken,
+            ParserType::parse_intersection_type_or_higher,
+            NodeFactory::create_union_type_node,
+        )
     }
 
     fn parse_type(&mut self) -> TypeNode {

--- a/src/compiler/scanner.rs
+++ b/src/compiler/scanner.rs
@@ -200,7 +200,7 @@ impl Scanner {
                 CharacterCodes::line_feed => {
                     self.set_token_flags(self.token_flags() | TokenFlags::PrecedingLineBreak);
                     if self.skip_trivia {
-                        self.set_pos(self.pos() + 1);
+                        self.increment_pos();
                         continue;
                     } else {
                         unimplemented!()
@@ -208,7 +208,7 @@ impl Scanner {
                 }
                 CharacterCodes::space => {
                     if self.skip_trivia {
-                        self.set_pos(self.pos() + 1);
+                        self.increment_pos();
                         continue;
                     }
                 }
@@ -217,13 +217,13 @@ impl Scanner {
                     return self.set_token(SyntaxKind::StringLiteral);
                 }
                 CharacterCodes::asterisk => {
-                    self.set_pos(self.pos() + 1);
+                    self.increment_pos();
                     return self.set_token(SyntaxKind::AsteriskToken);
                 }
                 CharacterCodes::plus => {
                     if let Some(next_char) = self.text().chars().nth(self.pos() + 1) {
                         if next_char == CharacterCodes::plus {
-                            self.set_pos(self.pos() + 2);
+                            self.increment_pos_by(2);
                             return self.set_token(SyntaxKind::PlusPlusToken);
                         }
                         unimplemented!();
@@ -231,7 +231,7 @@ impl Scanner {
                     unimplemented!();
                 }
                 CharacterCodes::comma => {
-                    self.set_pos(self.pos() + 1);
+                    self.increment_pos();
                     return self.set_token(SyntaxKind::CommaToken);
                 }
                 CharacterCodes::_0
@@ -253,36 +253,40 @@ impl Scanner {
                     return token;
                 }
                 CharacterCodes::colon => {
-                    self.set_pos(self.pos() + 1);
+                    self.increment_pos();
                     return self.set_token(SyntaxKind::ColonToken);
                 }
                 CharacterCodes::semicolon => {
-                    self.set_pos(self.pos() + 1);
+                    self.increment_pos();
                     return self.set_token(SyntaxKind::SemicolonToken);
                 }
                 CharacterCodes::less_than => {
-                    self.set_pos(self.pos() + 1);
+                    self.increment_pos();
                     return self.set_token(SyntaxKind::LessThanToken);
                 }
                 CharacterCodes::greater_than => {
-                    self.set_pos(self.pos() + 1);
+                    self.increment_pos();
                     return self.set_token(SyntaxKind::GreaterThanToken);
                 }
                 CharacterCodes::equals => {
-                    self.set_pos(self.pos() + 1);
+                    self.increment_pos();
                     return self.set_token(SyntaxKind::EqualsToken);
                 }
                 CharacterCodes::open_bracket => {
-                    self.set_pos(self.pos() + 1);
+                    self.increment_pos();
                     return self.set_token(SyntaxKind::OpenBracketToken);
                 }
                 CharacterCodes::close_bracket => {
-                    self.set_pos(self.pos() + 1);
+                    self.increment_pos();
                     return self.set_token(SyntaxKind::CloseBracketToken);
                 }
                 CharacterCodes::open_brace => {
-                    self.set_pos(self.pos() + 1);
+                    self.increment_pos();
                     return self.set_token(SyntaxKind::OpenBraceToken);
+                }
+                CharacterCodes::bar => {
+                    self.increment_pos();
+                    return self.set_token(SyntaxKind::BarToken);
                 }
                 CharacterCodes::close_brace => {
                     self.set_pos(self.pos() + 1);

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -3583,6 +3583,7 @@ impl CharacterCodes {
     pub const asterisk: char = '*';
     pub const at: char = '@';
     pub const backslash: char = '\\';
+    pub const bar: char = '|';
     pub const close_brace: char = '}';
     pub const close_bracket: char = ']';
     pub const colon: char = ':';

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -93,6 +93,8 @@ pub enum SyntaxKind {
     TypeReference,
     TypeLiteral,
     ArrayType,
+    UnionType,
+    IntersectionType,
     LiteralType,
     ObjectBindingPattern,
     ArrayBindingPattern,
@@ -103,6 +105,7 @@ pub enum SyntaxKind {
     PrefixUnaryExpression,
     BinaryExpression,
     ClassExpression,
+    OmittedExpression,
     ExpressionWithTypeArguments,
     EmptyStatement,
     VariableStatement,
@@ -441,6 +444,12 @@ impl From<&NodeArray> for Vec<Rc<Node>> {
     }
 }
 
+impl<'node_array> From<&'node_array NodeArray> for &'node_array [Rc<Node>] {
+    fn from(node_array: &'node_array NodeArray) -> Self {
+        &node_array._nodes
+    }
+}
+
 pub struct NodeArrayIter<'node_array>(
     Box<dyn Iterator<Item = &'node_array Rc<Node>> + 'node_array>,
 );
@@ -661,6 +670,8 @@ impl VariableDeclarationList {
 #[ast_type]
 pub enum TypeNode {
     KeywordTypeNode(KeywordTypeNode),
+    UnionTypeNode(UnionTypeNode),
+    IntersectionTypeNode(IntersectionTypeNode),
     LiteralTypeNode(LiteralTypeNode),
     TypeReferenceNode(TypeReferenceNode),
     TypeLiteralNode(TypeLiteralNode),
@@ -745,6 +756,38 @@ impl ArrayTypeNode {
         Self {
             _node: base_node,
             element_type,
+        }
+    }
+}
+
+#[derive(Debug)]
+#[ast_type(ancestors = "TypeNode")]
+pub struct UnionTypeNode {
+    _node: BaseNode,
+    pub types: NodeArray, /*<TypeNode>*/
+}
+
+impl UnionTypeNode {
+    pub fn new(base_node: BaseNode, types: NodeArray) -> Self {
+        Self {
+            _node: base_node,
+            types,
+        }
+    }
+}
+
+#[derive(Debug)]
+#[ast_type(ancestors = "TypeNode")]
+pub struct IntersectionTypeNode {
+    _node: BaseNode,
+    pub types: NodeArray, /*<TypeNode>*/
+}
+
+impl IntersectionTypeNode {
+    pub fn new(base_node: BaseNode, types: NodeArray) -> Self {
+        Self {
+            _node: base_node,
+            types,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,8 @@ pub use compiler::factory::node_factory::{
 };
 pub use compiler::factory::node_tests::{
     is_big_int_literal, is_binding_element, is_identifier, is_object_literal_expression,
-    is_private_identifier, is_property_assignment, is_property_declaration, is_property_signature,
-    is_variable_declaration,
+    is_omitted_expression, is_private_identifier, is_property_assignment, is_property_declaration,
+    is_property_signature, is_variable_declaration,
 };
 pub use compiler::parser::{create_source_file, for_each_child};
 pub use compiler::path::{normalize_path, to_path};
@@ -48,8 +48,8 @@ pub use compiler::types::{
     Expression, ExpressionStatement, FreshableIntrinsicType, HasExpressionInitializerInterface,
     HasTypeArgumentsInterface, HasTypeInterface, HasTypeParametersInterface, Identifier,
     InterfaceDeclaration, InterfaceType, InterfaceTypeWithDeclaredMembersInterface,
-    InternalSymbolName, IntrinsicType, KeywordTypeNode, ListFormat, LiteralLikeNode,
-    LiteralLikeNodeInterface, LiteralType, LiteralTypeInterface, LiteralTypeNode,
+    InternalSymbolName, IntersectionTypeNode, IntrinsicType, KeywordTypeNode, ListFormat,
+    LiteralLikeNode, LiteralLikeNodeInterface, LiteralType, LiteralTypeInterface, LiteralTypeNode,
     ModuleResolutionHost, ModuleSpecifierResolutionHost, NamedDeclarationInterface, Node,
     NodeArray, NodeArrayOrVec, NodeBuilderFlags, NodeCheckFlags, NodeFactory, NodeFlags, NodeId,
     NodeInterface, NodeLinks, NumberLiteralType, NumericLiteral, ObjectFlags,
@@ -63,8 +63,8 @@ pub use compiler::types::{
     TypeCheckerHost, TypeElement, TypeFlags, TypeFormatFlags, TypeInterface, TypeLiteralNode,
     TypeMapper, TypeNode, TypeParameter, TypeParameterDeclaration, TypeReference,
     TypeReferenceNode, UnionOrIntersectionType, UnionOrIntersectionTypeInterface, UnionReduction,
-    UnionType, VariableDeclaration, VariableDeclarationList, VariableLikeDeclarationInterface,
-    VariableStatement, __String,
+    UnionType, UnionTypeNode, VariableDeclaration, VariableDeclarationList,
+    VariableLikeDeclarationInterface, VariableStatement, __String,
 };
 pub use compiler::utilities::{
     chain_diagnostic_messages, create_detached_diagnostic, create_diagnostic_collection,


### PR DESCRIPTION
In this PR:
- parse + bind a union-of-string-literals type

To test:
If you run `cargo run tmp.tsx` against a source file containing eg `const a: 'foo' | 'bar' = 'baz'`, you should see `post-binding:` debug-logging where the `VariableDeclaration`'s `type_` is a `UnionTypeNode` whose `types` are a `LiteralTypeNode` with `StringLiteral` `"foo"` and a `LiteralTypeNode` with `StringLiteral` `"bar"` (and they should have their `parent` bindings initialized)

Based on `type-check-string-literal`