### PR TITLE
Pass symbol references as function parameters

### DIFF
--- a/src/compiler/binder.rs
+++ b/src/compiler/binder.rs
@@ -199,7 +199,7 @@ impl BinderType {
             None => unimplemented!(),
             Some(name) => {
                 if true {
-                    symbol = Some(Rc::new(self.create_symbol(SymbolFlags::None, name.clone())));
+                    symbol = Some(self.create_symbol(SymbolFlags::None, name.clone()).wrap());
                     symbol_table.insert(name, symbol.as_ref().unwrap().clone());
                 }
             }
@@ -380,7 +380,7 @@ impl BinderType {
         symbol_flags: SymbolFlags,
         name: __String,
     ) -> Rc<Symbol> {
-        let symbol = Rc::new(self.create_symbol(symbol_flags, name));
+        let symbol = self.create_symbol(symbol_flags, name).wrap();
         match &*self.file() {
             Node::SourceFile(source_file) => {
                 source_file.keep_strong_reference_to_symbol(symbol.clone());

--- a/src/compiler/checker/lines_0_1000.rs
+++ b/src/compiler/checker/lines_0_1000.rs
@@ -151,7 +151,7 @@ pub fn create_type_checker<TTypeCheckerHost: TypeCheckerHost>(
 
         assignable_relation: HashMap::new(),
     };
-    type_checker.unknown_symbol = Some(Rc::new(
+    type_checker.unknown_symbol = Some(
         type_checker
             .create_symbol(
                 SymbolFlags::Property,
@@ -159,7 +159,7 @@ pub fn create_type_checker<TTypeCheckerHost: TypeCheckerHost>(
                 None,
             )
             .into(),
-    ));
+    );
     type_checker.any_type = Some(
         type_checker
             .create_intrinsic_type(TypeFlags::Any, "any")

--- a/src/compiler/checker/lines_16000_18000.rs
+++ b/src/compiler/checker/lines_16000_18000.rs
@@ -324,7 +324,7 @@ impl TypeChecker {
         if let Some(value_declaration) = &*symbol.maybe_value_declaration() {
             result.set_value_declaration(value_declaration.upgrade().unwrap());
         }
-        Rc::new(result.into())
+        result.into()
     }
 
     pub(super) fn instantiate_type<TTypeRef: Borrow<Type>>(

--- a/src/compiler/checker/lines_16000_18000.rs
+++ b/src/compiler/checker/lines_16000_18000.rs
@@ -288,11 +288,8 @@ impl TypeChecker {
         }
     }
 
-    pub(super) fn instantiate_symbol(
-        &self,
-        mut symbol: Rc<Symbol>,
-        mapper: &TypeMapper,
-    ) -> Rc<Symbol> {
+    pub(super) fn instantiate_symbol(&self, symbol: &Symbol, mapper: &TypeMapper) -> Rc<Symbol> {
+        let mut symbol = symbol.symbol_wrapper();
         let links = self.get_symbol_links(&symbol);
         let links = (*links).borrow();
         if let Some(type_) = links.type_.as_ref() {
@@ -337,17 +334,22 @@ impl TypeChecker {
     ) -> Option<Rc<Type>> {
         if let Some(type_) = type_.as_ref() {
             if let Some(mapper) = mapper {
-                return Some(self.instantiate_type_with_alias(type_.borrow(), mapper, None, None));
+                return Some(self.instantiate_type_with_alias(
+                    type_.borrow(),
+                    mapper,
+                    Option::<&Symbol>::None,
+                    None,
+                ));
             }
         }
         type_.map(|type_| type_.borrow().type_wrapper())
     }
 
-    pub(super) fn instantiate_type_with_alias(
+    pub(super) fn instantiate_type_with_alias<TSymbolRef: Borrow<Symbol>>(
         &self,
         type_: &Type,
         mapper: &TypeMapper,
-        alias_symbol: Option<Rc<Symbol>>,
+        alias_symbol: Option<TSymbolRef>,
         alias_type_arguments: Option<&[Rc<Type>]>,
     ) -> Rc<Type> {
         let result =
@@ -355,11 +357,11 @@ impl TypeChecker {
         result
     }
 
-    pub(super) fn instantiate_type_worker(
+    pub(super) fn instantiate_type_worker<TSymbolRef: Borrow<Symbol>>(
         &self,
         type_: &Type,
         mapper: &TypeMapper,
-        alias_symbol: Option<Rc<Symbol>>,
+        alias_symbol: Option<TSymbolRef>,
         alias_type_arguments: Option<&[Rc<Type>]>,
     ) -> Rc<Type> {
         let flags = type_.flags();
@@ -555,7 +557,7 @@ impl TypeChecker {
             .iter()
             .flat_map(|prop| {
                 let type_ = self.get_literal_type_from_property(
-                    self.get_symbol_of_node(&**prop).unwrap(),
+                    &self.get_symbol_of_node(&**prop).unwrap(),
                     TypeFlags::StringOrNumberLiteralOrUnique,
                     None,
                 );

--- a/src/compiler/checker/lines_18000_20000.rs
+++ b/src/compiler/checker/lines_18000_20000.rs
@@ -253,7 +253,7 @@ impl<'type_checker> CheckTypeRelatedTo<'type_checker> {
         let is_comparing_jsx_attributes = false;
         let reduced_target = target;
         for prop in self.type_checker.get_properties_of_type(source) {
-            if self.should_check_as_excess_property(prop.clone(), source.symbol()) && true {
+            if self.should_check_as_excess_property(&prop, &source.symbol()) && true {
                 if !self.type_checker.is_known_property(
                     reduced_target,
                     prop.escaped_name(),
@@ -286,7 +286,7 @@ impl<'type_checker> CheckTypeRelatedTo<'type_checker> {
                             } else {
                                 self.report_error(
                                     &Diagnostics::Object_literal_may_only_specify_known_properties_and_0_does_not_exist_in_type_1,
-                                    Some(vec![self.type_checker.symbol_to_string(prop, None, None, None, None), self.type_checker.type_to_string(&error_target, Option::<&Node>::None, None)])
+                                    Some(vec![self.type_checker.symbol_to_string(&prop, None, None, None, None), self.type_checker.type_to_string(&error_target, Option::<&Node>::None, None)])
                                 );
                             }
                         }
@@ -298,7 +298,7 @@ impl<'type_checker> CheckTypeRelatedTo<'type_checker> {
         false
     }
 
-    fn should_check_as_excess_property(&self, prop: Rc<Symbol>, container: Rc<Symbol>) -> bool {
+    fn should_check_as_excess_property(&self, prop: &Symbol, container: &Symbol) -> bool {
         if let Some(prop_value_declaration) = prop.maybe_value_declaration().as_ref() {
             if let Some(container_value_declaration) = container.maybe_value_declaration().as_ref()
             {
@@ -480,9 +480,9 @@ impl<'type_checker> CheckTypeRelatedTo<'type_checker> {
 
     fn is_property_symbol_type_related(
         &self,
-        source_prop: Rc<Symbol>,
-        target_prop: Rc<Symbol>,
-        get_type_of_source_property: fn(&TypeChecker, Rc<Symbol>) -> Rc<Type>,
+        source_prop: &Symbol,
+        target_prop: &Symbol,
+        get_type_of_source_property: fn(&TypeChecker, &Symbol) -> Rc<Type>,
         report_errors: bool,
         intersection_state: IntersectionState,
     ) -> Ternary {
@@ -509,16 +509,16 @@ impl<'type_checker> CheckTypeRelatedTo<'type_checker> {
         &self,
         source: &Type,
         target: &Type,
-        source_prop: Rc<Symbol>,
-        target_prop: Rc<Symbol>,
-        get_type_of_source_property: fn(&TypeChecker, Rc<Symbol>) -> Rc<Type>,
+        source_prop: &Symbol,
+        target_prop: &Symbol,
+        get_type_of_source_property: fn(&TypeChecker, &Symbol) -> Rc<Type>,
         report_errors: bool,
         intersection_state: IntersectionState,
         skip_optional: bool,
     ) -> Ternary {
         let related = self.is_property_symbol_type_related(
             source_prop,
-            target_prop.clone(),
+            target_prop,
             get_type_of_source_property,
             report_errors,
             intersection_state,
@@ -574,8 +574,8 @@ impl<'type_checker> CheckTypeRelatedTo<'type_checker> {
                         let related = self.property_related_to(
                             source,
                             target,
-                            source_prop,
-                            target_prop,
+                            &source_prop,
+                            &target_prop,
                             TypeChecker::get_non_missing_type_of_symbol,
                             report_errors,
                             intersection_state,

--- a/src/compiler/checker/lines_2000_4000.rs
+++ b/src/compiler/checker/lines_2000_4000.rs
@@ -1,5 +1,6 @@
 #![allow(non_upper_case_globals)]
 
+use std::borrow::Borrow;
 use std::rc::Rc;
 
 use crate::{
@@ -8,7 +9,7 @@ use crate::{
 };
 
 impl TypeChecker {
-    pub(super) fn resolve_alias(&self, symbol: Rc<Symbol>) -> Rc<Symbol> {
+    pub(super) fn resolve_alias(&self, symbol: &Symbol) -> Rc<Symbol> {
         unimplemented!()
     }
 
@@ -61,12 +62,15 @@ impl TypeChecker {
         if symbol.flags().intersects(meaning) || dont_resolve_alias {
             Some(symbol)
         } else {
-            Some(self.resolve_alias(symbol))
+            Some(self.resolve_alias(&symbol))
         }
     }
 
-    pub(super) fn get_merged_symbol(&self, symbol: Option<Rc<Symbol>>) -> Option<Rc<Symbol>> {
-        symbol
+    pub(super) fn get_merged_symbol<TSymbolRef: Borrow<Symbol>>(
+        &self,
+        symbol: Option<TSymbolRef>,
+    ) -> Option<Rc<Symbol>> {
+        symbol.map(|symbol| symbol.borrow().symbol_wrapper())
     }
 
     pub(super) fn get_symbol_of_node<TNode: NodeInterface>(

--- a/src/compiler/checker/lines_24000_32000.rs
+++ b/src/compiler/checker/lines_24000_32000.rs
@@ -211,7 +211,7 @@ impl TypeChecker {
 
         let create_object_literal_type = || {
             let result =
-                self.create_anonymous_type(node.symbol(), Rc::new(RefCell::new(properties_table)));
+                self.create_anonymous_type(&node.symbol(), Rc::new(RefCell::new(properties_table)));
             result.set_object_flags(
                 result.object_flags()
                     | object_flags

--- a/src/compiler/emitter.rs
+++ b/src/compiler/emitter.rs
@@ -181,7 +181,7 @@ impl Printer {
     fn emit_identifier(&self, node: &Identifier) {
         let text_of_node = self.get_text_of_node(node, Some(false));
         if let Some(symbol) = node.maybe_symbol() {
-            self.write_symbol(&text_of_node, symbol);
+            self.write_symbol(&text_of_node, &symbol);
         } else {
             (self.write)(self, &text_of_node);
         }
@@ -336,8 +336,8 @@ impl Printer {
         self.writer_().write_string_literal(s);
     }
 
-    fn write_symbol(&self, s: &str, sym: Rc<Symbol>) {
-        self.writer_().write_symbol(s, &*sym);
+    fn write_symbol(&self, s: &str, sym: &Symbol) {
+        self.writer_().write_symbol(s, sym);
     }
 
     fn write_punctuation(&self, s: &str) {

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -1464,6 +1464,14 @@ pub enum Symbol {
     TransientSymbol(TransientSymbol),
 }
 
+impl Symbol {
+    pub fn wrap(self) -> Rc<Symbol> {
+        let rc = Rc::new(self);
+        rc.set_symbol_wrapper(rc.clone());
+        rc
+    }
+}
+
 #[derive(Debug)]
 pub struct BaseSymbol {
     _symbol_wrapper: RefCell<Option<Weak<Symbol>>>,

--- a/src/compiler/utilities.rs
+++ b/src/compiler/utilities.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 pub fn get_declaration_of_kind(
-    symbol: Rc<Symbol>,
+    symbol: &Symbol,
     kind: SyntaxKind,
 ) -> Option<Rc<Node /*T extends Declaration*/>> {
     let maybe_declarations = symbol.maybe_declarations();


### PR DESCRIPTION
In this PR:
- now that `.symbol_wrapper()` exists, update function parameters to be `&Symbol` instead of `Rc<Symbol>`

To test:
Behavior should still be the same as of #32 

Based on `symbol-type-macro`