### PR TITLE
Type-check if-statement

### DIFF
--- a/src/compiler/binder.rs
+++ b/src/compiler/binder.rs
@@ -8,12 +8,12 @@ use std::rc::Rc;
 use crate::{
     Symbol, SymbolTable, SyntaxKind, VariableDeclaration, __String, append_if_unique,
     create_symbol_table, for_each, for_each_child, get_escaped_text_of_identifier_or_literal,
-    get_name_of_declaration, is_binding_pattern, is_class_static_block_declaration,
-    is_function_like, is_property_name_literal, object_allocator, set_parent,
-    set_value_declaration, BaseSymbol, Expression, ExpressionStatement, IfStatement,
-    InternalSymbolName, NamedDeclarationInterface, Node, NodeArray, NodeInterface,
-    ObjectLiteralExpression, PropertySignature, Statement, SymbolFlags, SymbolInterface,
-    TypeElement, TypeParameterDeclaration,
+    get_name_of_declaration, is_binding_pattern, is_block_or_catch_scoped,
+    is_class_static_block_declaration, is_function_like, is_property_name_literal,
+    object_allocator, set_parent, set_value_declaration, BaseSymbol, Expression,
+    ExpressionStatement, IfStatement, InternalSymbolName, NamedDeclarationInterface, Node,
+    NodeArray, NodeInterface, ObjectLiteralExpression, PropertySignature, Statement, SymbolFlags,
+    SymbolInterface, TypeElement, TypeParameterDeclaration,
 };
 
 bitflags! {
@@ -521,6 +521,13 @@ impl BinderType {
     fn bind_variable_declaration_or_binding_element(&self, node: &VariableDeclaration) {
         if !is_binding_pattern(&*node.name()) {
             if false {
+                unimplemented!()
+            } else if is_block_or_catch_scoped(node) {
+                self.bind_block_scoped_declaration(
+                    node,
+                    SymbolFlags::BlockScopedVariable,
+                    SymbolFlags::BlockScopedVariableExcludes,
+                );
             } else {
                 self.declare_symbol_and_add_to_symbol_table(
                     node,

--- a/src/compiler/checker/lines_1000_2000.rs
+++ b/src/compiler/checker/lines_1000_2000.rs
@@ -167,10 +167,20 @@ impl TypeChecker {
         let error_location = location.clone();
 
         while let Some(location_unwrapped) = location {
-            if location_unwrapped.maybe_locals().is_some()
-                && !self.is_global_source_file(&*location_unwrapped)
-            {
-                unimplemented!()
+            let location_maybe_locals = location_unwrapped.maybe_locals();
+            if let Some(location_locals) = &*location_maybe_locals {
+                if !self.is_global_source_file(&*location_unwrapped) {
+                    result = lookup(self, location_locals, name, meaning);
+                    if let Some(result_unwrapped) = result.as_ref() {
+                        let mut use_result = true;
+
+                        if use_result {
+                            break;
+                        } else {
+                            result = None;
+                        }
+                    }
+                }
             }
 
             match location_unwrapped.kind() {

--- a/src/compiler/checker/lines_32000_40000.rs
+++ b/src/compiler/checker/lines_32000_40000.rs
@@ -6,13 +6,14 @@ use std::rc::Rc;
 use super::CheckMode;
 use crate::{
     for_each, get_combined_node_flags, get_effective_initializer, is_binding_element,
-    is_private_identifier, map, maybe_for_each, ArrayTypeNode, DiagnosticMessage, Diagnostics,
-    Expression, ExpressionStatement, HasTypeParametersInterface, IfStatement, InterfaceDeclaration,
-    LiteralLikeNode, LiteralLikeNodeInterface, NamedDeclarationInterface, Node, NodeArray,
-    NodeFlags, NodeInterface, PrefixUnaryExpression, PropertyAssignment, PropertySignature,
-    SymbolInterface, SyntaxKind, Type, TypeChecker, TypeFlags, TypeInterface,
-    TypeParameterDeclaration, TypeReferenceNode, UnionOrIntersectionTypeInterface,
-    VariableDeclaration, VariableLikeDeclarationInterface, VariableStatement,
+    is_function_or_module_block, is_private_identifier, map, maybe_for_each, ArrayTypeNode, Block,
+    DiagnosticMessage, Diagnostics, Expression, ExpressionStatement, HasTypeParametersInterface,
+    IfStatement, InterfaceDeclaration, LiteralLikeNode, LiteralLikeNodeInterface,
+    NamedDeclarationInterface, Node, NodeArray, NodeFlags, NodeInterface, PrefixUnaryExpression,
+    PropertyAssignment, PropertySignature, SymbolInterface, SyntaxKind, Type, TypeChecker,
+    TypeFlags, TypeInterface, TypeParameterDeclaration, TypeReferenceNode,
+    UnionOrIntersectionTypeInterface, VariableDeclaration, VariableLikeDeclarationInterface,
+    VariableStatement,
 };
 
 impl TypeChecker {
@@ -316,6 +317,20 @@ impl TypeChecker {
             },
         );
         self.get_type_from_type_node(node);
+    }
+
+    pub(super) fn check_block(&mut self, node: &Block) {
+        if is_function_or_module_block(node) {
+            for_each(&node.statements, |statement, _| {
+                self.check_source_element(Some(statement.clone()));
+                Option::<()>::None
+            });
+        } else {
+            for_each(&node.statements, |statement, _| {
+                self.check_source_element(Some(statement.clone()));
+                Option::<()>::None
+            });
+        }
     }
 
     pub(super) fn convert_auto_to_any(&self, type_: &Type) -> Rc<Type> {

--- a/src/compiler/checker/lines_32000_40000.rs
+++ b/src/compiler/checker/lines_32000_40000.rs
@@ -7,7 +7,7 @@ use super::CheckMode;
 use crate::{
     for_each, get_combined_node_flags, get_effective_initializer, is_binding_element,
     is_private_identifier, map, maybe_for_each, ArrayTypeNode, DiagnosticMessage, Diagnostics,
-    Expression, ExpressionStatement, HasTypeParametersInterface, InterfaceDeclaration,
+    Expression, ExpressionStatement, HasTypeParametersInterface, IfStatement, InterfaceDeclaration,
     LiteralLikeNode, LiteralLikeNodeInterface, NamedDeclarationInterface, Node, NodeArray,
     NodeFlags, NodeInterface, PrefixUnaryExpression, PropertyAssignment, PropertySignature,
     SymbolInterface, SyntaxKind, Type, TypeChecker, TypeFlags, TypeInterface,
@@ -391,6 +391,51 @@ impl TypeChecker {
             _ => panic!("Expected Expression"),
         };
         self.check_expression(expression, None);
+    }
+
+    pub(super) fn check_if_statement(&mut self, node: &IfStatement) {
+        let type_ = self.check_truthiness_expression(
+            match &*node.expression {
+                Node::Expression(expression) => expression,
+                _ => panic!("Expected expression"),
+            },
+            None,
+        );
+        self.check_source_element(Some(&*node.then_statement));
+
+        if node.then_statement.kind() == SyntaxKind::EmptyStatement {
+            self.error(
+                Some(&*node.then_statement),
+                &Diagnostics::The_body_of_an_if_statement_cannot_be_the_empty_statement,
+                None,
+            );
+        }
+
+        self.check_source_element(node.else_statement.clone());
+    }
+
+    pub(super) fn check_truthiness_of_type<TNode: NodeInterface>(
+        &self,
+        type_: &Type,
+        node: &TNode,
+    ) -> Rc<Type> {
+        if type_.flags().intersects(TypeFlags::Void) {
+            self.error(
+                Some(node.node_wrapper()),
+                &Diagnostics::An_expression_of_type_void_cannot_be_tested_for_truthiness,
+                None,
+            );
+        }
+
+        type_.type_wrapper()
+    }
+
+    pub(super) fn check_truthiness_expression(
+        &self,
+        node: &Expression,
+        check_mode: Option<CheckMode>,
+    ) -> Rc<Type> {
+        self.check_truthiness_of_type(&self.check_expression(node, check_mode), node)
     }
 
     pub(super) fn check_type_parameters(

--- a/src/compiler/checker/lines_40000_end.rs
+++ b/src/compiler/checker/lines_40000_end.rs
@@ -32,6 +32,7 @@ impl TypeChecker {
             Node::TypeNode(TypeNode::UnionTypeNode(_)) => {
                 self.check_union_or_intersection_type(&*node)
             }
+            Node::Statement(Statement::Block(block)) => self.check_block(block),
             Node::Statement(Statement::VariableStatement(variable_statement)) => {
                 self.check_variable_statement(variable_statement)
             }

--- a/src/compiler/checker/lines_40000_end.rs
+++ b/src/compiler/checker/lines_40000_end.rs
@@ -38,6 +38,9 @@ impl TypeChecker {
             Node::Statement(Statement::ExpressionStatement(expression_statement)) => {
                 self.check_expression_statement(expression_statement)
             }
+            Node::Statement(Statement::IfStatement(if_statement)) => {
+                self.check_if_statement(if_statement)
+            }
             Node::VariableDeclaration(variable_declaration) => {
                 self.check_variable_declaration(variable_declaration)
             }

--- a/src/compiler/factory/node_factory.rs
+++ b/src/compiler/factory/node_factory.rs
@@ -493,7 +493,9 @@ impl NodeFactory {
         declarations: TDeclarations,
         flags: Option<NodeFlags>,
     ) -> VariableDeclarationList {
-        let node = self.create_base_node(base_factory, SyntaxKind::VariableDeclarationList);
+        let flags = flags.unwrap_or(NodeFlags::None);
+        let mut node = self.create_base_node(base_factory, SyntaxKind::VariableDeclarationList);
+        node.flags |= flags & NodeFlags::BlockScoped;
         let node = VariableDeclarationList::new(node, self.create_node_array(declarations, None));
         node
     }

--- a/src/compiler/factory/node_tests.rs
+++ b/src/compiler/factory/node_tests.rs
@@ -36,10 +36,22 @@ pub fn is_omitted_expression<TNode: NodeInterface>(node: &TNode) -> bool {
     node.kind() == SyntaxKind::OmittedExpression
 }
 
+pub fn is_block<TNode: NodeInterface>(node: &TNode) -> bool {
+    node.kind() == SyntaxKind::Block
+}
+
 pub fn is_variable_declaration<TNode: NodeInterface>(node: &TNode) -> bool {
     node.kind() == SyntaxKind::VariableDeclaration
 }
 
+pub fn is_module_block<TNode: NodeInterface>(node: &TNode) -> bool {
+    node.kind() == SyntaxKind::ModuleBlock
+}
+
 pub fn is_property_assignment<TNode: NodeInterface>(node: &TNode) -> bool {
     node.kind() == SyntaxKind::PropertyAssignment
+}
+
+pub fn is_source_file<TNode: NodeInterface>(node: &TNode) -> bool {
+    node.kind() == SyntaxKind::SourceFile
 }

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -139,6 +139,8 @@ pub enum SyntaxKind {
     InterfaceDeclaration,
     ModuleBlock,
 
+    CatchClause,
+
     PropertyAssignment,
 
     EnumMember,
@@ -159,10 +161,13 @@ impl SyntaxKind {
 bitflags! {
     pub struct NodeFlags: u32 {
         const None = 0;
+        const Let = 1 << 0;
         const Const = 1 << 1;
         const DisallowInContext = 1 << 12;
         const YieldContext = 1 << 13;
         const AwaitContext = 1 << 15;
+
+        const BlockScoped = Self::Let.bits | Self::Const.bits;
 
         const TypeExcludesFlags = Self::YieldContext.bits | Self::AwaitContext.bits;
     }
@@ -1513,6 +1518,8 @@ bitflags! {
         const Type = Self::Class.bits | Self::Interface.bits | Self::Enum.bits | Self::EnumMember.bits | Self::TypeLiteral.bits | Self::TypeParameter.bits | Self::TypeAlias.bits;
 
         const FunctionScopedVariableExcludes = Self::Value.bits & !Self::FunctionScopedVariable.bits;
+
+        const BlockScopedVariableExcludes = Self::Value.bits;
 
         const PropertyExcludes = Self::None.bits;
         const InterfaceExcludes = Self::Type.bits & !(Self::Interface.bits | Self::Class.bits);

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -137,6 +137,7 @@ pub enum SyntaxKind {
     FunctionDeclaration,
     ClassDeclaration,
     InterfaceDeclaration,
+    ModuleBlock,
 
     PropertyAssignment,
 

--- a/src/compiler/utilities_public.rs
+++ b/src/compiler/utilities_public.rs
@@ -3,6 +3,7 @@ use std::rc::Rc;
 
 use crate::{
     CharacterCodes, Expression, Node, NodeFlags, NodeInterface, SyntaxKind, TextSpan, __String,
+    is_block, is_module_block, is_source_file,
 };
 
 fn create_text_span(start: isize, length: isize) -> TextSpan {
@@ -135,6 +136,12 @@ fn is_function_like_kind(kind: SyntaxKind) -> bool {
         | SyntaxKind::ConstructorType => true,
         _ => is_function_like_declaration_kind(kind),
     }
+}
+
+pub fn is_function_or_module_block<TNode: NodeInterface>(node: &TNode) -> bool {
+    is_source_file(node)
+        || is_module_block(node)
+        || is_block(node) && is_function_like(node.maybe_parent())
 }
 
 pub fn is_binding_pattern<TNode: NodeInterface>(node: &TNode) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,10 +75,10 @@ pub use compiler::utilities::{
     get_check_flags, get_declaration_of_kind, get_effective_initializer,
     get_effective_type_annotation_node, get_escaped_text_of_identifier_or_literal,
     get_first_identifier, get_literal_text, get_object_flags, get_source_file_of_node,
-    has_dynamic_name, is_external_or_common_js_module, is_keyword, is_property_name_literal,
-    is_write_only_access, node_is_missing, object_allocator, position_is_synthesized, set_parent,
-    set_text_range_pos_end, set_value_declaration, using_single_line_string_writer,
-    GetLiteralTextFlags, OperatorPrecedence,
+    has_dynamic_name, is_block_or_catch_scoped, is_external_or_common_js_module, is_keyword,
+    is_property_name_literal, is_write_only_access, node_is_missing, object_allocator,
+    position_is_synthesized, set_parent, set_text_range_pos_end, set_value_declaration,
+    using_single_line_string_writer, GetLiteralTextFlags, OperatorPrecedence,
 };
 pub use compiler::utilities_public::{
     create_text_span_from_bounds, escape_leading_underscores, get_combined_node_flags,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,10 +23,10 @@ pub use compiler::factory::node_factory::{
     create_node_factory, factory, get_synthetic_factory, BaseNodeFactorySynthetic,
 };
 pub use compiler::factory::node_tests::{
-    is_big_int_literal, is_binding_element, is_class_static_block_declaration, is_identifier,
-    is_object_literal_expression, is_omitted_expression, is_private_identifier,
-    is_property_assignment, is_property_declaration, is_property_signature,
-    is_variable_declaration,
+    is_big_int_literal, is_binding_element, is_block, is_class_static_block_declaration,
+    is_identifier, is_module_block, is_object_literal_expression, is_omitted_expression,
+    is_private_identifier, is_property_assignment, is_property_declaration, is_property_signature,
+    is_source_file, is_variable_declaration,
 };
 pub use compiler::parser::{create_source_file, for_each_child};
 pub use compiler::path::{normalize_path, to_path};
@@ -84,7 +84,7 @@ pub use compiler::utilities_public::{
     create_text_span_from_bounds, escape_leading_underscores, get_combined_node_flags,
     get_effective_type_parameter_declarations, get_name_of_declaration, has_initializer,
     has_only_expression_initializer, id_text, is_binding_pattern, is_expression, is_function_like,
-    is_member_name, unescape_leading_underscores,
+    is_function_or_module_block, is_member_name, unescape_leading_underscores,
 };
 pub use compiler::watch::emit_files_and_report_errors_and_get_exit_status;
 pub use execute_command_line::execute_command_line::execute_command_line;


### PR DESCRIPTION
In this PR:
- type-check `if`/`else` statement, flagging attempt to use a variable outside of its declared scope

To test:
If you run `cargo run tmp.tsx` against a source file containing eg:
```
if (true) {
    const a = 1;
} else {
    const b = 2;
}

++a
```
then you should see a diagnostic debug-logged with message `Cannot find name 'a'.`

If you run `cargo run tmp.tsx` against a source file containing eg:
```
if (true) {
    const a = 1;
    ++a
} else {
    const b = 2;
}
```
then you shouldn't see any diagnostics debug-logged

Based on `parse-if-statement`