### PR TITLE
.as_*() unwrapping helpers

### DIFF
--- a/local-macros/src/lib.rs
+++ b/local-macros/src/lib.rs
@@ -1469,16 +1469,16 @@ pub fn enum_unwrapped(input: TokenStream) -> TokenStream {
 }
 
 fn get_node_enum_unwrapped_call(argument: &Expr, variant_name: &Ident) -> TokenStream2 {
-    let known_node_variant_names: HashMap<String, Vec<&'static str>> = HashMap::from_iter(
-        IntoIter::new([("Expression".to_string(), vec!["Expression"])]),
-    );
+    let known_node_variant_names: HashMap<String, Vec<&'static str>> =
+        HashMap::from_iter(IntoIter::new([
+            ("Expression".to_string(), vec![]),
+            ("VariableDeclarationList".to_string(), vec![]),
+        ]));
 
     let mut ancestors = vec!["Node"];
-    ancestors.extend_from_slice(
-        known_node_variant_names
-            .get(&variant_name.to_string())
-            .unwrap(),
-    );
+    let variant_name_string = variant_name.to_string();
+    ancestors.extend_from_slice(known_node_variant_names.get(&variant_name_string).unwrap());
+    ancestors.push(&variant_name_string);
     let ancestors = ancestors
         .into_iter()
         .map(|ancestor_str| Ident::new(ancestor_str, variant_name.span()));

--- a/local-macros/src/lib.rs
+++ b/local-macros/src/lib.rs
@@ -2,6 +2,8 @@ use darling::FromMeta;
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, TokenStream as TokenStream2};
 use quote::quote;
+use std::array::IntoIter;
+use std::collections::HashMap;
 use syn::parse::{Parse, ParseStream, Result};
 use syn::Data::{Enum, Struct};
 use syn::{
@@ -1462,6 +1464,61 @@ pub fn enum_unwrapped(input: TokenStream) -> TokenStream {
 
     quote! {
         #enum_match
+    }
+    .into()
+}
+
+fn get_node_enum_unwrapped_call(argument: &Expr, variant_name: &Ident) -> TokenStream2 {
+    let known_node_variant_names: HashMap<String, Vec<&'static str>> = HashMap::from_iter(
+        IntoIter::new([("Expression".to_string(), vec!["Expression"])]),
+    );
+
+    let mut ancestors = vec!["Node"];
+    ancestors.extend_from_slice(
+        known_node_variant_names
+            .get(&variant_name.to_string())
+            .unwrap(),
+    );
+    let ancestors = ancestors
+        .into_iter()
+        .map(|ancestor_str| Ident::new(ancestor_str, variant_name.span()));
+    let ancestors = quote! {
+        [#(#ancestors),*]
+    };
+
+    quote! {
+        ::local_macros::enum_unwrapped!(#argument, #ancestors)
+    }
+}
+
+struct NodeUnwrapped {
+    argument: Expr,
+    variant_name: Ident,
+}
+
+impl Parse for NodeUnwrapped {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let argument: Expr = input.parse()?;
+        input.parse::<Token![,]>()?;
+        let variant_name: Ident = input.parse()?;
+        Ok(NodeUnwrapped {
+            argument,
+            variant_name,
+        })
+    }
+}
+
+#[proc_macro]
+pub fn node_unwrapped(input: TokenStream) -> TokenStream {
+    let NodeUnwrapped {
+        argument,
+        variant_name,
+    } = parse_macro_input!(input as NodeUnwrapped);
+
+    let enum_unwrapped_call = get_node_enum_unwrapped_call(&argument, &variant_name);
+
+    quote! {
+        #enum_unwrapped_call
     }
     .into()
 }

--- a/local-macros/src/lib.rs
+++ b/local-macros/src/lib.rs
@@ -1474,6 +1474,7 @@ fn get_node_enum_unwrapped_call(argument: &Expr, variant_name: &Ident) -> TokenS
             ("Expression".to_string(), vec![]),
             ("VariableDeclarationList".to_string(), vec![]),
             ("TypeParameterDeclaration".to_string(), vec![]),
+            ("PropertyAssignment".to_string(), vec![]),
         ]));
 
     let mut ancestors = vec!["Node"];

--- a/local-macros/src/lib.rs
+++ b/local-macros/src/lib.rs
@@ -1473,6 +1473,7 @@ fn get_node_enum_unwrapped_call(argument: &Expr, variant_name: &Ident) -> TokenS
         HashMap::from_iter(IntoIter::new([
             ("Expression".to_string(), vec![]),
             ("VariableDeclarationList".to_string(), vec![]),
+            ("TypeParameterDeclaration".to_string(), vec![]),
         ]));
 
     let mut ancestors = vec!["Node"];

--- a/src/compiler/binder.rs
+++ b/src/compiler/binder.rs
@@ -15,7 +15,6 @@ use crate::{
     NodeArray, NodeInterface, ObjectLiteralExpression, PropertySignature, Statement, SymbolFlags,
     SymbolInterface, TypeElement, TypeParameterDeclaration,
 };
