### PR TITLE
Pass type references as function parameters

### DIFF
--- a/local-macros/src/lib.rs
+++ b/local-macros/src/lib.rs
@@ -658,9 +658,8 @@ fn get_type_struct_interface_impl(
                     fn get_or_initialize_fresh_type(
                         &self,
                         type_checker: &crate::TypeChecker,
-                        wrapper: &::std::rc::Rc<crate::Type>,
                     ) -> Rc<Type> {
-                        self.#first_field_name.get_or_initialize_fresh_type(type_checker, wrapper)
+                        self.#first_field_name.get_or_initialize_fresh_type(type_checker)
                     }
 
                     fn regular_type(&self) -> ::std::rc::Rc<crate::Type> {
@@ -816,10 +815,9 @@ fn get_type_enum_interface_impl(
                     fn get_or_initialize_fresh_type(
                         &self,
                         type_checker: &crate::TypeChecker,
-                        wrapper: &::std::rc::Rc<crate::Type>,
                     ) -> Rc<Type> {
                         match self {
-                            #(#type_type_name::#variant_names(nested) => nested.get_or_initialize_fresh_type(type_checker, wrapper)),*
+                            #(#type_type_name::#variant_names(nested) => nested.get_or_initialize_fresh_type(type_checker)),*
                         }
                     }
 

--- a/src/compiler/checker/lines_0_1000.rs
+++ b/src/compiler/checker/lines_0_1000.rs
@@ -160,40 +160,36 @@ pub fn create_type_checker<TTypeCheckerHost: TypeCheckerHost>(
             )
             .into(),
     ));
-    type_checker.any_type = Some(Rc::new(
+    type_checker.any_type = Some(
         type_checker
             .create_intrinsic_type(TypeFlags::Any, "any")
             .into(),
-    ));
-    type_checker.number_type = Some(Rc::new(
+    );
+    type_checker.number_type = Some(
         type_checker
             .create_intrinsic_type(TypeFlags::Number, "number")
             .into(),
-    ));
-    type_checker.bigint_type = Some(Rc::new(
+    );
+    type_checker.bigint_type = Some(
         type_checker
             .create_intrinsic_type(TypeFlags::BigInt, "bigint")
             .into(),
-    ));
-    let true_type: Rc<Type> = Rc::new(
-        FreshableIntrinsicType::new(
-            type_checker.create_intrinsic_type(TypeFlags::BooleanLiteral, "true"),
-        )
-        .into(),
     );
-    let regular_true_type: Rc<Type> = Rc::new(
-        FreshableIntrinsicType::new(
-            type_checker.create_intrinsic_type(TypeFlags::BooleanLiteral, "true"),
-        )
-        .into(),
-    );
+    let true_type: Rc<Type> = FreshableIntrinsicType::new(
+        type_checker.create_intrinsic_type(TypeFlags::BooleanLiteral, "true"),
+    )
+    .into();
+    let regular_true_type: Rc<Type> = FreshableIntrinsicType::new(
+        type_checker.create_intrinsic_type(TypeFlags::BooleanLiteral, "true"),
+    )
+    .into();
     match &*true_type {
         Type::IntrinsicType(intrinsic_type) => match intrinsic_type {
             IntrinsicType::FreshableIntrinsicType(freshable_intrinsic_type) => {
                 freshable_intrinsic_type
                     .regular_type
-                    .init(&regular_true_type, true);
-                freshable_intrinsic_type.fresh_type.init(&true_type, true);
+                    .init(&regular_true_type, false);
+                freshable_intrinsic_type.fresh_type.init(&true_type, false);
             }
             _ => panic!("Expected FreshableIntrinsicType"),
         },
@@ -215,25 +211,21 @@ pub fn create_type_checker<TTypeCheckerHost: TypeCheckerHost>(
         _ => panic!("Expected IntrinsicType"),
     }
     type_checker.regular_true_type = Some(regular_true_type);
-    let false_type: Rc<Type> = Rc::new(
-        FreshableIntrinsicType::new(
-            type_checker.create_intrinsic_type(TypeFlags::BooleanLiteral, "false"),
-        )
-        .into(),
-    );
-    let regular_false_type: Rc<Type> = Rc::new(
-        FreshableIntrinsicType::new(
-            type_checker.create_intrinsic_type(TypeFlags::BooleanLiteral, "false"),
-        )
-        .into(),
-    );
+    let false_type: Rc<Type> = FreshableIntrinsicType::new(
+        type_checker.create_intrinsic_type(TypeFlags::BooleanLiteral, "false"),
+    )
+    .into();
+    let regular_false_type: Rc<Type> = FreshableIntrinsicType::new(
+        type_checker.create_intrinsic_type(TypeFlags::BooleanLiteral, "false"),
+    )
+    .into();
     match &*false_type {
         Type::IntrinsicType(intrinsic_type) => match intrinsic_type {
             IntrinsicType::FreshableIntrinsicType(freshable_intrinsic_type) => {
                 freshable_intrinsic_type
                     .regular_type
                     .init(&regular_false_type, false);
-                freshable_intrinsic_type.fresh_type.init(&false_type, true);
+                freshable_intrinsic_type.fresh_type.init(&false_type, false);
             }
             _ => panic!("Expected FreshableIntrinsicType"),
         },
@@ -262,11 +254,11 @@ pub fn create_type_checker<TTypeCheckerHost: TypeCheckerHost>(
         ],
         None,
     ));
-    type_checker.never_type = Some(Rc::new(
+    type_checker.never_type = Some(
         type_checker
             .create_intrinsic_type(TypeFlags::Never, "never")
             .into(),
-    ));
+    );
     type_checker.number_or_big_int_type = Some(type_checker.get_union_type(
         vec![type_checker.number_type(), type_checker.bigint_type()],
         None,

--- a/src/compiler/checker/lines_12000_16000.rs
+++ b/src/compiler/checker/lines_12000_16000.rs
@@ -165,10 +165,9 @@ impl TypeChecker {
                 )
                 .unwrap_or_else(|| vec![]),
             );
-            return Rc::new(
-                self.create_type_reference(&type_, Some(type_arguments))
-                    .into(),
-            );
+            return self
+                .create_type_reference(&type_, Some(type_arguments))
+                .into();
         }
         if self.check_no_type_arguments(node, symbol) {
             type_
@@ -451,14 +450,14 @@ impl TypeChecker {
             });
             let object_flags_to_set =
                 object_flags | self.get_propagating_flags_of_types(&types, TypeFlags::Nullable);
-            type_ = Some(Rc::new(
+            type_ = Some(
                 UnionType::new(BaseUnionOrIntersectionType::new(
                     base_type,
                     types,
                     object_flags_to_set,
                 ))
                 .into(),
-            ));
+            );
             // TODO: also treat union type as intrinsic type with intrinsic_name = "boolean" if
             // is_boolean - should expose maybe_intrinsic_name on UnionType or something?
         }

--- a/src/compiler/checker/lines_16000_18000.rs
+++ b/src/compiler/checker/lines_16000_18000.rs
@@ -25,7 +25,7 @@ impl TypeChecker {
     ) -> Rc<Type> {
         let type_ = self.create_type(flags);
         let type_ = BaseLiteralType::new(type_);
-        let type_: Rc<Type> = Rc::new(StringLiteralType::new(type_, value).into());
+        let type_: Rc<Type> = StringLiteralType::new(type_, value).into();
         match &*type_ {
             Type::LiteralType(literal_type) => {
                 literal_type.set_regular_type(&if let Some(regular_type) = regular_type {
@@ -47,7 +47,7 @@ impl TypeChecker {
     ) -> Rc<Type> {
         let type_ = self.create_type(flags);
         let type_ = BaseLiteralType::new(type_);
-        let type_: Rc<Type> = Rc::new(NumberLiteralType::new(type_, value).into());
+        let type_: Rc<Type> = NumberLiteralType::new(type_, value).into();
         match &*type_ {
             Type::LiteralType(literal_type) => {
                 literal_type.set_regular_type(&if let Some(regular_type) = regular_type {

--- a/src/compiler/checker/lines_24000_32000.rs
+++ b/src/compiler/checker/lines_24000_32000.rs
@@ -218,7 +218,7 @@ impl TypeChecker {
                     | ObjectFlags::ObjectLiteral
                     | ObjectFlags::ContainsObjectOrArrayLiteral,
             );
-            Rc::new(result.into())
+            result.into()
         };
 
         create_object_literal_type()

--- a/src/compiler/checker/lines_24000_32000.rs
+++ b/src/compiler/checker/lines_24000_32000.rs
@@ -1,5 +1,6 @@
 #![allow(non_upper_case_globals)]
 
+use std::borrow::Borrow;
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -67,7 +68,7 @@ impl TypeChecker {
 
     pub(super) fn get_type_of_property_of_contextual_type(
         &self,
-        type_: Rc<Type>,
+        type_: &Type,
         name: &__String,
     ) -> Option<Rc<Type>> {
         self.map_type(
@@ -118,7 +119,7 @@ impl TypeChecker {
         if let Some(type_) = type_ {
             if self.has_bindable_name(element) {
                 return self.get_type_of_property_of_contextual_type(
-                    type_,
+                    &type_,
                     self.get_symbol_of_node(element).unwrap().escaped_name(),
                 );
             }
@@ -141,7 +142,7 @@ impl TypeChecker {
             if true {
                 let apparent_type = self
                     .map_type(
-                        instantiated_type,
+                        &instantiated_type,
                         &mut |type_| Some(self.get_apparent_type(type_)),
                         Some(true),
                     )
@@ -160,15 +161,15 @@ impl TypeChecker {
         None
     }
 
-    pub(super) fn instantiate_contextual_type<TNode: NodeInterface>(
+    pub(super) fn instantiate_contextual_type<TTypeRef: Borrow<Type>, TNode: NodeInterface>(
         &self,
-        contextual_type: Option<Rc<Type>>,
+        contextual_type: Option<TTypeRef>,
         node: &TNode,
     ) -> Option<Rc<Type>> {
         if false {
             unimplemented!()
         }
-        contextual_type
+        contextual_type.map(|contextual_type| contextual_type.borrow().type_wrapper())
     }
 
     pub(super) fn get_contextual_type<TNode: NodeInterface>(
@@ -225,7 +226,7 @@ impl TypeChecker {
 
     pub(super) fn is_known_property(
         &self,
-        target_type: Rc<Type>,
+        target_type: &Type,
         name: &__String,
         is_comparing_jsx_attributes: bool,
     ) -> bool {
@@ -247,9 +248,9 @@ impl TypeChecker {
         false
     }
 
-    pub(super) fn is_excess_property_check_target(&self, type_: Rc<Type>) -> bool {
+    pub(super) fn is_excess_property_check_target(&self, type_: &Type) -> bool {
         (type_.flags().intersects(TypeFlags::Object)
-            && !(get_object_flags(&*type_)
+            && !(get_object_flags(type_)
                 .intersects(ObjectFlags::ObjectLiteralPatternWithComputedProperties)))
             || type_.flags().intersects(TypeFlags::NonPrimitive)
             || (type_.flags().intersects(TypeFlags::Union) && unimplemented!())

--- a/src/compiler/checker/lines_8000_12000.rs
+++ b/src/compiler/checker/lines_8000_12000.rs
@@ -1,5 +1,6 @@
 #![allow(non_upper_case_globals)]
 
+use std::borrow::Borrow;
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -63,7 +64,7 @@ impl TypeChecker {
 
     pub(super) fn add_optionality(
         &self,
-        type_: Rc<Type>,
+        type_: &Type,
         is_property: Option<bool>,
         is_optional: Option<bool>,
     ) -> Rc<Type> {
@@ -72,7 +73,7 @@ impl TypeChecker {
         if self.strict_null_checks && is_optional {
             self.get_optional_type(type_, Some(is_property))
         } else {
-            type_
+            type_.type_wrapper()
         }
     }
 
@@ -86,7 +87,11 @@ impl TypeChecker {
 
         let declared_type = self.try_get_type_from_effective_type_node(declaration);
         if let Some(declared_type) = declared_type {
-            return Some(self.add_optionality(declared_type, Some(is_property), Some(is_optional)));
+            return Some(self.add_optionality(
+                &declared_type,
+                Some(is_property),
+                Some(is_optional),
+            ));
         }
 
         if has_only_expression_initializer(declaration)
@@ -95,9 +100,9 @@ impl TypeChecker {
                 .maybe_initializer()
                 .is_some()
         {
-            let type_ = self.check_declaration_initializer(declaration, None);
-            let type_ = self.widen_type_inferred_from_initializer(declaration, type_);
-            return Some(self.add_optionality(type_, Some(is_property), Some(is_optional)));
+            let type_ = self.check_declaration_initializer(declaration, Option::<&Type>::None);
+            let type_ = self.widen_type_inferred_from_initializer(declaration, &type_);
+            return Some(self.add_optionality(&type_, Some(is_property), Some(is_optional)));
         }
 
         None
@@ -111,13 +116,13 @@ impl TypeChecker {
         self.widen_type_for_variable_like_declaration(type_, declaration)
     }
 
-    pub(super) fn widen_type_for_variable_like_declaration(
+    pub(super) fn widen_type_for_variable_like_declaration<TTypeRef: Borrow<Type>>(
         &self,
-        type_: Option<Rc<Type>>,
+        type_: Option<TTypeRef>,
         declaration: &Node,
     ) -> Rc<Type> {
         if let Some(type_) = type_ {
-            return self.get_widened_type(type_);
+            return self.get_widened_type(type_.borrow());
         }
         unimplemented!()
     }
@@ -135,7 +140,7 @@ impl TypeChecker {
         symbol: &Symbol,
     ) -> Rc<Type> {
         let links = self.get_symbol_links(symbol);
-        let links_type_is_none = { links.borrow().type_.is_none() };
+        let links_type_is_none = { (*links).borrow().type_.is_none() };
         if links_type_is_none {
             let type_ = self.get_type_of_variable_or_parameter_or_property_worker(symbol);
             let mut links_ref = links.borrow_mut();
@@ -143,7 +148,7 @@ impl TypeChecker {
                 links_ref.type_ = Some(type_);
             }
         }
-        let links_ref = links.borrow();
+        let links_ref = (*links).borrow();
         links_ref.type_.clone().unwrap()
     }
 
@@ -212,7 +217,7 @@ impl TypeChecker {
 
     pub(super) fn get_non_missing_type_of_symbol(&self, symbol: Rc<Symbol>) -> Rc<Type> {
         self.remove_missing_type(
-            self.get_type_of_symbol(&*symbol),
+            &self.get_type_of_symbol(&*symbol),
             symbol.flags().intersects(SymbolFlags::Optional),
         )
     }
@@ -398,8 +403,8 @@ impl TypeChecker {
         result
     }
 
-    pub(super) fn resolve_declared_members(&self, type_: Rc<Type /*InterfaceType*/>) -> Rc<Type> {
-        let type_as_interface_type = match &*type_ {
+    pub(super) fn resolve_declared_members(&self, type_: &Type /*InterfaceType*/) -> Rc<Type> {
+        let type_as_interface_type = match type_ {
             Type::ObjectType(ObjectType::InterfaceType(interface_type)) => interface_type,
             _ => panic!("Expected InterfaceType"),
         };
@@ -407,12 +412,12 @@ impl TypeChecker {
             let symbol = type_.symbol();
             let members = self.get_members_of_symbol(symbol);
             type_as_interface_type
-                .set_declared_properties(self.get_named_members(&*members.borrow()));
+                .set_declared_properties(self.get_named_members(&*(*members).borrow()));
         }
-        type_
+        type_.type_wrapper()
     }
 
-    pub(super) fn is_type_usable_as_property_name(&self, type_: Rc<Type>) -> bool {
+    pub(super) fn is_type_usable_as_property_name(&self, type_: &Type) -> bool {
         type_
             .flags()
             .intersects(TypeFlags::StringOrNumberLiteralOrUnique)
@@ -427,13 +432,13 @@ impl TypeChecker {
 
     pub(super) fn get_property_name_from_type(
         &self,
-        type_: Rc<Type /*StringLiteralType | NumberLiteralType | UniqueESSymbolType*/>,
+        type_: &Type, /*StringLiteralType | NumberLiteralType | UniqueESSymbolType*/
     ) -> __String {
         if type_
             .flags()
             .intersects(TypeFlags::StringLiteral | TypeFlags::NumberLiteral)
         {
-            return match &*type_ {
+            return match type_ {
                 Type::LiteralType(LiteralType::NumberLiteralType(number_literal_type)) => {
                     escape_leading_underscores(&number_literal_type.value.to_string())
                 }
@@ -459,8 +464,8 @@ impl TypeChecker {
 
     pub(super) fn resolve_object_type_members(
         &self,
-        type_: Rc<Type /*ObjectType*/>,
-        source: Rc<Type /*InterfaceTypeWithDeclaredMembers*/>,
+        type_: &Type,  /*ObjectType*/
+        source: &Type, /*InterfaceTypeWithDeclaredMembers*/
         type_parameters: Vec<Rc<Type /*TypeParameter*/>>,
         type_arguments: Vec<Rc<Type>>,
     ) {
@@ -477,7 +482,7 @@ impl TypeChecker {
             mapper = Some(self.create_type_mapper(type_parameters, Some(type_arguments)));
             members = Rc::new(RefCell::new(
                 self.create_instantiated_symbol_table(
-                    match &*source {
+                    match source {
                         Type::ObjectType(ObjectType::InterfaceType(
                             InterfaceType::BaseInterfaceType(base_interface_type),
                         )) => base_interface_type,
@@ -492,7 +497,7 @@ impl TypeChecker {
             ));
         }
         self.set_structured_type_members(
-            match &*type_ {
+            match type_ {
                 Type::ObjectType(object_type) => object_type,
                 _ => panic!("Expected ObjectType"),
             },
@@ -500,12 +505,12 @@ impl TypeChecker {
         );
     }
 
-    pub(super) fn resolve_type_reference_members(&self, type_: Rc<Type /*TypeReference*/>) {
-        let type_as_type_reference = match &*type_ {
+    pub(super) fn resolve_type_reference_members(&self, type_: &Type /*TypeReference*/) {
+        let type_as_type_reference = match type_ {
             Type::ObjectType(ObjectType::TypeReference(type_reference)) => type_reference,
             _ => panic!("Expected TypeReference"),
         };
-        let source = self.resolve_declared_members(type_as_type_reference.target.clone());
+        let source = self.resolve_declared_members(&type_as_type_reference.target);
         let source_as_base_interface_type = match &*source {
             Type::ObjectType(ObjectType::InterfaceType(InterfaceType::BaseInterfaceType(
                 base_interface_type,
@@ -527,15 +532,15 @@ impl TypeChecker {
         let padded_type_arguments = if type_arguments.len() == type_parameters.len() {
             type_arguments
         } else {
-            concatenate(type_arguments, vec![type_.clone()])
+            concatenate(type_arguments, vec![type_.type_wrapper()])
         };
-        self.resolve_object_type_members(type_, source, type_parameters, padded_type_arguments);
+        self.resolve_object_type_members(type_, &source, type_parameters, padded_type_arguments);
     }
 
-    pub(super) fn resolve_class_or_interface_members(&self, type_: Rc<Type /*InterfaceType*/>) {
+    pub(super) fn resolve_class_or_interface_members(&self, type_: &Type /*InterfaceType*/) {
         self.resolve_object_type_members(
-            type_.clone(),
-            self.resolve_declared_members(type_),
+            type_,
+            &self.resolve_declared_members(type_),
             vec![],
             vec![],
         );
@@ -543,7 +548,7 @@ impl TypeChecker {
 
     pub(super) fn resolve_structured_type_members(
         &self,
-        type_: Rc<Type /*StructuredType*/>,
+        type_: &Type, /*StructuredType*/
     ) -> Rc<Type /*ResolvedType*/> {
         if !type_.as_resolvable_type().is_resolved() {
             if let Type::ObjectType(object_type) = &*type_
@@ -553,12 +558,12 @@ impl TypeChecker {
                     .object_flags()
                     .intersects(ObjectFlags::Reference)
                 {
-                    self.resolve_type_reference_members(type_.clone());
+                    self.resolve_type_reference_members(type_);
                 } else if object_type
                     .object_flags()
                     .intersects(ObjectFlags::ClassOrInterface)
                 {
-                    self.resolve_class_or_interface_members(type_.clone());
+                    self.resolve_class_or_interface_members(type_);
                 } else {
                     unimplemented!()
                 }
@@ -566,10 +571,10 @@ impl TypeChecker {
                 unimplemented!()
             }
         }
-        type_
+        type_.type_wrapper()
     }
 
-    pub(super) fn get_properties_of_object_type(&self, type_: Rc<Type>) -> Vec<Rc<Symbol>> {
+    pub(super) fn get_properties_of_object_type(&self, type_: &Type) -> Vec<Rc<Symbol>> {
         if type_.flags().intersects(TypeFlags::Object) {
             return self
                 .resolve_structured_type_members(type_)
@@ -584,7 +589,7 @@ impl TypeChecker {
 
     pub(super) fn get_property_of_object_type(
         &self,
-        type_: Rc<Type>,
+        type_: &Type,
         name: &__String,
     ) -> Option<Rc<Symbol>> {
         if type_.flags().intersects(TypeFlags::Object) {
@@ -602,12 +607,12 @@ impl TypeChecker {
         None
     }
 
-    pub(super) fn get_properties_of_type(&self, type_: Rc<Type>) -> Vec<Rc<Symbol>> {
+    pub(super) fn get_properties_of_type(&self, type_: &Type) -> Vec<Rc<Symbol>> {
         let type_ = self.get_reduced_apparent_type(type_);
         if type_.flags().intersects(TypeFlags::UnionOrIntersection) {
             unimplemented!()
         } else {
-            self.get_properties_of_object_type(type_)
+            self.get_properties_of_object_type(&type_)
         }
     }
 }

--- a/src/compiler/checker/lines_8000_12000.rs
+++ b/src/compiler/checker/lines_8000_12000.rs
@@ -326,13 +326,13 @@ impl TypeChecker {
                     )),
                     outer_type_parameters,
                     local_type_parameters,
-                    Some(Rc::new(this_type.into())),
+                    Some(this_type.into()),
                 )
             } else {
                 BaseInterfaceType::new(type_, None, None, None, None)
             }
             .into();
-            let type_rc = Rc::new(type_.into());
+            let type_rc: Rc<Type> = type_.into();
             match &*type_rc {
                 Type::ObjectType(ObjectType::InterfaceType(InterfaceType::BaseInterfaceType(
                     base_interface_type,
@@ -360,7 +360,7 @@ impl TypeChecker {
         let links = self.get_symbol_links(&symbol);
         let mut links = links.borrow_mut();
         if links.declared_type.is_none() {
-            links.declared_type = Some(Rc::new(self.create_type_parameter(Some(symbol)).into()));
+            links.declared_type = Some(self.create_type_parameter(Some(symbol)).into());
         }
         links.declared_type.clone().unwrap()
     }


### PR DESCRIPTION
In this PR:
- now that `.type_wrapper()` exists, update function parameters to be `&Type` instead of `Rc<Type>`

To test:
Behavior should still be the same as of #32 

Based on `type-type-macro`