### PR TITLE
Type error for unknown variable reference

### DIFF
--- a/src/compiler/checker/lines_0_1000.rs
+++ b/src/compiler/checker/lines_0_1000.rs
@@ -132,6 +132,7 @@ pub fn create_type_checker<TTypeCheckerHost: TypeCheckerHost>(
         unknown_symbol: None,
 
         any_type: None,
+        error_type: None,
         number_type: None,
         bigint_type: None,
         true_type: None,
@@ -150,6 +151,7 @@ pub fn create_type_checker<TTypeCheckerHost: TypeCheckerHost>(
         diagnostics: RefCell::new(create_diagnostic_collection()),
 
         assignable_relation: HashMap::new(),
+        comparable_relation: HashMap::new(),
     };
     type_checker.unknown_symbol = Some(
         type_checker
@@ -163,6 +165,11 @@ pub fn create_type_checker<TTypeCheckerHost: TypeCheckerHost>(
     type_checker.any_type = Some(
         type_checker
             .create_intrinsic_type(TypeFlags::Any, "any")
+            .into(),
+    );
+    type_checker.error_type = Some(
+        type_checker
+            .create_intrinsic_type(TypeFlags::Any, "error")
             .into(),
     );
     type_checker.number_type = Some(
@@ -308,6 +315,10 @@ impl TypeChecker {
 
     pub(super) fn any_type(&self) -> Rc<Type> {
         self.any_type.as_ref().unwrap().clone()
+    }
+
+    pub(super) fn error_type(&self) -> Rc<Type> {
+        self.error_type.as_ref().unwrap().clone()
     }
 
     pub(super) fn number_type(&self) -> Rc<Type> {

--- a/src/compiler/checker/lines_16000_18000.rs
+++ b/src/compiler/checker/lines_16000_18000.rs
@@ -609,6 +609,13 @@ impl TypeChecker {
         if s.intersects(TypeFlags::NumberLike) && t.intersects(TypeFlags::Number) {
             return true;
         }
+        if ptr::eq(relation, &self.assignable_relation)
+            || ptr::eq(relation, &self.comparable_relation)
+        {
+            if s.intersects(TypeFlags::Any) {
+                return true;
+            }
+        }
         false
     }
 

--- a/src/compiler/checker/lines_2000_4000.rs
+++ b/src/compiler/checker/lines_2000_4000.rs
@@ -3,12 +3,21 @@
 use std::borrow::Borrow;
 use std::rc::Rc;
 
+use super::ResolveNameNameArg;
 use crate::{
-    get_first_identifier, node_is_missing, Debug_, Expression, Node, NodeInterface, Symbol,
-    SymbolFlags, SymbolInterface, TypeChecker,
+    declaration_name_to_string, get_first_identifier, node_is_missing,
+    unescape_leading_underscores, Debug_, Expression, Node, NodeInterface, Symbol, SymbolFlags,
+    SymbolInterface, TypeChecker,
 };
 
 impl TypeChecker {
+    pub(super) fn diagnostic_name(&self, name_arg: ResolveNameNameArg) -> String {
+        match name_arg {
+            ResolveNameNameArg::__String(__string) => unescape_leading_underscores(&__string),
+            ResolveNameNameArg::Node(node) => declaration_name_to_string(Some(&*node)),
+        }
+    }
+
     pub(super) fn resolve_alias(&self, symbol: &Symbol) -> Rc<Symbol> {
         unimplemented!()
     }

--- a/src/compiler/checker/lines_24000_32000.rs
+++ b/src/compiler/checker/lines_24000_32000.rs
@@ -20,6 +20,9 @@ impl TypeChecker {
         check_mode: Option<CheckMode>,
     ) -> Rc<Type> {
         let symbol = self.get_resolved_symbol(node);
+        if Rc::ptr_eq(&symbol, &self.unknown_symbol()) {
+            return self.error_type();
+        }
 
         let local_or_export_symbol = self
             .get_export_symbol_of_value_symbol_if_exported(Some(symbol))

--- a/src/compiler/checker/lines_32000_40000.rs
+++ b/src/compiler/checker/lines_32000_40000.rs
@@ -23,7 +23,7 @@ impl TypeChecker {
         diagnostic: &DiagnosticMessage,
     ) -> bool {
         if !self.is_type_assignable_to(type_, &self.number_or_big_int_type()) {
-            self.error_and_maybe_suggest_await(operand, diagnostic);
+            self.error_and_maybe_suggest_await(operand, diagnostic, None);
             return false;
         }
         true
@@ -269,8 +269,9 @@ impl TypeChecker {
     pub(super) fn check_property_signature(&mut self, node: &PropertySignature) {
         if is_private_identifier(&*node.name()) {
             self.error(
-                Some(node),
+                Some(node.node_wrapper()),
                 &Diagnostics::Private_identifiers_are_not_allowed_outside_class_bodies,
+                None,
             );
         }
         self.check_property_declaration(node)

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -1295,6 +1295,7 @@ pub struct TypeChecker {
     pub number_literal_types: RefCell<HashMap<Number, Rc</*NumberLiteralType*/ Type>>>,
     pub unknown_symbol: Option<Rc<Symbol>>,
     pub any_type: Option<Rc<Type>>,
+    pub error_type: Option<Rc<Type>>,
     pub number_type: Option<Rc<Type>>,
     pub bigint_type: Option<Rc<Type>>,
     pub true_type: Option<Rc<Type>>,
@@ -1309,6 +1310,7 @@ pub struct TypeChecker {
     pub node_links: RefCell<HashMap<NodeId, Rc<RefCell<NodeLinks>>>>,
     pub diagnostics: RefCell<DiagnosticCollection>,
     pub assignable_relation: HashMap<String, RelationComparisonResult>,
+    pub comparable_relation: HashMap<String, RelationComparisonResult>,
 }
 
 bitflags! {

--- a/src/compiler/utilities.rs
+++ b/src/compiler/utilities.rs
@@ -278,18 +278,20 @@ pub fn declaration_name_to_string<TNode: NodeInterface>(name: Option<&TNode>) ->
 pub fn create_diagnostic_for_node<TNode: NodeInterface>(
     node: &TNode,
     message: &DiagnosticMessage,
+    args: Option<Vec<String>>,
 ) -> DiagnosticWithLocation {
     let source_file = get_source_file_of_node(node);
-    create_diagnostic_for_node_in_source_file(source_file, node, message)
+    create_diagnostic_for_node_in_source_file(source_file, node, message, args)
 }
 
 fn create_diagnostic_for_node_in_source_file<TNode: NodeInterface>(
     source_file: Rc<SourceFile>,
     node: &TNode,
     message: &DiagnosticMessage,
+    args: Option<Vec<String>>,
 ) -> DiagnosticWithLocation {
     let span = get_error_span_for_node(source_file.clone(), node);
-    create_file_diagnostic(source_file, span.start, span.length, message)
+    create_file_diagnostic(source_file, span.start, span.length, message, args)
 }
 
 pub fn create_diagnostic_for_node_from_message_chain<TNode: NodeInterface>(
@@ -761,8 +763,15 @@ fn create_file_diagnostic(
     start: isize,
     length: isize,
     message: &DiagnosticMessage,
+    args: Option<Vec<String>>,
 ) -> DiagnosticWithLocation {
-    let text = get_locale_specific_message(message);
+    let mut text = get_locale_specific_message(message);
+
+    if let Some(args) = args {
+        if !args.is_empty() {
+            text = format_string_from_args(&text, args);
+        }
+    }
 
     DiagnosticWithLocation::new(BaseDiagnostic::new(BaseDiagnosticRelatedInformation::new(
         Some(file),


### PR DESCRIPTION
In this PR:
- fix bug where type-checking of non-generic interface variable declarations had stopped working
- flag type error when an unknown variable is referenced

To test:
The testing from #21/#22 should now work again
If you run `cargo run tmp.tsx` against a source file containing eg `++b` you should see a diagnostic debug-logged with message `Cannot find name 'b'.`. The testing from #32 should still work (ie it should still be able to look up an existing variable reference)

Based on `pass-symbol-references`