-use local_macros::enum_unwrapped;
 
 bitflags! {
     struct ContainerFlags: u32 {
@@ -421,7 +420,8 @@ impl BinderType {
         name: __String,
     ) -> Rc<Symbol> {
         let symbol = self.create_symbol(symbol_flags, name).wrap();
-        enum_unwrapped!(&*self.file(), [Node, SourceFile])
+        self.file()
+            .as_source_file()
             .keep_strong_reference_to_symbol(symbol.clone());
         self.add_declaration_to_symbol(&symbol, node, symbol_flags);
         symbol

--- a/src/compiler/checker/lines_0_1000.rs
+++ b/src/compiler/checker/lines_0_1000.rs
@@ -12,7 +12,6 @@ use crate::{
     ObjectFlags, Symbol, SymbolFlags, SymbolId, SymbolInterface, SymbolTable, Type, TypeChecker,
     TypeCheckerHost, TypeFlags,
 };
-use local_macros::enum_unwrapped;
 
 thread_local! {
     pub(super) static next_symbol_id: RefCell<SymbolId> = RefCell::new(1);
@@ -192,8 +191,7 @@ pub fn create_type_checker<TTypeCheckerHost: TypeCheckerHost>(
         type_checker.create_intrinsic_type(TypeFlags::BooleanLiteral, "true"),
     )
     .into();
-    let true_type_as_freshable_intrinsic_type =
-        enum_unwrapped!(&*true_type, [Type, IntrinsicType, FreshableIntrinsicType]);
+    let true_type_as_freshable_intrinsic_type = true_type.as_freshable_intrinsic_type();
     true_type_as_freshable_intrinsic_type
         .regular_type
         .init(&regular_true_type, false);
@@ -201,10 +199,8 @@ pub fn create_type_checker<TTypeCheckerHost: TypeCheckerHost>(
         .fresh_type
         .init(&true_type, false);
     type_checker.true_type = Some(true_type);
-    let regular_true_type_as_freshable_intrinsic_type = enum_unwrapped!(
-        &*regular_true_type,
-        [Type, IntrinsicType, FreshableIntrinsicType]
-    );
+    let regular_true_type_as_freshable_intrinsic_type =
+        regular_true_type.as_freshable_intrinsic_type();
     regular_true_type_as_freshable_intrinsic_type
         .regular_type
         .init(&regular_true_type, false);
@@ -220,8 +216,7 @@ pub fn create_type_checker<TTypeCheckerHost: TypeCheckerHost>(
         type_checker.create_intrinsic_type(TypeFlags::BooleanLiteral, "false"),
     )
     .into();
-    let false_type_as_freshable_intrinsic_type =
-        enum_unwrapped!(&*false_type, [Type, IntrinsicType, FreshableIntrinsicType]);
+    let false_type_as_freshable_intrinsic_type = false_type.as_freshable_intrinsic_type();
     false_type_as_freshable_intrinsic_type
         .regular_type
         .init(&regular_false_type, false);
@@ -229,10 +224,8 @@ pub fn create_type_checker<TTypeCheckerHost: TypeCheckerHost>(
         .fresh_type
         .init(&false_type, false);
     type_checker.false_type = Some(false_type);
-    let regular_false_type_as_freshable_intrinsic_type = enum_unwrapped!(
-        &*regular_false_type,
-        [Type, IntrinsicType, FreshableIntrinsicType]
-    );
+    let regular_false_type_as_freshable_intrinsic_type =
+        regular_false_type.as_freshable_intrinsic_type();
     regular_false_type_as_freshable_intrinsic_type
         .regular_type
         .init(&regular_false_type, false);

--- a/src/compiler/checker/lines_12000_16000.rs
+++ b/src/compiler/checker/lines_12000_16000.rs
@@ -379,7 +379,7 @@ impl TypeChecker {
                     } else {
                         TypeFlags::None
                     },
-                type_.as_union_or_intersection_type().types(),
+                type_.as_union_or_intersection_type_interface().types(),
             );
         }
         if !flags.intersects(TypeFlags::Never) {

--- a/src/compiler/checker/lines_12000_16000.rs
+++ b/src/compiler/checker/lines_12000_16000.rs
@@ -106,10 +106,7 @@ impl TypeChecker {
                 None => vec![],
                 Some(node) => match &**node {
                     Node::TypeNode(TypeNode::TypeReferenceNode(type_reference_node)) => {
-                        let target_as_base_interface_type = enum_unwrapped!(
-                            &*type_.target,
-                            [Type, ObjectType, InterfaceType, BaseInterfaceType]
-                        );
+                        let target_as_base_interface_type = type_.target.as_base_interface_type();
                         concatenate(
                             target_as_base_interface_type
                                 .outer_type_parameters

--- a/src/compiler/checker/lines_12000_16000.rs
+++ b/src/compiler/checker/lines_12000_16000.rs
@@ -1,19 +1,18 @@
 #![allow(non_upper_case_globals)]
 
 use std::borrow::Borrow;
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 use std::ptr;
 use std::rc::Rc;
 
 use crate::{
     UnionType, __String, binary_search_copy_key, compare_values, concatenate,
     get_name_of_declaration, get_object_flags, map, unescape_leading_underscores, ArrayTypeNode,
-    BaseUnionOrIntersectionType, DiagnosticMessage, Diagnostics, Expression, InterfaceType, Node,
-    NodeInterface, ObjectFlags, ObjectFlagsTypeInterface, ObjectType, Symbol, SymbolFlags,
-    SymbolInterface, SyntaxKind, Type, TypeChecker, TypeFlags, TypeId, TypeInterface, TypeNode,
-    TypeReference, TypeReferenceNode, UnionReduction, UnionTypeNode,
+    BaseUnionOrIntersectionType, DiagnosticMessage, Diagnostics, Expression, Node, NodeInterface,
+    ObjectFlags, ObjectFlagsTypeInterface, Symbol, SymbolFlags, SymbolInterface, SyntaxKind, Type,
+    TypeChecker, TypeFlags, TypeId, TypeInterface, TypeNode, TypeReference, TypeReferenceNode,
+    UnionReduction, UnionTypeNode,
 };
-use local_macros::enum_unwrapped;
 
 impl TypeChecker {
     pub(super) fn get_apparent_type(&self, type_: &Type) -> Rc<Type> {
@@ -145,14 +144,11 @@ impl TypeChecker {
     ) -> Rc<Type> {
         let type_ =
             self.get_declared_type_of_symbol(&self.get_merged_symbol(Some(symbol)).unwrap());
-        let type_as_interface_type = enum_unwrapped!(
-            &*type_,
-            [Type, ObjectType, InterfaceType, BaseInterfaceType]
-        );
-        let type_parameters = type_as_interface_type.type_parameters.as_ref();
+        let type_as_base_interface_type = type_.as_base_interface_type();
+        let type_parameters = type_as_base_interface_type.type_parameters.as_ref();
         if let Some(type_parameters) = type_parameters {
             let type_arguments = concatenate(
-                type_as_interface_type
+                type_as_base_interface_type
                     .outer_type_parameters
                     .clone()
                     .unwrap_or_else(|| vec![]),

--- a/src/compiler/checker/lines_16000_18000.rs
+++ b/src/compiler/checker/lines_16000_18000.rs
@@ -27,13 +27,13 @@ impl TypeChecker {
         let type_ = self.create_type(flags);
         let type_ = BaseLiteralType::new(type_);
         let type_: Rc<Type> = StringLiteralType::new(type_, value).into();
-        enum_unwrapped!(&*type_, [Type, LiteralType]).set_regular_type(
-            &if let Some(regular_type) = regular_type {
+        type_
+            .as_literal_type()
+            .set_regular_type(&if let Some(regular_type) = regular_type {
                 regular_type.borrow().type_wrapper()
             } else {
                 type_.clone()
-            },
-        );
+            });
         type_
     }
 
@@ -46,13 +46,13 @@ impl TypeChecker {
         let type_ = self.create_type(flags);
         let type_ = BaseLiteralType::new(type_);
         let type_: Rc<Type> = NumberLiteralType::new(type_, value).into();
-        enum_unwrapped!(&*type_, [Type, LiteralType]).set_regular_type(
-            &if let Some(regular_type) = regular_type {
+        type_
+            .as_literal_type()
+            .set_regular_type(&if let Some(regular_type) = regular_type {
                 regular_type.borrow().type_wrapper()
             } else {
                 type_.clone()
-            },
-        );
+            });
         type_
     }
 
@@ -65,13 +65,13 @@ impl TypeChecker {
         let type_ = self.create_type(flags);
         let type_ = BaseLiteralType::new(type_);
         let type_: Rc<Type> = BigIntLiteralType::new(type_, value).into();
-        enum_unwrapped!(&*type_, [Type, LiteralType]).set_regular_type(
-            &if let Some(regular_type) = regular_type {
+        type_
+            .as_literal_type()
+            .set_regular_type(&if let Some(regular_type) = regular_type {
                 regular_type.borrow().type_wrapper()
             } else {
                 type_.clone()
-            },
-        );
+            });
         type_
     }
 
@@ -162,7 +162,7 @@ impl TypeChecker {
         let mut links_ref = links.borrow_mut();
         if links_ref.resolved_type.is_none() {
             links_ref.resolved_type = Some(self.get_regular_type_of_literal_type(
-                &self.check_expression(enum_unwrapped!(&*node.literal, [Node, Expression]), None),
+                &self.check_expression(node.literal.as_expression(), None),
             ));
         }
         links_ref.resolved_type.clone().unwrap()
@@ -180,7 +180,7 @@ impl TypeChecker {
     }
 
     pub(super) fn get_type_from_type_node_worker(&self, node: &Node /*TypeNode*/) -> Rc<Type> {
-        let node = enum_unwrapped!(node, [Node, TypeNode]);
+        let node = node.as_type_node();
         match node {
             TypeNode::KeywordTypeNode(_) => match node.kind() {
                 SyntaxKind::NumberKeyword => self.number_type(),
@@ -494,7 +494,7 @@ impl TypeChecker {
         source_prop_type: &Type,
     ) -> Rc<Type> {
         self.check_expression_for_mutable_location(
-            enum_unwrapped!(next, [Node, Expression]),
+            next.as_expression(),
             Some(CheckMode::Contextual),
             Some(source_prop_type),
         )

--- a/src/compiler/checker/lines_18000_20000.rs
+++ b/src/compiler/checker/lines_18000_20000.rs
@@ -12,7 +12,6 @@ use crate::{
     NodeInterface, ObjectFlags, RelationComparisonResult, Symbol, SymbolInterface, Ternary, Type,
     TypeChecker, TypeFlags, TypeInterface,
 };
-use local_macros::enum_unwrapped;
 
 pub(super) struct CheckTypeRelatedTo<'type_checker> {
     type_checker: &'type_checker TypeChecker,
@@ -425,7 +424,7 @@ impl<'type_checker> CheckTypeRelatedTo<'type_checker> {
                     unimplemented!()
                 } else {
                     self.each_type_related_to_type(
-                        enum_unwrapped!(source, [Type, UnionOrIntersectionType]),
+                        source.as_union_or_intersection_type(),
                         target,
                         report_errors,
                         intersection_state & !IntersectionState::UnionIntersectionCheck,
@@ -435,7 +434,7 @@ impl<'type_checker> CheckTypeRelatedTo<'type_checker> {
             if target.flags().intersects(TypeFlags::Union) {
                 return self.type_related_to_some_type(
                     &self.type_checker.get_regular_type_of_object_literal(source),
-                    enum_unwrapped!(target, [Type, UnionOrIntersectionType]),
+                    target.as_union_or_intersection_type(),
                     report_errors
                         && !(source.flags().intersects(TypeFlags::Primitive))
                         && !(target.flags().intersects(TypeFlags::Primitive)),

--- a/src/compiler/checker/lines_24000_32000.rs
+++ b/src/compiler/checker/lines_24000_32000.rs
@@ -12,7 +12,6 @@ use crate::{
     ObjectLiteralExpression, PropertyAssignment, Symbol, SymbolInterface, SyntaxKind, Type,
     TypeChecker, TypeFlags, TypeInterface,
 };
-use local_macros::enum_unwrapped;
 
 impl TypeChecker {
     pub(super) fn check_identifier(
@@ -52,7 +51,7 @@ impl TypeChecker {
         node: &TNode,
     ) -> Option<Rc<Type>> {
         let parent = node.parent();
-        let declaration = enum_unwrapped!(&*parent, [Node, VariableDeclaration]);
+        let declaration = parent.as_variable_declaration();
         if has_initializer(declaration)
             && Rc::ptr_eq(
                 &node.node_wrapper(),
@@ -103,7 +102,7 @@ impl TypeChecker {
         element: &PropertyAssignment,
     ) -> Option<Rc<Type>> {
         let parent = element.parent();
-        let object_literal = enum_unwrapped!(&*parent, [Node, Expression, ObjectLiteralExpression]);
+        let object_literal = parent.as_object_literal_expression();
         // let property_assignment_type = if is_property_assignment(element) {
         // } else {
         //     None

--- a/src/compiler/checker/lines_32000_40000.rs
+++ b/src/compiler/checker/lines_32000_40000.rs
@@ -15,7 +15,7 @@ use crate::{
     TypeReferenceNode, UnionOrIntersectionTypeInterface, VariableDeclaration,
     VariableLikeDeclarationInterface, VariableStatement,
 };
-use local_macros::enum_unwrapped;
+use local_macros::{enum_unwrapped, node_unwrapped};
 
 impl TypeChecker {
     pub(super) fn check_arithmetic_operand_type(
@@ -32,7 +32,7 @@ impl TypeChecker {
     }
 
     pub(super) fn check_prefix_unary_expression(&self, node: &PrefixUnaryExpression) -> Rc<Type> {
-        let operand_expression = enum_unwrapped!(&*node.operand, [Node, Expression]);
+        let operand_expression = node_unwrapped!(&*node.operand, Expression);
         let operand_type = self.check_expression(operand_expression, None);
         match node.operator {
             SyntaxKind::PlusPlusToken => {

--- a/src/compiler/checker/lines_32000_40000.rs
+++ b/src/compiler/checker/lines_32000_40000.rs
@@ -15,7 +15,6 @@ use crate::{
     TypeReferenceNode, UnionOrIntersectionTypeInterface, VariableDeclaration,
     VariableLikeDeclarationInterface, VariableStatement,
 };
-use local_macros::{enum_unwrapped, node_unwrapped};
 
 impl TypeChecker {
     pub(super) fn check_arithmetic_operand_type(

--- a/src/compiler/checker/lines_32000_40000.rs
+++ b/src/compiler/checker/lines_32000_40000.rs
@@ -391,15 +391,12 @@ impl TypeChecker {
     }
 
     pub(super) fn check_expression_statement(&mut self, node: &ExpressionStatement) {
-        let expression = enum_unwrapped!(&*node.expression, [Node, Expression]);
+        let expression = node.expression.as_expression();
         self.check_expression(expression, None);
     }
 
     pub(super) fn check_if_statement(&mut self, node: &IfStatement) {
-        let type_ = self.check_truthiness_expression(
-            enum_unwrapped!(&*node.expression, [Node, Expression]),
-            None,
-        );
+        let type_ = self.check_truthiness_expression(node.expression.as_expression(), None);
         self.check_source_element(Some(&*node.then_statement));
 
         if node.then_statement.kind() == SyntaxKind::EmptyStatement {
@@ -443,10 +440,7 @@ impl TypeChecker {
     ) {
         if let Some(type_parameter_declarations) = type_parameter_declarations {
             for node in type_parameter_declarations {
-                self.check_type_parameter(enum_unwrapped!(
-                    &**node,
-                    [Node, TypeParameterDeclaration]
-                ));
+                self.check_type_parameter(node.as_type_parameter_declaration());
             }
         }
     }

--- a/src/compiler/checker/lines_32000_40000.rs
+++ b/src/compiler/checker/lines_32000_40000.rs
@@ -32,7 +32,7 @@ impl TypeChecker {
     }
 
     pub(super) fn check_prefix_unary_expression(&self, node: &PrefixUnaryExpression) -> Rc<Type> {
-        let operand_expression = node_unwrapped!(&*node.operand, Expression);
+        let operand_expression = node.operand.as_expression();
         let operand_type = self.check_expression(operand_expression, None);
         match node.operator {
             SyntaxKind::PlusPlusToken => {

--- a/src/compiler/checker/lines_32000_40000.rs
+++ b/src/compiler/checker/lines_32000_40000.rs
@@ -87,7 +87,7 @@ impl TypeChecker {
         contextual_type: Option<TTypeRef>,
     ) -> Rc<Type> {
         let initializer = get_effective_initializer(declaration).unwrap();
-        let initializer_as_expression = enum_unwrapped!(&*initializer, [Node, Expression]);
+        let initializer_as_expression = initializer.as_expression();
         let type_ = self
             .get_quick_type_of_expression(initializer_as_expression)
             .unwrap_or_else(|| {
@@ -188,7 +188,7 @@ impl TypeChecker {
         check_mode: Option<CheckMode>,
     ) -> Rc<Type> {
         self.check_expression_for_mutable_location(
-            enum_unwrapped!(&*node.initializer, [Node, Expression]),
+            node.initializer.as_expression(),
             check_mode,
             Option::<&Type>::None,
         )
@@ -360,15 +360,13 @@ impl TypeChecker {
             let initializer = get_effective_initializer(node);
             if let Some(initializer) = initializer {
                 if true {
-                    let initializer_type = self.check_expression_cached(
-                        enum_unwrapped!(&*initializer, [Node, Expression]),
-                        None,
-                    );
+                    let initializer_type =
+                        self.check_expression_cached(initializer.as_expression(), None);
                     self.check_type_assignable_to_and_optionally_elaborate(
                         &initializer_type,
                         &type_,
                         Some(&*wrapper),
-                        Some(enum_unwrapped!(&*initializer, [Node, Expression])),
+                        Some(initializer.as_expression()),
                         None,
                     );
                 }
@@ -384,7 +382,10 @@ impl TypeChecker {
 
     pub(super) fn check_variable_statement(&mut self, node: &VariableStatement) {
         for_each(
-            &enum_unwrapped!(&*node.declaration_list, [Node, VariableDeclarationList]).declarations,
+            &node
+                .declaration_list
+                .as_variable_declaration_list()
+                .declarations,
             |declaration, _| Some(self.check_source_element(Some(&**declaration))),
         );
     }

--- a/src/compiler/checker/lines_40000_end.rs
+++ b/src/compiler/checker/lines_40000_end.rs
@@ -7,7 +7,6 @@ use crate::{
     bind_source_file, for_each, is_external_or_common_js_module, Diagnostic, Node, NodeInterface,
     NumericLiteral, SourceFile, Statement, TypeChecker, TypeCheckerHost, TypeElement, TypeNode,
 };
-use local_macros::enum_unwrapped;
 
 impl TypeChecker {
     pub(super) fn check_source_element<TNodeRef: Borrow<Node>>(&mut self, node: Option<TNodeRef>) {
@@ -91,7 +90,7 @@ impl TypeChecker {
         }
 
         for file in host.get_source_files() {
-            if !is_external_or_common_js_module(enum_unwrapped!(&*file, [Node, SourceFile])) {
+            if !is_external_or_common_js_module(file.as_source_file()) {
                 self.merge_symbol_table(&mut *self.globals(), &*file.locals(), None);
             }
         }

--- a/src/compiler/checker/lines_4000_8000.rs
+++ b/src/compiler/checker/lines_4000_8000.rs
@@ -15,7 +15,6 @@ use crate::{
     SymbolTable, SymbolTracker, SyntaxKind, Type, TypeChecker, TypeFlags, TypeFormatFlags,
     TypeInterface, TypeParameter,
 };
-use local_macros::enum_unwrapped;
 
 impl TypeChecker {
     pub(super) fn get_export_symbol_of_value_symbol_if_exported<TSymbolRef: Borrow<Symbol>>(
@@ -407,9 +406,7 @@ impl NodeBuilder {
                     factory
                         .create_string_literal(
                             &self.synthetic_factory,
-                            enum_unwrapped!(type_, [Type, LiteralType, StringLiteralType])
-                                .value
-                                .clone(),
+                            type_.as_string_literal_type().value.clone(),
                             Some(
                                 context.flags.intersects(
                                     NodeBuilderFlags::UseSingleQuotesForStringLiteralType,
@@ -422,9 +419,7 @@ impl NodeBuilder {
                 .into();
         }
         if type_.flags().intersects(TypeFlags::NumberLiteral) {
-            let value = enum_unwrapped!(type_, [Type, LiteralType, NumberLiteralType])
-                .value
-                .value();
+            let value = type_.as_number_literal_type().value.value();
             return factory
                 .create_literal_type_node(
                     &self.synthetic_factory,
@@ -461,9 +456,7 @@ impl NodeBuilder {
                     factory
                         .create_big_int_literal(
                             &self.synthetic_factory,
-                            enum_unwrapped!(type_, [Type, LiteralType, BigIntLiteralType])
-                                .value
-                                .clone(),
+                            type_.as_big_int_literal_type().value.clone(),
                         )
                         .into(),
                 )
@@ -499,7 +492,7 @@ impl NodeBuilder {
             .intersects(TypeFlags::Union | TypeFlags::Intersection)
         {
             let types = {
-                let types = type_.as_union_or_intersection_type().types();
+                let types = type_.as_union_or_intersection_type_interface().types();
                 if type_.flags().intersects(TypeFlags::Union) {
                     type_checker.format_union_types(types)
                 } else {

--- a/src/compiler/checker/lines_8000_12000.rs
+++ b/src/compiler/checker/lines_8000_12000.rs
@@ -357,19 +357,15 @@ impl TypeChecker {
             .into();
             let type_rc: Rc<Type> = type_.into();
             if need_to_set_constraint {
-                *enum_unwrapped!(
-                    &**enum_unwrapped!(
-                        &*type_rc,
-                        [Type, ObjectType, InterfaceType, BaseInterfaceType]
-                    )
+                *type_rc
+                    .as_base_interface_type()
                     .this_type
                     .borrow_mut()
                     .as_ref()
-                    .unwrap(),
-                    [Type, TypeParameter]
-                )
-                .constraint
-                .borrow_mut() = Some(Rc::downgrade(&type_rc));
+                    .unwrap()
+                    .as_type_parameter()
+                    .constraint
+                    .borrow_mut() = Some(Rc::downgrade(&type_rc));
             }
             original_links_ref.declared_type = Some(type_rc.clone());
             if !Rc::ptr_eq(&links, &original_links) {

--- a/src/compiler/checker/lines_8000_12000.rs
+++ b/src/compiler/checker/lines_8000_12000.rs
@@ -198,10 +198,7 @@ impl TypeChecker {
             type_ = self
                 .try_get_type_from_effective_type_node(&*declaration)
                 .unwrap_or_else(|| {
-                    self.check_property_assignment(
-                        enum_unwrapped!(&*declaration, [Node, PropertyAssignment]),
-                        None,
-                    )
+                    self.check_property_assignment(declaration.as_property_assignment(), None)
                 });
         } else if is_property_signature(&*declaration) || is_variable_declaration(&*declaration) {
             type_ = self.get_widened_type_for_variable_like_declaration(&*declaration);

--- a/src/compiler/checker/lines_8000_12000.rs
+++ b/src/compiler/checker/lines_8000_12000.rs
@@ -17,7 +17,6 @@ use crate::{
     SyntaxKind, Type, TypeChecker, TypeFlags, TypeInterface, TypeMapper, UnionOrIntersectionType,
     UnionOrIntersectionTypeInterface,
 };
-use local_macros::enum_unwrapped;
 
 impl TypeChecker {
     pub(super) fn format_union_types(&self, types: &[Rc<Type>]) -> Vec<Rc<Type>> {
@@ -430,7 +429,7 @@ impl TypeChecker {
     }
 
     pub(super) fn resolve_declared_members(&self, type_: &Type /*InterfaceType*/) -> Rc<Type> {
-        let type_as_interface_type = enum_unwrapped!(type_, [Type, ObjectType, InterfaceType]);
+        let type_as_interface_type = type_.as_interface_type();
         if type_as_interface_type.maybe_declared_properties().is_none() {
             let symbol = type_.symbol();
             let members = self.get_members_of_symbol(&symbol);
@@ -505,7 +504,8 @@ impl TypeChecker {
             mapper = Some(self.create_type_mapper(type_parameters, Some(type_arguments)));
             members = Rc::new(RefCell::new(
                 self.create_instantiated_symbol_table(
-                    enum_unwrapped!(source, [Type, ObjectType, InterfaceType, BaseInterfaceType])
+                    source
+                        .as_base_interface_type()
                         .maybe_declared_properties()
                         .as_ref()
                         .unwrap(),
@@ -514,16 +514,13 @@ impl TypeChecker {
                 ),
             ));
         }
-        self.set_structured_type_members(enum_unwrapped!(type_, [Type, ObjectType]), members);
+        self.set_structured_type_members(type_.as_object_type(), members);
     }
 
     pub(super) fn resolve_type_reference_members(&self, type_: &Type /*TypeReference*/) {
-        let type_as_type_reference = enum_unwrapped!(type_, [Type, ObjectType, TypeReference]);
+        let type_as_type_reference = type_.as_type_reference();
         let source = self.resolve_declared_members(&type_as_type_reference.target);
-        let source_as_base_interface_type = enum_unwrapped!(
-            &*source,
-            [Type, ObjectType, InterfaceType, BaseInterfaceType]
-        );
+        let source_as_base_interface_type = source.as_base_interface_type();
         let type_parameters = concatenate(
             source_as_base_interface_type
                 .type_parameters

--- a/src/compiler/program.rs
+++ b/src/compiler/program.rs
@@ -6,7 +6,6 @@ use crate::{
     ModuleResolutionHost, ModuleSpecifierResolutionHost, Node, Path, Program, SourceFile,
     StructureIsReused, System, TypeChecker, TypeCheckerHost,
 };
-use local_macros::enum_unwrapped;
 
 fn create_compiler_host() -> impl CompilerHost {
     create_compiler_host_worker()
@@ -76,9 +75,7 @@ impl ProgramConcrete {
     ) -> Vec<Rc<Diagnostic>> {
         self.get_source_files()
             .iter()
-            .flat_map(|source_file| {
-                get_diagnostics(self, &*enum_unwrapped!(&**source_file, [Node, SourceFile]))
-            })
+            .flat_map(|source_file| get_diagnostics(self, source_file.as_source_file()))
             .collect()
     }
 

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -1944,6 +1944,18 @@ impl Type {
     pub fn as_type_parameter(&self) -> &TypeParameter {
         enum_unwrapped!(self, [Type, TypeParameter])
     }
+
+    pub fn as_interface_type(&self) -> &InterfaceType {
+        enum_unwrapped!(self, [Type, ObjectType, InterfaceType])
+    }
+
+    pub fn as_object_type(&self) -> &ObjectType {
+        enum_unwrapped!(self, [Type, ObjectType])
+    }
+
+    pub fn as_type_reference(&self) -> &TypeReference {
+        enum_unwrapped!(self, [Type, ObjectType, TypeReference])
+    }
 }
 
 pub trait TypeInterface {

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -333,6 +333,10 @@ impl Node {
     pub fn as_type_parameter_declaration(&self) -> &TypeParameterDeclaration {
         node_unwrapped!(self, TypeParameterDeclaration)
     }
+
+    pub fn as_property_assignment(&self) -> &PropertyAssignment {
+        node_unwrapped!(self, PropertyAssignment)
+    }
 }
 
 #[derive(Debug)]

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -342,6 +342,18 @@ impl Node {
     pub fn as_source_file(&self) -> &Rc<SourceFile> {
         enum_unwrapped!(self, [Node, SourceFile])
     }
+
+    pub fn as_variable_declaration(&self) -> &VariableDeclaration {
+        enum_unwrapped!(self, [Node, VariableDeclaration])
+    }
+
+    pub fn as_object_literal_expression(&self) -> &ObjectLiteralExpression {
+        enum_unwrapped!(self, [Node, Expression, ObjectLiteralExpression])
+    }
+
+    pub fn as_identifier(&self) -> &Identifier {
+        enum_unwrapped!(self, [Node, Expression, Identifier])
+    }
 }
 
 #[derive(Debug)]
@@ -1908,7 +1920,7 @@ impl Type {
         }
     }
 
-    pub fn as_union_or_intersection_type(&self) -> &dyn UnionOrIntersectionTypeInterface {
+    pub fn as_union_or_intersection_type_interface(&self) -> &dyn UnionOrIntersectionTypeInterface {
         match self {
             Type::UnionOrIntersectionType(union_or_intersection_type) => union_or_intersection_type,
             _ => panic!("Expected union or intersection type"),
@@ -1960,6 +1972,22 @@ impl Type {
 
     pub fn as_type_reference(&self) -> &TypeReference {
         enum_unwrapped!(self, [Type, ObjectType, TypeReference])
+    }
+
+    pub fn as_string_literal_type(&self) -> &StringLiteralType {
+        enum_unwrapped!(self, [Type, LiteralType, StringLiteralType])
+    }
+
+    pub fn as_number_literal_type(&self) -> &NumberLiteralType {
+        enum_unwrapped!(self, [Type, LiteralType, NumberLiteralType])
+    }
+
+    pub fn as_big_int_literal_type(&self) -> &BigIntLiteralType {
+        enum_unwrapped!(self, [Type, LiteralType, BigIntLiteralType])
+    }
+
+    pub fn as_union_or_intersection_type(&self) -> &UnionOrIntersectionType {
+        enum_unwrapped!(self, [Type, UnionOrIntersectionType])
     }
 }
 

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -323,19 +323,24 @@ impl Node {
     }
 
     pub fn as_expression(&self) -> &Expression {
-        node_unwrapped!(self, Expression)
+        // node_unwrapped!(self, Expression)
+        enum_unwrapped!(self, [Node, Expression])
     }
 
     pub fn as_variable_declaration_list(&self) -> &VariableDeclarationList {
-        node_unwrapped!(self, VariableDeclarationList)
+        enum_unwrapped!(self, [Node, VariableDeclarationList])
     }
 
     pub fn as_type_parameter_declaration(&self) -> &TypeParameterDeclaration {
-        node_unwrapped!(self, TypeParameterDeclaration)
+        enum_unwrapped!(self, [Node, TypeParameterDeclaration])
     }
 
     pub fn as_property_assignment(&self) -> &PropertyAssignment {
-        node_unwrapped!(self, PropertyAssignment)
+        enum_unwrapped!(self, [Node, PropertyAssignment])
+    }
+
+    pub fn as_source_file(&self) -> &Rc<SourceFile> {
+        enum_unwrapped!(self, [Node, SourceFile])
     }
 }
 

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -9,7 +9,9 @@ use std::ops::BitAndAssign;
 use std::rc::{Rc, Weak};
 
 use crate::{NodeBuilder, Number, SortedArray, WeakSelf};
-use local_macros::{ast_type, enum_unwrapped, node_unwrapped, symbol_type, type_type};
+use local_macros::{
+    ast_type, enum_unwrapped, node_unwrapped, symbol_type, type_type, type_unwrapped,
+};
 
 #[derive(Debug)]
 pub struct Path(String);
@@ -1929,6 +1931,10 @@ impl Type {
             Type::UnionOrIntersectionType(union_or_intersection_type) => union_or_intersection_type,
             _ => panic!("Expected object flags type"),
         }
+    }
+
+    pub fn as_base_interface_type(&self) -> &BaseInterfaceType {
+        type_unwrapped!(self, BaseInterfaceType)
     }
 }
 

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -327,6 +327,10 @@ impl Node {
     pub fn as_variable_declaration_list(&self) -> &VariableDeclarationList {
         node_unwrapped!(self, VariableDeclarationList)
     }
+
+    pub fn as_type_parameter_declaration(&self) -> &TypeParameterDeclaration {
+        node_unwrapped!(self, TypeParameterDeclaration)
+    }
 }
 
 #[derive(Debug)]

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -323,6 +323,10 @@ impl Node {
     pub fn as_expression(&self) -> &Expression {
         node_unwrapped!(self, Expression)
     }
+
+    pub fn as_variable_declaration_list(&self) -> &VariableDeclarationList {
+        node_unwrapped!(self, VariableDeclarationList)
+    }
 }
 
 #[derive(Debug)]

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -1938,7 +1938,11 @@ impl Type {
     }
 
     pub fn as_base_interface_type(&self) -> &BaseInterfaceType {
-        type_unwrapped!(self, BaseInterfaceType)
+        enum_unwrapped!(self, [Type, ObjectType, InterfaceType, BaseInterfaceType])
+    }
+
+    pub fn as_type_parameter(&self) -> &TypeParameter {
+        enum_unwrapped!(self, [Type, TypeParameter])
     }
 }
 

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -9,7 +9,7 @@ use std::ops::BitAndAssign;
 use std::rc::{Rc, Weak};
 
 use crate::{NodeBuilder, Number, SortedArray, WeakSelf};
-use local_macros::{ast_type, enum_unwrapped, symbol_type, type_type};
+use local_macros::{ast_type, enum_unwrapped, node_unwrapped, symbol_type, type_type};
 
 #[derive(Debug)]
 pub struct Path(String);
@@ -318,6 +318,10 @@ impl Node {
             }
             _ => panic!("Expected union or intersection type"),
         }
+    }
+
+    pub fn as_expression(&self) -> &Expression {
+        node_unwrapped!(self, Expression)
     }
 }
 

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -9,9 +9,7 @@ use std::ops::BitAndAssign;
 use std::rc::{Rc, Weak};
 
 use crate::{NodeBuilder, Number, SortedArray, WeakSelf};
-use local_macros::{
-    ast_type, enum_unwrapped, node_unwrapped, symbol_type, type_type, type_unwrapped,
-};
+use local_macros::{ast_type, enum_unwrapped, symbol_type, type_type};
 
 #[derive(Debug)]
 pub struct Path(String);
@@ -353,6 +351,10 @@ impl Node {
 
     pub fn as_identifier(&self) -> &Identifier {
         enum_unwrapped!(self, [Node, Expression, Identifier])
+    }
+
+    pub fn as_type_node(&self) -> &TypeNode {
+        enum_unwrapped!(self, [Node, TypeNode])
     }
 }
 
@@ -1989,6 +1991,14 @@ impl Type {
     pub fn as_union_or_intersection_type(&self) -> &UnionOrIntersectionType {
         enum_unwrapped!(self, [Type, UnionOrIntersectionType])
     }
+
+    pub fn as_literal_type(&self) -> &LiteralType {
+        enum_unwrapped!(self, [Type, LiteralType])
+    }
+
+    pub fn as_freshable_intrinsic_type(&self) -> &FreshableIntrinsicType {
+        enum_unwrapped!(self, [Type, IntrinsicType, FreshableIntrinsicType])
+    }
 }
 
 pub trait TypeInterface {
@@ -2191,7 +2201,7 @@ impl StringLiteralType {
             self.value.clone(),
             Some(self.type_wrapper()),
         );
-        enum_unwrapped!(&*fresh_type, [Type, LiteralType]).set_fresh_type(&fresh_type);
+        fresh_type.as_literal_type().set_fresh_type(&fresh_type);
         self.set_fresh_type(&fresh_type);
         type_checker.keep_strong_reference_to_type(fresh_type);
         self.fresh_type().unwrap().upgrade().unwrap()
@@ -2246,7 +2256,7 @@ impl NumberLiteralType {
             self.value,
             Some(self.type_wrapper()),
         );
-        enum_unwrapped!(&*fresh_type, [Type, LiteralType]).set_fresh_type(&fresh_type);
+        fresh_type.as_literal_type().set_fresh_type(&fresh_type);
         self.set_fresh_type(&fresh_type);
         type_checker.keep_strong_reference_to_type(fresh_type);
         self.fresh_type().unwrap().upgrade().unwrap()
@@ -2301,7 +2311,7 @@ impl BigIntLiteralType {
             self.value.clone(),
             Some(self.type_wrapper()),
         );
-        enum_unwrapped!(&*fresh_type, [Type, LiteralType]).set_fresh_type(&fresh_type);
+        fresh_type.as_literal_type().set_fresh_type(&fresh_type);
         self.set_fresh_type(&fresh_type);
         type_checker.keep_strong_reference_to_type(fresh_type);
         self.fresh_type().unwrap().upgrade().unwrap()

--- a/src/compiler/utilities.rs
+++ b/src/compiler/utilities.rs
@@ -273,7 +273,7 @@ pub fn get_source_file_of_node<TNode: NodeInterface>(node: &TNode) -> Rc<SourceF
     while parent.kind() != SyntaxKind::SourceFile {
         parent = parent.parent();
     }
-    enum_unwrapped!(&*parent, [Node, SourceFile]).clone()
+    parent.as_source_file().clone()
 }
 
 pub fn node_is_missing<TNode: NodeInterface>(node: &TNode) -> bool {

--- a/src/compiler/utilities_public.rs
+++ b/src/compiler/utilities_public.rs
@@ -5,7 +5,6 @@ use crate::{
     CharacterCodes, Expression, Node, NodeFlags, NodeInterface, SyntaxKind, TextSpan, __String,
     is_block, is_module_block, is_source_file,
 };
-use local_macros::enum_unwrapped;
 
 fn create_text_span(start: isize, length: isize) -> TextSpan {
     TextSpan { start, length }
@@ -73,11 +72,10 @@ pub fn id_text<TNode: NodeInterface>(
     identifier_or_private_name: &TNode, /*Identifier | PrivateIdentifier*/
 ) -> String {
     unescape_leading_underscores(
-        &enum_unwrapped!(
-            &*identifier_or_private_name.node_wrapper(),
-            [Node, Expression, Identifier]
-        )
-        .escaped_text,
+        &identifier_or_private_name
+            .node_wrapper()
+            .as_identifier()
+            .escaped_text,
     )
 }
 


### PR DESCRIPTION
In this PR:
- expose `.as_*()` "unwrapping helpers" on `Node`/`Type` to improve the ergonomics on top of `enum_unwrapped!()`

To test:
Behavior should still be the same as of #40 

Based on `enum-unwrapped-macro`