### PR TITLE
Type-check variable usage

### DIFF
--- a/local-macros/src/lib.rs
+++ b/local-macros/src/lib.rs
@@ -71,6 +71,10 @@ fn get_struct_interface_impl(
                         self.#first_field_name.kind()
                     }
 
+                    fn flags(&self) -> crate::NodeFlags {
+                        self.#first_field_name.flags()
+                    }
+
                     fn maybe_id(&self) -> ::std::option::Option<crate::NodeId> {
                         self.#first_field_name.maybe_id()
                     }
@@ -167,8 +171,8 @@ fn get_struct_interface_impl(
         "HasExpressionInitializerInterface" => {
             quote! {
                 impl crate::HasExpressionInitializerInterface for #ast_type_name {
-                    fn initializer(&self) -> ::std::option::Option<::std::rc::Rc<crate::Node>> {
-                        self.#first_field_name.initializer()
+                    fn maybe_initializer(&self) -> ::std::option::Option<::std::rc::Rc<crate::Node>> {
+                        self.#first_field_name.maybe_initializer()
                     }
 
                     fn set_initializer(&mut self, initializer: ::std::rc::Rc<crate::Node>) {
@@ -253,6 +257,12 @@ fn get_enum_interface_impl(
                     fn kind(&self) -> crate::SyntaxKind {
                         match self {
                             #(#ast_type_name::#variant_names(nested) => nested.kind()),*
+                        }
+                    }
+
+                    fn flags(&self) -> crate::NodeFlags {
+                        match self {
+                            #(#ast_type_name::#variant_names(nested) => nested.flags()),*
                         }
                     }
 

--- a/src/compiler/checker/lines_0_1000.rs
+++ b/src/compiler/checker/lines_0_1000.rs
@@ -8,9 +8,9 @@ use std::rc::Rc;
 use super::create_node_builder;
 use crate::{
     __String, create_diagnostic_collection, create_symbol_table, object_allocator,
-    DiagnosticCollection, FreshableIntrinsicType, IntrinsicType, Node, NodeId, NodeInterface,
-    Number, ObjectFlags, Symbol, SymbolFlags, SymbolId, SymbolInterface, SymbolTable, Type,
-    TypeChecker, TypeCheckerHost, TypeFlags,
+    DiagnosticCollection, FreshableIntrinsicType, IntrinsicType, NodeId, NodeInterface, Number,
+    ObjectFlags, Symbol, SymbolFlags, SymbolId, SymbolInterface, SymbolTable, Type, TypeChecker,
+    TypeCheckerHost, TypeFlags,
 };
 
 thread_local! {
@@ -39,6 +39,17 @@ pub(super) fn increment_next_node_id() {
     next_node_id.with(|_next_node_id| {
         *_next_node_id.borrow_mut() += 1;
     });
+}
+
+bitflags! {
+    pub(super) struct CheckMode: u32 {
+        const Normal = 0;
+        const Contextual = 1 << 0;
+        const Inferential = 1 << 1;
+        const SkipContextSensitive = 1 << 2;
+        const SkipGenericFunctions = 1 << 3;
+        const IsForSignatureHelp = 1 << 4;
+    }
 }
 
 bitflags! {

--- a/src/compiler/checker/lines_16000_18000.rs
+++ b/src/compiler/checker/lines_16000_18000.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::ptr;
 use std::rc::Rc;
 
-use super::CheckTypeRelatedTo;
+use super::{CheckMode, CheckTypeRelatedTo};
 use crate::{
     get_check_flags, ArrayTypeNode, BaseLiteralType, CheckFlags, Debug_, DiagnosticMessage,
     Expression, IntrinsicType, LiteralTypeInterface, LiteralTypeNode, NamedDeclarationInterface,
@@ -117,12 +117,14 @@ impl TypeChecker {
         let links = self.get_node_links(node);
         let mut links_ref = links.borrow_mut();
         if links_ref.resolved_type.is_none() {
-            links_ref.resolved_type = Some(self.get_regular_type_of_literal_type(
-                self.check_expression(match &*node.literal {
-                    Node::Expression(expression) => expression,
-                    _ => panic!("Expected Expression"),
-                }),
-            ));
+            links_ref.resolved_type =
+                Some(self.get_regular_type_of_literal_type(self.check_expression(
+                    match &*node.literal {
+                        Node::Expression(expression) => expression,
+                        _ => panic!("Expected Expression"),
+                    },
+                    None,
+                )));
         }
         links_ref.resolved_type.clone().unwrap()
     }
@@ -462,6 +464,7 @@ impl TypeChecker {
                 Node::Expression(expression) => expression,
                 _ => panic!("Expected Expression"),
             },
+            Some(CheckMode::Contextual),
             Some(source_prop_type),
         )
     }

--- a/src/compiler/checker/lines_24000_32000.rs
+++ b/src/compiler/checker/lines_24000_32000.rs
@@ -35,7 +35,10 @@ impl TypeChecker {
             _ => panic!("Expected VariableDeclaration"),
         };
         if has_initializer(declaration)
-            && Rc::ptr_eq(&node.node_wrapper(), &declaration.initializer().unwrap())
+            && Rc::ptr_eq(
+                &node.node_wrapper(),
+                &declaration.maybe_initializer().unwrap(),
+            )
         {
             let result = self.get_contextual_type_for_variable_like_declaration(&*parent);
             if result.is_some() {

--- a/src/compiler/checker/lines_24000_32000.rs
+++ b/src/compiler/checker/lines_24000_32000.rs
@@ -3,15 +3,32 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use super::CheckMode;
 use crate::{
     __String, create_symbol_table, get_effective_type_annotation_node, get_object_flags,
     has_initializer, is_object_literal_expression, Expression, HasExpressionInitializerInterface,
-    Node, NodeInterface, ObjectFlags, ObjectFlagsTypeInterface, ObjectLiteralExpression,
-    PropertyAssignment, Symbol, SymbolInterface, SyntaxKind, Type, TypeChecker, TypeFlags,
-    TypeInterface,
+    Identifier, Node, NodeInterface, ObjectFlags, ObjectFlagsTypeInterface,
+    ObjectLiteralExpression, PropertyAssignment, Symbol, SymbolInterface, SyntaxKind, Type,
+    TypeChecker, TypeFlags, TypeInterface,
 };
 
 impl TypeChecker {
+    pub(super) fn check_identifier(
+        &self,
+        node: &Identifier,
+        check_mode: Option<CheckMode>,
+    ) -> Rc<Type> {
+        let symbol = self.get_resolved_symbol(node);
+
+        let local_or_export_symbol = self
+            .get_export_symbol_of_value_symbol_if_exported(Some(symbol))
+            .unwrap();
+
+        let type_ = self.get_type_of_symbol(&*local_or_export_symbol);
+
+        type_
+    }
+
     pub(super) fn get_contextual_type_for_variable_like_declaration(
         &self,
         declaration: &Node,

--- a/src/compiler/checker/lines_32000_40000.rs
+++ b/src/compiler/checker/lines_32000_40000.rs
@@ -2,6 +2,7 @@
 
 use std::rc::Rc;
 
+use super::CheckMode;
 use crate::{
     for_each, get_combined_node_flags, get_effective_initializer, is_binding_element,
     is_private_identifier, map, maybe_for_each, ArrayTypeNode, DiagnosticMessage, Diagnostics,
@@ -32,7 +33,7 @@ impl TypeChecker {
             Node::Expression(expression) => expression,
             _ => panic!("Expected Expression"),
         };
-        let operand_type = self.check_expression(operand_expression);
+        let operand_type = self.check_expression(operand_expression, None);
         match node.operator {
             SyntaxKind::PlusPlusToken => {
                 self.check_arithmetic_operand_type(operand_expression, operand_type.clone(), &Diagnostics::An_arithmetic_operand_must_be_of_type_any_number_bigint_or_an_enum_type);
@@ -62,8 +63,22 @@ impl TypeChecker {
         false
     }
 
-    pub(super) fn check_expression_cached(&self, node: &Expression) -> Rc<Type> {
-        self.check_expression(node)
+    pub(super) fn check_expression_cached(
+        &self,
+        node: &Expression,
+        check_mode: Option<CheckMode>,
+    ) -> Rc<Type> {
+        let links = self.get_node_links(node);
+        let mut links_ref = links.borrow_mut();
+        if links_ref.resolved_type.is_none() {
+            if let Some(check_mode) = check_mode {
+                if check_mode != CheckMode::Normal {
+                    return self.check_expression(node, Some(check_mode));
+                }
+            }
+            links_ref.resolved_type = Some(self.check_expression(node, check_mode));
+        }
+        links_ref.resolved_type.clone().unwrap()
     }
 
     pub(super) fn check_declaration_initializer(
@@ -82,7 +97,7 @@ impl TypeChecker {
                 if let Some(contextual_type) = contextual_type {
                     unimplemented!()
                 } else {
-                    self.check_expression_cached(initializer_as_expression)
+                    self.check_expression_cached(initializer_as_expression, None)
                 }
             });
         if false {
@@ -148,9 +163,10 @@ impl TypeChecker {
     pub(super) fn check_expression_for_mutable_location(
         &self,
         node: &Expression,
+        check_mode: Option<CheckMode>,
         contextual_type: Option<Rc<Type>>,
     ) -> Rc<Type> {
-        let type_ = self.check_expression(node);
+        let type_ = self.check_expression(node, check_mode);
         if false {
             unimplemented!()
         } else {
@@ -168,12 +184,17 @@ impl TypeChecker {
         }
     }
 
-    pub(super) fn check_property_assignment(&self, node: &PropertyAssignment) -> Rc<Type> {
+    pub(super) fn check_property_assignment(
+        &self,
+        node: &PropertyAssignment,
+        check_mode: Option<CheckMode>,
+    ) -> Rc<Type> {
         self.check_expression_for_mutable_location(
             match &*node.initializer {
                 Node::Expression(expression) => expression,
                 _ => panic!("Expected Expression"),
             },
+            check_mode,
             None,
         )
     }
@@ -189,17 +210,26 @@ impl TypeChecker {
                 | SyntaxKind::TrueKeyword
                 | SyntaxKind::FalseKeyword
         ) {
-            return Some(self.check_expression(node));
+            return Some(self.check_expression(node, None));
         }
         None
     }
 
-    pub(super) fn check_expression(&self, node: &Expression) -> Rc<Type> {
-        self.check_expression_worker(node)
+    pub(super) fn check_expression(
+        &self,
+        node: &Expression,
+        check_mode: Option<CheckMode>,
+    ) -> Rc<Type> {
+        self.check_expression_worker(node, check_mode)
     }
 
-    pub(super) fn check_expression_worker(&self, node: &Expression) -> Rc<Type> {
+    pub(super) fn check_expression_worker(
+        &self,
+        node: &Expression,
+        check_mode: Option<CheckMode>,
+    ) -> Rc<Type> {
         match node {
+            Expression::Identifier(identifier) => self.check_identifier(identifier, check_mode),
             Expression::TokenExpression(token_expression) => match token_expression.kind() {
                 SyntaxKind::TrueKeyword => self.true_type(),
                 _ => unimplemented!(),
@@ -311,10 +341,13 @@ impl TypeChecker {
             let initializer = get_effective_initializer(node);
             if let Some(initializer) = initializer {
                 if true {
-                    let initializer_type = self.check_expression_cached(match &*initializer {
-                        Node::Expression(expression) => expression,
-                        _ => panic!("Expected Expression"),
-                    });
+                    let initializer_type = self.check_expression_cached(
+                        match &*initializer {
+                            Node::Expression(expression) => expression,
+                            _ => panic!("Expected Expression"),
+                        },
+                        None,
+                    );
                     self.check_type_assignable_to_and_optionally_elaborate(
                         initializer_type,
                         type_,
@@ -354,7 +387,7 @@ impl TypeChecker {
             Node::Expression(expression) => expression,
             _ => panic!("Expected Expression"),
         };
-        self.check_expression(expression);
+        self.check_expression(expression, None);
     }
 
     pub(super) fn check_type_parameters(

--- a/src/compiler/checker/lines_4000_8000.rs
+++ b/src/compiler/checker/lines_4000_8000.rs
@@ -17,6 +17,21 @@ use crate::{
 };
 
 impl TypeChecker {
+    pub(super) fn get_export_symbol_of_value_symbol_if_exported(
+        &self,
+        symbol: Option<Rc<Symbol>>,
+    ) -> Option<Rc<Symbol>> {
+        self.get_merged_symbol(if let Some(symbol) = symbol {
+            if symbol.flags().intersects(SymbolFlags::ExportValue) {
+                unimplemented!()
+            } else {
+                Some(symbol)
+            }
+        } else {
+            symbol
+        })
+    }
+
     pub(super) fn symbol_is_value(&self, symbol: Rc<Symbol>) -> bool {
         symbol.flags().intersects(SymbolFlags::Value)
     }

--- a/src/compiler/checker/lines_8000_12000.rs
+++ b/src/compiler/checker/lines_8000_12000.rs
@@ -166,10 +166,13 @@ impl TypeChecker {
             type_ = self
                 .try_get_type_from_effective_type_node(&*declaration)
                 .unwrap_or_else(|| {
-                    self.check_property_assignment(match &*declaration {
-                        Node::PropertyAssignment(property_assignment) => property_assignment,
-                        _ => panic!("Expected PropertyAssignment"),
-                    })
+                    self.check_property_assignment(
+                        match &*declaration {
+                            Node::PropertyAssignment(property_assignment) => property_assignment,
+                            _ => panic!("Expected PropertyAssignment"),
+                        },
+                        None,
+                    )
                 });
         } else if is_property_signature(&*declaration) || is_variable_declaration(&*declaration) {
             type_ = self.get_widened_type_for_variable_like_declaration(&*declaration);

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -70,7 +70,7 @@ pub fn for_each_child<TNodeCallback: FnMut(Option<Rc<Node>>), TNodesCallback: Fn
         Node::VariableDeclaration(variable_declaration) => {
             visit_node(&mut cb_node, Some(variable_declaration.name()));
             visit_node(&mut cb_node, variable_declaration.type_());
-            visit_node(&mut cb_node, variable_declaration.initializer())
+            visit_node(&mut cb_node, variable_declaration.maybe_initializer())
         }
         Node::TypeNode(TypeNode::TypeReferenceNode(type_reference_node)) => {
             visit_node(&mut cb_node, Some(type_reference_node.type_name.clone()));
@@ -159,6 +159,12 @@ impl NodeInterface for MissingNode {
     fn kind(&self) -> SyntaxKind {
         match self {
             MissingNode::Identifier(identifier) => identifier.kind(),
+        }
+    }
+
+    fn flags(&self) -> NodeFlags {
+        match self {
+            MissingNode::Identifier(identifier) => identifier.flags(),
         }
     }
 

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -48,6 +48,7 @@ pub enum SyntaxKind {
     GreaterThanToken,
     AsteriskToken,
     PlusPlusToken,
+    MinusMinusToken,
     LessThanLessThanToken,
     AmpersandToken,
     BarToken,
@@ -104,6 +105,7 @@ pub enum SyntaxKind {
     ArrayLiteralExpression,
     ObjectLiteralExpression,
     PropertyAccessExpression,
+    ParenthesizedExpression,
     PrefixUnaryExpression,
     BinaryExpression,
     ClassExpression,
@@ -1419,6 +1421,7 @@ bitflags! {
         const SetAccessor = 1 << 16;
         const TypeParameter = 1 << 18;
         const TypeAlias = 1 << 19;
+        const ExportValue = 1 << 20;
         const Optional = 1 << 24;
         const Transient = 1 << 25;
 
@@ -1918,6 +1921,7 @@ bitflags! {
 pub struct NodeLinks {
     pub flags: NodeCheckFlags,
     pub resolved_type: Option<Rc<Type>>,
+    pub resolved_symbol: Option<Rc<Symbol>>,
 }
 
 impl NodeLinks {
@@ -1925,6 +1929,7 @@ impl NodeLinks {
         Self {
             flags: NodeCheckFlags::None,
             resolved_type: None,
+            resolved_symbol: None,
         }
     }
 }

--- a/src/compiler/utilities.rs
+++ b/src/compiler/utilities.rs
@@ -16,8 +16,8 @@ use crate::{
     Debug_, Diagnostic, DiagnosticCollection, DiagnosticMessage, DiagnosticMessageChain,
     DiagnosticRelatedInformationInterface, DiagnosticWithDetachedLocation, DiagnosticWithLocation,
     EmitFlags, EmitTextWriter, Expression, LiteralLikeNode, LiteralLikeNodeInterface, Node,
-    NodeInterface, ObjectFlags, ReadonlyTextRange, SortedArray, SourceFile, Symbol, SymbolFlags,
-    SymbolInterface, SymbolTable, TransientSymbolInterface, Type, TypeInterface,
+    NodeFlags, NodeInterface, ObjectFlags, ReadonlyTextRange, SortedArray, SourceFile, Symbol,
+    SymbolFlags, SymbolInterface, SymbolTable, TransientSymbolInterface, Type, TypeInterface,
 };
 
 pub fn get_declaration_of_kind(
@@ -335,7 +335,7 @@ pub fn get_effective_initializer<TNode: NodeInterface>(
 ) -> Option<Rc<Node>> {
     node.node_wrapper()
         .as_has_expression_initializer()
-        .initializer()
+        .maybe_initializer()
 }
 
 pub fn set_value_declaration<TNode: NodeInterface>(symbol: &Symbol, node: &TNode) {
@@ -601,17 +601,17 @@ fn _Type(flags: TypeFlags) -> BaseType {
 
 #[allow(non_snake_case)]
 fn Node(kind: SyntaxKind, pos: isize, end: isize) -> BaseNode {
-    BaseNode::new(kind, pos, end)
+    BaseNode::new(kind, NodeFlags::None, pos, end)
 }
 
 #[allow(non_snake_case)]
 fn Token(kind: SyntaxKind, pos: isize, end: isize) -> BaseNode {
-    BaseNode::new(kind, pos, end)
+    BaseNode::new(kind, NodeFlags::None, pos, end)
 }
 
 #[allow(non_snake_case)]
 fn Identifier(kind: SyntaxKind, pos: isize, end: isize) -> BaseNode {
-    BaseNode::new(kind, pos, end)
+    BaseNode::new(kind, NodeFlags::None, pos, end)
 }
 
 pub struct ObjectAllocator {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,9 +74,9 @@ pub use compiler::utilities::{
     get_effective_type_annotation_node, get_escaped_text_of_identifier_or_literal,
     get_first_identifier, get_literal_text, get_object_flags, get_source_file_of_node,
     has_dynamic_name, is_external_or_common_js_module, is_keyword, is_property_name_literal,
-    node_is_missing, object_allocator, position_is_synthesized, set_parent, set_text_range_pos_end,
-    set_value_declaration, using_single_line_string_writer, GetLiteralTextFlags,
-    OperatorPrecedence,
+    is_write_only_access, node_is_missing, object_allocator, position_is_synthesized, set_parent,
+    set_text_range_pos_end, set_value_declaration, using_single_line_string_writer,
+    GetLiteralTextFlags, OperatorPrecedence,
 };
 pub use compiler::utilities_public::{
     create_text_span_from_bounds, escape_leading_underscores, get_combined_node_flags,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,9 +79,10 @@ pub use compiler::utilities::{
     OperatorPrecedence,
 };
 pub use compiler::utilities_public::{
-    create_text_span_from_bounds, escape_leading_underscores,
-    get_effective_type_parameter_declarations, get_name_of_declaration, has_initializer, id_text,
-    is_binding_pattern, is_expression, is_member_name, unescape_leading_underscores,
+    create_text_span_from_bounds, escape_leading_underscores, get_combined_node_flags,
+    get_effective_type_parameter_declarations, get_name_of_declaration, has_initializer,
+    has_only_expression_initializer, id_text, is_binding_pattern, is_expression, is_member_name,
+    unescape_leading_underscores,
 };
 pub use compiler::watch::emit_files_and_report_errors_and_get_exit_status;
 pub use execute_command_line::execute_command_line::execute_command_line;


### PR DESCRIPTION
In this PR:
- type-check usage of a variable

To test:
If you run `cargo run tmp.tsx` against a source file containing eg:
```
const a = true
++a
```
then you should see a diagnostic debug-logged with message `"An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type."`
If you run `cargo run tmp.tsx` against a source file containing eg:
```
const a = 1
++a
```
then you should see no diagnostics debug-logged

Based on `type-check-union-of-string-literals`