### PR TITLE
Parse + bind type-alias declaration

### DIFF
--- a/src/compiler/binder.rs
+++ b/src/compiler/binder.rs
@@ -345,6 +345,9 @@ impl BinderType {
             SyntaxKind::InterfaceDeclaration => {
                 return ContainerFlags::IsContainer | ContainerFlags::IsInterface;
             }
+            SyntaxKind::TypeAliasDeclaration => {
+                return ContainerFlags::IsContainer | ContainerFlags::HasLocals;
+            }
             SyntaxKind::SourceFile => {
                 return ContainerFlags::IsContainer
                     | ContainerFlags::IsControlFlowContainer
@@ -378,6 +381,13 @@ impl BinderType {
             SyntaxKind::InterfaceDeclaration => Some(self.declare_symbol(
                 &mut *self.container().symbol().members().borrow_mut(),
                 Some(self.container().symbol()),
+                node,
+                symbol_flags,
+                symbol_excludes,
+            )),
+            SyntaxKind::TypeAliasDeclaration => Some(self.declare_symbol(
+                &mut *self.container().locals(),
+                Option::<&Symbol>::None,
                 node,
                 symbol_flags,
                 symbol_excludes,
@@ -497,6 +507,12 @@ impl BinderType {
                     interface_declaration,
                     SymbolFlags::Interface,
                     SymbolFlags::InterfaceExcludes,
+                ),
+            Node::Statement(Statement::TypeAliasDeclaration(type_alias_declaration)) => self
+                .bind_block_scoped_declaration(
+                    type_alias_declaration,
+                    SymbolFlags::TypeAlias,
+                    SymbolFlags::TypeAliasExcludes,
                 ),
             _ => (),
         }

--- a/src/compiler/factory/node_factory.rs
+++ b/src/compiler/factory/node_factory.rs
@@ -12,8 +12,8 @@ use crate::{
     IntersectionTypeNode, LiteralLikeNode, LiteralLikeNodeInterface, LiteralTypeNode, Node,
     NodeArray, NodeArrayOrVec, NodeFactory, NodeFlags, NumericLiteral, ObjectLiteralExpression,
     PrefixUnaryExpression, PropertyAssignment, PropertySignature, PseudoBigInt, SourceFile,
-    Statement, StringLiteral, SyntaxKind, TokenFlags, TypeLiteralNode, TypeNode,
-    TypeParameterDeclaration, TypeReferenceNode, UnionTypeNode, VariableDeclaration,
+    Statement, StringLiteral, SyntaxKind, TokenFlags, TypeAliasDeclaration, TypeLiteralNode,
+    TypeNode, TypeParameterDeclaration, TypeReferenceNode, UnionTypeNode, VariableDeclaration,
     VariableDeclarationList, VariableStatement,
 };
 
@@ -559,6 +559,26 @@ impl NodeFactory {
             type_parameters,
         );
         let node = InterfaceDeclaration::new(node, self.create_node_array(members, None));
+        node
+    }
+
+    pub fn create_type_alias_declaration<
+        TBaseNodeFactory: BaseNodeFactory,
+        TTypeParameters: Into<NodeArrayOrVec>,
+    >(
+        &self,
+        base_factory: &TBaseNodeFactory,
+        name: Rc<Node>,
+        type_parameters: Option<TTypeParameters>,
+        type_: Rc<Node>,
+    ) -> TypeAliasDeclaration {
+        let node = self.create_base_generic_named_declaration(
+            base_factory,
+            SyntaxKind::TypeAliasDeclaration,
+            name,
+            type_parameters,
+        );
+        let node = TypeAliasDeclaration::new(node, type_);
         node
     }
 

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -132,6 +132,15 @@ pub fn for_each_child<TNodeCallback: FnMut(Option<Rc<Node>>), TNodesCallback: Fn
                 Some(&interface_declaration.members),
             )
         }
+        Node::Statement(Statement::TypeAliasDeclaration(type_alias_declaration)) => {
+            visit_node(&mut cb_node, Some(type_alias_declaration.name()));
+            visit_nodes(
+                &mut cb_node,
+                &mut cb_nodes,
+                type_alias_declaration.maybe_type_parameters(),
+            );
+            visit_node(&mut cb_node, Some(type_alias_declaration.type_.clone()))
+        }
         _ => unimplemented!(),
     }
 }

