### PR TITLE
enum_unwrapped!() macro

### DIFF
--- a/local-macros/src/lib.rs
+++ b/local-macros/src/lib.rs
@@ -1394,7 +1394,26 @@ pub fn symbol_type(attr: TokenStream, item: TokenStream) -> TokenStream {
     .into()
 }
 
-fn get_enum_unwrapped_match(argument: &Expr, ancestors: &[Ident]) -> TokenStream2 {}
+fn get_enum_unwrapped_match(argument: &Expr, ancestors: &[Ident]) -> TokenStream2 {
+    let mut unwrapped_variant_selector = quote! {
+        unwrapped
+    };
+    for (index, ancestor) in ancestors.iter().skip(1).rev().enumerate() {
+        let previous_ancestor = &ancestors[ancestors.len() - 2 - index];
+        unwrapped_variant_selector = quote! {
+            crate::#previous_ancestor::#ancestor(#unwrapped_variant_selector)
+        }
+    }
+
+    let last_variant = ancestors.last().unwrap();
+
+    quote! {
+        match #argument {
+            #unwrapped_variant_selector => unwrapped,
+            _ => panic!("Expected {}", stringify!(#last_variant)),
+        }
+    }
+}
 
 fn expr_to_ident(expr: &Expr) -> Result<Ident> {
     match expr {
@@ -1439,7 +1458,7 @@ pub fn enum_unwrapped(input: TokenStream) -> TokenStream {
         ancestors,
     } = parse_macro_input!(input as EnumUnwrapped);
 
-    let mut enum_match = get_enum_unwrapped_match(&argument, &ancestors);
+    let enum_match = get_enum_unwrapped_match(&argument, &ancestors);
 
     quote! {
         (#enum_match)

--- a/local-macros/src/lib.rs
+++ b/local-macros/src/lib.rs
@@ -1461,7 +1461,7 @@ pub fn enum_unwrapped(input: TokenStream) -> TokenStream {
     let enum_match = get_enum_unwrapped_match(&argument, &ancestors);
 
     quote! {
-        (#enum_match)
+        #enum_match
     }
     .into()
 }

--- a/src/compiler/binder.rs
+++ b/src/compiler/binder.rs
@@ -15,6 +15,7 @@ use crate::{
     NodeArray, NodeInterface, ObjectLiteralExpression, PropertySignature, Statement, SymbolFlags,
     SymbolInterface, TypeElement, TypeParameterDeclaration,
 };
+use local_macros::enum_unwrapped;
 
 bitflags! {
     struct ContainerFlags: u32 {
@@ -420,12 +421,8 @@ impl BinderType {
         name: __String,
     ) -> Rc<Symbol> {
         let symbol = self.create_symbol(symbol_flags, name).wrap();
-        match &*self.file() {
-            Node::SourceFile(source_file) => {
-                source_file.keep_strong_reference_to_symbol(symbol.clone());
-            }
-            _ => panic!("Expected SourceFile"),
-        }
+        enum_unwrapped!(&*self.file(), [Node, SourceFile])
+            .keep_strong_reference_to_symbol(symbol.clone());
         self.add_declaration_to_symbol(&symbol, node, symbol_flags);
         symbol
     }

--- a/src/compiler/checker/lines_0_1000.rs
+++ b/src/compiler/checker/lines_0_1000.rs
@@ -12,6 +12,7 @@ use crate::{
     ObjectFlags, Symbol, SymbolFlags, SymbolId, SymbolInterface, SymbolTable, Type, TypeChecker,
     TypeCheckerHost, TypeFlags,
 };
+use local_macros::enum_unwrapped;
 
 thread_local! {
     pub(super) static next_symbol_id: RefCell<SymbolId> = RefCell::new(1);
@@ -191,33 +192,25 @@ pub fn create_type_checker<TTypeCheckerHost: TypeCheckerHost>(
         type_checker.create_intrinsic_type(TypeFlags::BooleanLiteral, "true"),
     )
     .into();
-    match &*true_type {
-        Type::IntrinsicType(intrinsic_type) => match intrinsic_type {
-            IntrinsicType::FreshableIntrinsicType(freshable_intrinsic_type) => {
-                freshable_intrinsic_type
-                    .regular_type
-                    .init(&regular_true_type, false);
-                freshable_intrinsic_type.fresh_type.init(&true_type, false);
-            }
-            _ => panic!("Expected FreshableIntrinsicType"),
-        },
-        _ => panic!("Expected IntrinsicType"),
-    }
+    let true_type_as_freshable_intrinsic_type =
+        enum_unwrapped!(&*true_type, [Type, IntrinsicType, FreshableIntrinsicType]);
+    true_type_as_freshable_intrinsic_type
+        .regular_type
+        .init(&regular_true_type, false);
+    true_type_as_freshable_intrinsic_type
+        .fresh_type
+        .init(&true_type, false);
     type_checker.true_type = Some(true_type);
-    match &*regular_true_type {
-        Type::IntrinsicType(intrinsic_type) => match intrinsic_type {
-            IntrinsicType::FreshableIntrinsicType(freshable_intrinsic_type) => {
-                freshable_intrinsic_type
-                    .regular_type
-                    .init(&regular_true_type, false);
-                freshable_intrinsic_type
-                    .fresh_type
-                    .init(type_checker.true_type.as_ref().unwrap(), false);
-            }
-            _ => panic!("Expected FreshableIntrinsicType"),
-        },
-        _ => panic!("Expected IntrinsicType"),
-    }
+    let regular_true_type_as_freshable_intrinsic_type = enum_unwrapped!(
+        &*regular_true_type,
+        [Type, IntrinsicType, FreshableIntrinsicType]
+    );
+    regular_true_type_as_freshable_intrinsic_type
+        .regular_type
+        .init(&regular_true_type, false);
+    regular_true_type_as_freshable_intrinsic_type
+        .fresh_type
+        .init(type_checker.true_type.as_ref().unwrap(), false);
     type_checker.regular_true_type = Some(regular_true_type);
     let false_type: Rc<Type> = FreshableIntrinsicType::new(
         type_checker.create_intrinsic_type(TypeFlags::BooleanLiteral, "false"),
@@ -227,33 +220,25 @@ pub fn create_type_checker<TTypeCheckerHost: TypeCheckerHost>(
         type_checker.create_intrinsic_type(TypeFlags::BooleanLiteral, "false"),
     )
     .into();
-    match &*false_type {
-        Type::IntrinsicType(intrinsic_type) => match intrinsic_type {
-            IntrinsicType::FreshableIntrinsicType(freshable_intrinsic_type) => {
-                freshable_intrinsic_type
-                    .regular_type
-                    .init(&regular_false_type, false);
-                freshable_intrinsic_type.fresh_type.init(&false_type, false);
-            }
-            _ => panic!("Expected FreshableIntrinsicType"),
-        },
-        _ => panic!("Expected IntrinsicType"),
-    }
+    let false_type_as_freshable_intrinsic_type =
+        enum_unwrapped!(&*false_type, [Type, IntrinsicType, FreshableIntrinsicType]);
+    false_type_as_freshable_intrinsic_type
+        .regular_type
+        .init(&regular_false_type, false);
+    false_type_as_freshable_intrinsic_type
+        .fresh_type
+        .init(&false_type, false);
     type_checker.false_type = Some(false_type);
-    match &*regular_false_type {
-        Type::IntrinsicType(intrinsic_type) => match intrinsic_type {
-            IntrinsicType::FreshableIntrinsicType(freshable_intrinsic_type) => {
-                freshable_intrinsic_type
-                    .regular_type
-                    .init(&regular_false_type, false);
-                freshable_intrinsic_type
-                    .fresh_type
-                    .init(type_checker.false_type.as_ref().unwrap(), false);
-            }
-            _ => panic!("Expected FreshableIntrinsicType"),
-        },
-        _ => panic!("Expected IntrinsicType"),
-    }
+    let regular_false_type_as_freshable_intrinsic_type = enum_unwrapped!(
+        &*regular_false_type,
+        [Type, IntrinsicType, FreshableIntrinsicType]
+    );
+    regular_false_type_as_freshable_intrinsic_type
+        .regular_type
+        .init(&regular_false_type, false);
+    regular_false_type_as_freshable_intrinsic_type
+        .fresh_type
+        .init(type_checker.false_type.as_ref().unwrap(), false);
     type_checker.regular_false_type = Some(regular_false_type);
     type_checker.boolean_type = Some(type_checker.get_union_type(
         vec![

--- a/src/compiler/checker/lines_12000_16000.rs
+++ b/src/compiler/checker/lines_12000_16000.rs
@@ -13,6 +13,7 @@ use crate::{
     SymbolInterface, SyntaxKind, Type, TypeChecker, TypeFlags, TypeId, TypeInterface, TypeNode,
     TypeReference, TypeReferenceNode, UnionReduction, UnionTypeNode,
 };
+use local_macros::enum_unwrapped;
 
 impl TypeChecker {
     pub(super) fn get_apparent_type(&self, type_: &Type) -> Rc<Type> {
@@ -105,12 +106,10 @@ impl TypeChecker {
                 None => vec![],
                 Some(node) => match &**node {
                     Node::TypeNode(TypeNode::TypeReferenceNode(type_reference_node)) => {
-                        let target_as_base_interface_type = match &*type_.target {
-                            Type::ObjectType(ObjectType::InterfaceType(
-                                InterfaceType::BaseInterfaceType(base_interface_type),
-                            )) => base_interface_type,
-                            _ => panic!("Expected BaseInterfaceType"),
-                        };
+                        let target_as_base_interface_type = enum_unwrapped!(
+                            &*type_.target,
+                            [Type, ObjectType, InterfaceType, BaseInterfaceType]
+                        );
                         concatenate(
                             target_as_base_interface_type
                                 .outer_type_parameters
@@ -149,12 +148,10 @@ impl TypeChecker {
     ) -> Rc<Type> {
         let type_ =
             self.get_declared_type_of_symbol(&self.get_merged_symbol(Some(symbol)).unwrap());
-        let type_as_interface_type = match &*type_ {
-            Type::ObjectType(ObjectType::InterfaceType(InterfaceType::BaseInterfaceType(
-                base_interface_type,
-            ))) => base_interface_type,
-            _ => panic!("Expected BaseInterfaceType"),
-        };
+        let type_as_interface_type = enum_unwrapped!(
+            &*type_,
+            [Type, ObjectType, InterfaceType, BaseInterfaceType]
+        );
         let type_parameters = type_as_interface_type.type_parameters.as_ref();
         if let Some(type_parameters) = type_parameters {
             let type_arguments = concatenate(

--- a/src/compiler/checker/lines_16000_18000.rs
+++ b/src/compiler/checker/lines_16000_18000.rs
@@ -14,6 +14,7 @@ use crate::{
     SymbolInterface, SyntaxKind, TransientSymbolInterface, Type, TypeChecker, TypeFlags,
     TypeInterface, TypeMapper, TypeNode, UnionOrIntersectionType,
 };
+use local_macros::enum_unwrapped;
 
 impl TypeChecker {
     // pub fn create_literal_type(

--- a/src/compiler/checker/lines_16000_18000.rs
+++ b/src/compiler/checker/lines_16000_18000.rs
@@ -26,16 +26,13 @@ impl TypeChecker {
         let type_ = self.create_type(flags);
         let type_ = BaseLiteralType::new(type_);
         let type_: Rc<Type> = StringLiteralType::new(type_, value).into();
-        match &*type_ {
-            Type::LiteralType(literal_type) => {
-                literal_type.set_regular_type(&if let Some(regular_type) = regular_type {
-                    regular_type.borrow().type_wrapper()
-                } else {
-                    type_.clone()
-                });
-            }
-            _ => panic!("Expected LiteralType"),
-        }
+        enum_unwrapped!(&*type_, [Type, LiteralType]).set_regular_type(
+            &if let Some(regular_type) = regular_type {
+                regular_type.borrow().type_wrapper()
+            } else {
+                type_.clone()
+            },
+        );
         type_
     }
 

--- a/src/compiler/checker/lines_18000_20000.rs
+++ b/src/compiler/checker/lines_18000_20000.rs
@@ -12,6 +12,7 @@ use crate::{
     NodeInterface, ObjectFlags, RelationComparisonResult, Symbol, SymbolInterface, Ternary, Type,
     TypeChecker, TypeFlags, TypeInterface,
 };
+use local_macros::enum_unwrapped;
 
 pub(super) struct CheckTypeRelatedTo<'type_checker> {
     type_checker: &'type_checker TypeChecker,
@@ -424,12 +425,7 @@ impl<'type_checker> CheckTypeRelatedTo<'type_checker> {
                     unimplemented!()
                 } else {
                     self.each_type_related_to_type(
-                        match source {
-                            Type::UnionOrIntersectionType(union_or_intersection_type) => {
-                                union_or_intersection_type
-                            }
-                            _ => panic!("Expected UnionOrIntersectionType"),
-                        },
+                        enum_unwrapped!(source, [Type, UnionOrIntersectionType]),
                         target,
                         report_errors,
                         intersection_state & !IntersectionState::UnionIntersectionCheck,
@@ -439,12 +435,7 @@ impl<'type_checker> CheckTypeRelatedTo<'type_checker> {
             if target.flags().intersects(TypeFlags::Union) {
                 return self.type_related_to_some_type(
                     &self.type_checker.get_regular_type_of_object_literal(source),
-                    match target {
-                        Type::UnionOrIntersectionType(union_or_intersection_type) => {
-                            union_or_intersection_type
-                        }
-                        _ => panic!("Expected UnionOrIntersectionType"),
-                    },
+                    enum_unwrapped!(target, [Type, UnionOrIntersectionType]),
                     report_errors
                         && !(source.flags().intersects(TypeFlags::Primitive))
                         && !(target.flags().intersects(TypeFlags::Primitive)),

--- a/src/compiler/checker/lines_20000_24000.rs
+++ b/src/compiler/checker/lines_20000_24000.rs
@@ -8,6 +8,7 @@ use crate::{
     DiagnosticMessage, Diagnostics, Expression, Identifier, Node, NodeInterface, ObjectFlags,
     Symbol, SymbolFlags, Type, TypeChecker, TypeFlags, TypeInterface, UnionReduction,
 };
+use local_macros::enum_unwrapped;
 
 impl TypeChecker {
     pub(super) fn type_could_have_top_level_singleton_types(&self, type_: &Type) -> bool {
@@ -175,17 +176,14 @@ impl TypeChecker {
         &self,
         node: &Node,
     ) -> DiagnosticMessage {
-        match node {
-            Node::Expression(Expression::Identifier(identifier)) => match identifier.escaped_text {
-                _ => {
-                    if false {
-                        unimplemented!()
-                    } else {
-                        Diagnostics::Cannot_find_name_0
-                    }
+        match enum_unwrapped!(node, [Node, Expression, Identifier]).escaped_text {
+            _ => {
+                if false {
+                    unimplemented!()
+                } else {
+                    Diagnostics::Cannot_find_name_0
                 }
-            },
-            _ => panic!("Expected Identifier"),
+            }
         }
     }
 

--- a/src/compiler/checker/lines_24000_32000.rs
+++ b/src/compiler/checker/lines_24000_32000.rs
@@ -12,6 +12,7 @@ use crate::{
     ObjectLiteralExpression, PropertyAssignment, Symbol, SymbolInterface, SyntaxKind, Type,
     TypeChecker, TypeFlags, TypeInterface,
 };
+use local_macros::enum_unwrapped;
 
 impl TypeChecker {
     pub(super) fn check_identifier(
@@ -51,10 +52,7 @@ impl TypeChecker {
         node: &TNode,
     ) -> Option<Rc<Type>> {
         let parent = node.parent();
-        let declaration = match &*parent {
-            Node::VariableDeclaration(variable_declaration) => variable_declaration,
-            _ => panic!("Expected VariableDeclaration"),
-        };
+        let declaration = enum_unwrapped!(&*parent, [Node, VariableDeclaration]);
         if has_initializer(declaration)
             && Rc::ptr_eq(
                 &node.node_wrapper(),
@@ -105,12 +103,7 @@ impl TypeChecker {
         element: &PropertyAssignment,
     ) -> Option<Rc<Type>> {
         let parent = element.parent();
-        let object_literal = match &*parent {
-            Node::Expression(Expression::ObjectLiteralExpression(object_literal_expression)) => {
-                object_literal_expression
-            }
-            _ => panic!("Expected ObjectLiteralExpression"),
-        };
+        let object_literal = enum_unwrapped!(&*parent, [Node, Expression, ObjectLiteralExpression]);
         // let property_assignment_type = if is_property_assignment(element) {
         // } else {
         //     None

--- a/src/compiler/checker/lines_40000_end.rs
+++ b/src/compiler/checker/lines_40000_end.rs
@@ -7,6 +7,7 @@ use crate::{
     bind_source_file, for_each, is_external_or_common_js_module, Diagnostic, Node, NodeInterface,
     NumericLiteral, SourceFile, Statement, TypeChecker, TypeCheckerHost, TypeElement, TypeNode,
 };
+use local_macros::enum_unwrapped;
 
 impl TypeChecker {
     pub(super) fn check_source_element<TNodeRef: Borrow<Node>>(&mut self, node: Option<TNodeRef>) {
@@ -90,10 +91,7 @@ impl TypeChecker {
         }
 
         for file in host.get_source_files() {
-            if !is_external_or_common_js_module(match &*file {
-                Node::SourceFile(source_file) => source_file,
-                _ => panic!("Expected SourceFile"),
-            }) {
+            if !is_external_or_common_js_module(enum_unwrapped!(&*file, [Node, SourceFile])) {
                 self.merge_symbol_table(&mut *self.globals(), &*file.locals(), None);
             }
         }

--- a/src/compiler/checker/lines_4000_8000.rs
+++ b/src/compiler/checker/lines_4000_8000.rs
@@ -15,6 +15,7 @@ use crate::{
     SymbolTable, SymbolTracker, SyntaxKind, Type, TypeChecker, TypeFlags, TypeFormatFlags,
     TypeInterface, TypeParameter,
 };
+use local_macros::enum_unwrapped;
 
 impl TypeChecker {
     pub(super) fn get_export_symbol_of_value_symbol_if_exported<TSymbolRef: Borrow<Symbol>>(
@@ -406,12 +407,9 @@ impl NodeBuilder {
                     factory
                         .create_string_literal(
                             &self.synthetic_factory,
-                            match type_ {
-                                Type::LiteralType(LiteralType::StringLiteralType(
-                                    string_literal_type,
-                                )) => string_literal_type.value.clone(),
-                                _ => panic!("Expected StringLiteralType"),
-                            },
+                            enum_unwrapped!(type_, [Type, LiteralType, StringLiteralType])
+                                .value
+                                .clone(),
                             Some(
                                 context.flags.intersects(
                                     NodeBuilderFlags::UseSingleQuotesForStringLiteralType,
@@ -424,14 +422,9 @@ impl NodeBuilder {
                 .into();
         }
         if type_.flags().intersects(TypeFlags::NumberLiteral) {
-            let value = match type_ {
-                Type::LiteralType(LiteralType::NumberLiteralType(number_literal_type)) => {
-                    number_literal_type
-                }
-                _ => panic!("Expected NumberLiteralType"),
-            }
-            .value
-            .value();
+            let value = enum_unwrapped!(type_, [Type, LiteralType, NumberLiteralType])
+                .value
+                .value();
             return factory
                 .create_literal_type_node(
                     &self.synthetic_factory,
@@ -468,14 +461,9 @@ impl NodeBuilder {
                     factory
                         .create_big_int_literal(
                             &self.synthetic_factory,
-                            match type_ {
-                                Type::LiteralType(LiteralType::BigIntLiteralType(
-                                    big_int_literal_type,
-                                )) => big_int_literal_type,
-                                _ => panic!("Expected BigIntLiteralType"),
-                            }
-                            .value
-                            .clone(),
+                            enum_unwrapped!(type_, [Type, LiteralType, BigIntLiteralType])
+                                .value
+                                .clone(),
                         )
                         .into(),
                 )

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -20,6 +20,7 @@ use crate::{
     Symbol, SymbolTable, SyntaxKind, TypeElement, TypeNode, TypeParameterDeclaration,
     VariableDeclaration, VariableDeclarationList,
 };
+use local_macros::enum_unwrapped;
 
 #[derive(Eq, PartialEq)]
 enum SpeculationKind {
@@ -139,7 +140,7 @@ pub fn create_source_file(file_name: &str, source_text: &str) -> SourceFile {
     Parser().parse_source_file(file_name, source_text)
 }
 
-enum MissingNode {
+pub enum MissingNode {
     Identifier(Identifier),
 }
 
@@ -747,14 +748,14 @@ impl ParserType {
 
         let default_message = Diagnostics::Identifier_expected;
 
-        match self.create_missing_node(
-            SyntaxKind::Identifier,
-            diagnostic_message.unwrap_or(default_message),
-            Some(vec![msg_arg]),
-        ) {
-            MissingNode::Identifier(identifier) => identifier,
-            _ => panic!("Expected identifier"),
-        }
+        enum_unwrapped!(
+            self.create_missing_node(
+                SyntaxKind::Identifier,
+                diagnostic_message.unwrap_or(default_message),
+                Some(vec![msg_arg]),
+            ),
+            [MissingNode, Identifier]
+        )
     }
 
     fn parse_binding_identifier(&mut self) -> Identifier {

--- a/src/compiler/program.rs
+++ b/src/compiler/program.rs
@@ -6,6 +6,7 @@ use crate::{
     ModuleResolutionHost, ModuleSpecifierResolutionHost, Node, Path, Program, SourceFile,
     StructureIsReused, System, TypeChecker, TypeCheckerHost,
 };
+use local_macros::enum_unwrapped;
 
 fn create_compiler_host() -> impl CompilerHost {
     create_compiler_host_worker()
@@ -76,13 +77,7 @@ impl ProgramConcrete {
         self.get_source_files()
             .iter()
             .flat_map(|source_file| {
-                get_diagnostics(
-                    self,
-                    match &**source_file {
-                        Node::SourceFile(source_file) => &*source_file,
-                        _ => panic!("Expected SourceFile"),
-                    },
-                )
+                get_diagnostics(self, &*enum_unwrapped!(&**source_file, [Node, SourceFile]))
             })
             .collect()
     }

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -9,7 +9,7 @@ use std::ops::BitAndAssign;
 use std::rc::{Rc, Weak};
 
 use crate::{NodeBuilder, Number, SortedArray, WeakSelf};
-use local_macros::{ast_type, symbol_type, type_type};
+use local_macros::{ast_type, enum_unwrapped, symbol_type, type_type};
 
 #[derive(Debug)]
 pub struct Path(String);
@@ -250,20 +250,14 @@ impl Node {
 
     pub fn as_member_name(&self) -> &dyn MemberNameInterface {
         match self {
-            Node::Expression(expression) => match expression {
-                Expression::Identifier(identifier) => identifier,
-                _ => panic!("Expected member name"),
-            },
+            Node::Expression(Expression::Identifier(identifier)) => identifier,
             _ => panic!("Expected member name"),
         }
     }
 
     pub fn as_literal_like_node(&self) -> &dyn LiteralLikeNodeInterface {
         match self {
-            Node::Expression(expression) => match expression {
-                Expression::LiteralLikeNode(literal_like_node) => literal_like_node,
-                _ => panic!("Expected literal like node"),
-            },
+            Node::Expression(Expression::LiteralLikeNode(literal_like_node)) => literal_like_node,
             _ => panic!("Expected literal like node"),
         }
     }
@@ -2126,12 +2120,7 @@ impl StringLiteralType {
             self.value.clone(),
             Some(self.type_wrapper()),
         );
-        match &*fresh_type {
-            Type::LiteralType(literal_type) => {
-                literal_type.set_fresh_type(&fresh_type);
-            }
-            _ => panic!("Expected LiteralType"),
-        }
+        enum_unwrapped!(&*fresh_type, [Type, LiteralType]).set_fresh_type(&fresh_type);
         self.set_fresh_type(&fresh_type);
         type_checker.keep_strong_reference_to_type(fresh_type);
         self.fresh_type().unwrap().upgrade().unwrap()
@@ -2186,12 +2175,7 @@ impl NumberLiteralType {
             self.value,
             Some(self.type_wrapper()),
         );
-        match &*fresh_type {
-            Type::LiteralType(literal_type) => {
-                literal_type.set_fresh_type(&fresh_type);
-            }
-            _ => panic!("Expected LiteralType"),
-        }
+        enum_unwrapped!(&*fresh_type, [Type, LiteralType]).set_fresh_type(&fresh_type);
         self.set_fresh_type(&fresh_type);
         type_checker.keep_strong_reference_to_type(fresh_type);
         self.fresh_type().unwrap().upgrade().unwrap()
@@ -2246,12 +2230,7 @@ impl BigIntLiteralType {
             self.value.clone(),
             Some(self.type_wrapper()),
         );
-        match &*fresh_type {
-            Type::LiteralType(literal_type) => {
-                literal_type.set_fresh_type(&fresh_type);
-            }
-            _ => panic!("Expected LiteralType"),
-        }
+        enum_unwrapped!(&*fresh_type, [Type, LiteralType]).set_fresh_type(&fresh_type);
         self.set_fresh_type(&fresh_type);
         type_checker.keep_strong_reference_to_type(fresh_type);
         self.fresh_type().unwrap().upgrade().unwrap()

--- a/src/compiler/utilities.rs
+++ b/src/compiler/utilities.rs
@@ -23,6 +23,7 @@ use crate::{
     SortedArray, SourceFile, Symbol, SymbolFlags, SymbolInterface, SymbolTable,
     TransientSymbolInterface, Type, TypeInterface,
 };
+use local_macros::enum_unwrapped;
 
 pub fn get_declaration_of_kind(
     symbol: &Symbol,
@@ -272,10 +273,7 @@ pub fn get_source_file_of_node<TNode: NodeInterface>(node: &TNode) -> Rc<SourceF
     while parent.kind() != SyntaxKind::SourceFile {
         parent = parent.parent();
     }
-    match &*parent {
-        Node::SourceFile(source_file) => source_file.clone(),
-        _ => panic!("Expected SourceFile"),
-    }
+    enum_unwrapped!(&*parent, [Node, SourceFile]).clone()
 }
 
 pub fn node_is_missing<TNode: NodeInterface>(node: &TNode) -> bool {
@@ -948,14 +946,8 @@ fn compare_message_text(t1: &DiagnosticMessageText, t2: &DiagnosticMessageText) 
     if matches!(t2, DiagnosticMessageText::String(_)) {
         return Comparison::GreaterThan;
     }
-    let t1 = match t1 {
-        DiagnosticMessageText::DiagnosticMessageChain(t1) => t1,
-        _ => panic!("Expected DiagnosticMessageChain"),
-    };
-    let t2 = match t2 {
-        DiagnosticMessageText::DiagnosticMessageChain(t2) => t2,
-        _ => panic!("Expected DiagnosticMessageChain"),
-    };
+    let t1 = enum_unwrapped!(t1, [DiagnosticMessageText, DiagnosticMessageChain]);
+    let t2 = enum_unwrapped!(t2, [DiagnosticMessageText, DiagnosticMessageChain]);
     let mut res = compare_strings_case_sensitive(Some(&t1.message_text), Some(&t2.message_text));
     if res != Comparison::EqualTo {
         return res;

--- a/src/compiler/utilities_public.rs
+++ b/src/compiler/utilities_public.rs
@@ -5,6 +5,7 @@ use crate::{
     CharacterCodes, Expression, Node, NodeFlags, NodeInterface, SyntaxKind, TextSpan, __String,
     is_block, is_module_block, is_source_file,
 };
+use local_macros::enum_unwrapped;
 
 fn create_text_span(start: isize, length: isize) -> TextSpan {
     TextSpan { start, length }
@@ -72,10 +73,10 @@ pub fn id_text<TNode: NodeInterface>(
     identifier_or_private_name: &TNode, /*Identifier | PrivateIdentifier*/
 ) -> String {
     unescape_leading_underscores(
-        &match &*identifier_or_private_name.node_wrapper() {
-            Node::Expression(Expression::Identifier(identifier)) => identifier,
-            _ => panic!("Expected Identifier"),
-        }
+        &enum_unwrapped!(
+            &*identifier_or_private_name.node_wrapper(),
+            [Node, Expression, Identifier]
+        )
         .escaped_text,
     )
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ pub use compiler::factory::node_tests::{
     is_private_identifier, is_property_assignment, is_property_declaration, is_property_signature,
     is_source_file, is_variable_declaration,
 };
-pub use compiler::parser::{create_source_file, for_each_child};
+pub use compiler::parser::{create_source_file, for_each_child, MissingNode};
 pub use compiler::path::{normalize_path, to_path};
 pub use compiler::program::create_program;
 pub use compiler::scanner::{


### PR DESCRIPTION
In this PR:
- use new `enum_unwrapped!()` macro for boilerplate of unwrapping expected enum variants

To test:
Behavior should still be the same as of #40 

Based on `heterogeneous-union-type`