--- a/src/compiler/scanner.rs
+++ b/src/compiler/scanner.rs
@@ -28,6 +28,7 @@ lazy_static! {
             ("interface".to_string(), SyntaxKind::InterfaceKeyword),
             ("number".to_string(), SyntaxKind::NumberKeyword),
             ("true".to_string(), SyntaxKind::TrueKeyword),
+            ("type".to_string(), SyntaxKind::TypeKeyword),
         ]));
 }
 

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -244,6 +244,9 @@ impl Node {
             Node::Statement(Statement::InterfaceDeclaration(interface_declaration)) => {
                 interface_declaration
             }
+            Node::Statement(Statement::TypeAliasDeclaration(type_alias_declaration)) => {
+                type_alias_declaration
+            }
             Node::TypeElement(type_element) => type_element,
             Node::PropertyAssignment(property_assignment) => property_assignment,
             _ => panic!("Expected named declaration"),
@@ -300,6 +303,9 @@ impl Node {
         match self {
             Node::Statement(Statement::InterfaceDeclaration(interface_declaration)) => {
                 interface_declaration
+            }
+            Node::Statement(Statement::TypeAliasDeclaration(type_alias_declaration)) => {
+                type_alias_declaration
             }
             _ => panic!("Expected has type parameters"),
         }
@@ -1379,7 +1385,7 @@ impl InterfaceDeclaration {
 )]
 pub struct TypeAliasDeclaration {
     _generic_named_declaration: BaseGenericNamedDeclaration, /*name: Identifier*/
-    type_: Rc<Node /*TypeNode*/>,
+    pub type_: Rc<Node /*TypeNode*/>,
 }
 
 impl TypeAliasDeclaration {
@@ -1620,6 +1626,7 @@ bitflags! {
         const PropertyExcludes = Self::None.bits;
         const InterfaceExcludes = Self::Type.bits & !(Self::Interface.bits | Self::Class.bits);
         const TypeParameterExcludes = Self::Type.bits & !Self::TypeParameter.bits;
+        const TypeAliasExcludes = Self::Type.bits;
     }
 }
 

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -93,6 +93,7 @@ pub enum SyntaxKind {
     ObjectKeyword,
     StringKeyword,
     SymbolKeyword,
+    TypeKeyword,
     UndefinedKeyword,
     UniqueKeyword,
     UnknownKeyword,
@@ -145,6 +146,7 @@ pub enum SyntaxKind {
     FunctionDeclaration,
     ClassDeclaration,
     InterfaceDeclaration,
+    TypeAliasDeclaration,
     ModuleBlock,
 
     CatchClause,
@@ -1152,6 +1154,7 @@ pub enum Statement {
     ExpressionStatement(ExpressionStatement),
     IfStatement(IfStatement),
     InterfaceDeclaration(InterfaceDeclaration),
+    TypeAliasDeclaration(TypeAliasDeclaration),
 }
 
 #[derive(Debug)]
@@ -1365,6 +1368,28 @@ impl InterfaceDeclaration {
         Self {
             _interface_or_class_like_declaration: base_interface_or_class_like_declaration,
             members,
+        }
+    }
+}
+
+#[derive(Debug)]
+#[ast_type(
+    ancestors = "Statement",
+    interfaces = "NamedDeclarationInterface, HasTypeParametersInterface"
+)]
+pub struct TypeAliasDeclaration {
+    _generic_named_declaration: BaseGenericNamedDeclaration, /*name: Identifier*/
+    type_: Rc<Node /*TypeNode*/>,
+}
+
+impl TypeAliasDeclaration {
+    pub fn new(
+        base_generic_named_declaration: BaseGenericNamedDeclaration,
+        type_: Rc<Node>,
+    ) -> Self {
+        Self {
+            _generic_named_declaration: base_generic_named_declaration,
+            type_,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,11 +64,11 @@ pub use compiler::types::{
     Statement, StringLiteral, StringLiteralType, StructureIsReused, Symbol, SymbolFlags,
     SymbolFormatFlags, SymbolId, SymbolInterface, SymbolLinks, SymbolTable, SymbolTracker,
     SymbolWriter, SyntaxKind, Ternary, TextSpan, TokenFlags, TransientSymbol,
-    TransientSymbolInterface, Type, TypeChecker, TypeCheckerHost, TypeElement, TypeFlags,
-    TypeFormatFlags, TypeId, TypeInterface, TypeLiteralNode, TypeMapper, TypeNode, TypeParameter,
-    TypeParameterDeclaration, TypeReference, TypeReferenceNode, UnionOrIntersectionType,
-    UnionOrIntersectionTypeInterface, UnionReduction, UnionType, UnionTypeNode,
-    VariableDeclaration, VariableDeclarationList, VariableLikeDeclarationInterface,
+    TransientSymbolInterface, Type, TypeAliasDeclaration, TypeChecker, TypeCheckerHost,
+    TypeElement, TypeFlags, TypeFormatFlags, TypeId, TypeInterface, TypeLiteralNode, TypeMapper,
+    TypeNode, TypeParameter, TypeParameterDeclaration, TypeReference, TypeReferenceNode,
+    UnionOrIntersectionType, UnionOrIntersectionTypeInterface, UnionReduction, UnionType,
+    UnionTypeNode, VariableDeclaration, VariableDeclarationList, VariableLikeDeclarationInterface,
     VariableStatement, __String,
 };
 pub use compiler::utilities::{


### PR DESCRIPTION
In this PR:
- parse + bind a simple type alias declaration

To test:
If you run `cargo run tmp.tsx` against a source file containing eg:
```
type Num = number;

const a: Num = true;
```
then in the `post-binding:` debug-logging you should see `Num` show up in the `locals` symbol table of the `SourceFile` and the first statement should be a `TypeAliasDeclaration` with `name` `"Num"` and `type_` a `NumberKeyword` `KeywordTypeNode` (and those should have initialized `parent` bindings)

Based on `type-check-generic-interface-pr-feedback`