### PR TITLE
Type-check type alias usage

### DIFF
--- a/src/compiler/checker/lines_32000_40000.rs
+++ b/src/compiler/checker/lines_32000_40000.rs
@@ -11,9 +11,9 @@ use crate::{
     HasTypeParametersInterface, IfStatement, InterfaceDeclaration, LiteralLikeNode,
     LiteralLikeNodeInterface, NamedDeclarationInterface, Node, NodeArray, NodeFlags, NodeInterface,
     PrefixUnaryExpression, PropertyAssignment, PropertySignature, PseudoBigInt, SymbolInterface,
-    SyntaxKind, Type, TypeChecker, TypeFlags, TypeInterface, TypeParameterDeclaration,
-    TypeReferenceNode, UnionOrIntersectionTypeInterface, VariableDeclaration,
-    VariableLikeDeclarationInterface, VariableStatement,
+    SyntaxKind, Type, TypeAliasDeclaration, TypeChecker, TypeFlags, TypeInterface,
+    TypeParameterDeclaration, TypeReferenceNode, UnionOrIntersectionTypeInterface,
+    VariableDeclaration, VariableLikeDeclarationInterface, VariableStatement,
 };
 
 impl TypeChecker {
@@ -450,5 +450,14 @@ impl TypeChecker {
             self.check_source_element(Some(&**member));
             Option::<()>::None
         });
+    }
+
+    pub(super) fn check_type_alias_declaration(&mut self, node: &TypeAliasDeclaration) {
+        self.check_type_parameters(node.maybe_type_parameters());
+        if false {
+            unimplemented!()
+        } else {
+            self.check_source_element(Some(&*node.type_));
+        }
     }
 }

--- a/src/compiler/checker/lines_40000_end.rs
+++ b/src/compiler/checker/lines_40000_end.rs
@@ -48,6 +48,9 @@ impl TypeChecker {
             Node::Statement(Statement::InterfaceDeclaration(interface_declaration)) => {
                 self.check_interface_declaration(interface_declaration)
             }
+            Node::Statement(Statement::TypeAliasDeclaration(type_alias_declaration)) => {
+                self.check_type_alias_declaration(type_alias_declaration)
+            }
             _ => unimplemented!("{:?}", node.kind()),
         };
     }

--- a/src/compiler/checker/lines_8000_12000.rs
+++ b/src/compiler/checker/lines_8000_12000.rs
@@ -302,6 +302,7 @@ impl TypeChecker {
                 || node.kind() == SyntaxKind::ClassDeclaration
                 || node.kind() == SyntaxKind::ClassExpression
                 || false
+                || is_type_alias(&**node)
             {
                 let declaration = node;
                 result = self.append_type_parameters(
@@ -389,13 +390,29 @@ impl TypeChecker {
                         declarations
                             .iter()
                             .find(|declaration| is_type_alias(&***declaration))
+                            .map(|rc| rc.clone())
                     }),
                 None,
             );
-            // links.declared_type = Some(
-            //     self.create_type_parameter(Some(symbol.symbol_wrapper()))
-            //         .into(),
-            // );
+            let type_node = if false {
+                unimplemented!()
+            } else {
+                Some(declaration.as_type_alias_declaration().type_.clone())
+            };
+            let type_ = type_node.map_or_else(
+                || self.error_type(),
+                |type_node| self.get_type_from_type_node(&type_node),
+            );
+            if true {
+                let type_parameters =
+                    self.get_local_type_parameters_of_class_or_interface_or_type_alias(symbol);
+                if let Some(type_parameters) = type_parameters {
+                    unimplemented!()
+                }
+            } else {
+                unimplemented!()
+            }
+            links.declared_type = Some(type_);
         }
         links.declared_type.clone().unwrap()
     }

--- a/src/compiler/factory/node_tests.rs
+++ b/src/compiler/factory/node_tests.rs
@@ -44,6 +44,10 @@ pub fn is_variable_declaration<TNode: NodeInterface>(node: &TNode) -> bool {
     node.kind() == SyntaxKind::VariableDeclaration
 }
 
+pub fn is_type_alias_declaration<TNode: NodeInterface>(node: &TNode) -> bool {
+    node.kind() == SyntaxKind::TypeAliasDeclaration
+}
+
 pub fn is_module_block<TNode: NodeInterface>(node: &TNode) -> bool {
     node.kind() == SyntaxKind::ModuleBlock
 }

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -367,6 +367,10 @@ impl Node {
     pub fn as_type_node(&self) -> &TypeNode {
         enum_unwrapped!(self, [Node, TypeNode])
     }
+
+    pub fn as_type_alias_declaration(&self) -> &TypeAliasDeclaration {
+        enum_unwrapped!(self, [Node, Statement, TypeAliasDeclaration])
+    }
 }
 
 #[derive(Debug)]

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -159,6 +159,9 @@ pub enum SyntaxKind {
 
     JSDocFunctionType,
     JSDocSignature,
+    JSDocCallbackTag,
+    JSDocEnumTag,
+    JSDocTypedefTag,
 }
 
 impl SyntaxKind {

--- a/src/compiler/utilities.rs
+++ b/src/compiler/utilities.rs
@@ -13,15 +13,15 @@ use crate::{
     SymbolTracker, SymbolWriter, SyntaxKind, TextSpan, TypeFlags, __String,
     compare_strings_case_sensitive, compare_values, create_text_span_from_bounds,
     escape_leading_underscores, for_each, get_combined_node_flags, get_name_of_declaration,
-    insert_sorted, is_big_int_literal, is_member_name, skip_trivia, BaseDiagnostic,
-    BaseDiagnosticRelatedInformation, BaseNode, BaseSymbol, BaseType, CharacterCodes, CheckFlags,
-    Comparison, Debug_, Diagnostic, DiagnosticCollection, DiagnosticInterface, DiagnosticMessage,
-    DiagnosticMessageChain, DiagnosticMessageText, DiagnosticRelatedInformation,
-    DiagnosticRelatedInformationInterface, DiagnosticWithDetachedLocation, DiagnosticWithLocation,
-    EmitFlags, EmitTextWriter, Expression, LiteralLikeNode, LiteralLikeNodeInterface, Node,
-    NodeFlags, NodeInterface, ObjectFlags, PrefixUnaryExpression, PseudoBigInt, ReadonlyTextRange,
-    SortedArray, SourceFile, Symbol, SymbolFlags, SymbolInterface, SymbolTable,
-    TransientSymbolInterface, Type, TypeInterface,
+    insert_sorted, is_big_int_literal, is_member_name, is_type_alias_declaration, skip_trivia,
+    BaseDiagnostic, BaseDiagnosticRelatedInformation, BaseNode, BaseSymbol, BaseType,
+    CharacterCodes, CheckFlags, Comparison, Debug_, Diagnostic, DiagnosticCollection,
+    DiagnosticInterface, DiagnosticMessage, DiagnosticMessageChain, DiagnosticMessageText,
+    DiagnosticRelatedInformation, DiagnosticRelatedInformationInterface,
+    DiagnosticWithDetachedLocation, DiagnosticWithLocation, EmitFlags, EmitTextWriter, Expression,
+    LiteralLikeNode, LiteralLikeNodeInterface, Node, NodeFlags, NodeInterface, ObjectFlags,
+    PrefixUnaryExpression, PseudoBigInt, ReadonlyTextRange, SortedArray, SourceFile, Symbol,
+    SymbolFlags, SymbolInterface, SymbolTable, TransientSymbolInterface, Type, TypeInterface,
 };
 use local_macros::enum_unwrapped;
 
@@ -378,6 +378,17 @@ pub fn set_value_declaration<TNode: NodeInterface>(symbol: &Symbol, node: &TNode
         }
     }
     symbol.set_value_declaration(node.node_wrapper());
+}
+
+fn is_jsdoc_type_alias<TNode: NodeInterface>(node: &TNode) -> bool {
+    matches!(
+        node.kind(),
+        SyntaxKind::JSDocTypedefTag | SyntaxKind::JSDocCallbackTag | SyntaxKind::JSDocEnumTag
+    )
+}
+
+pub fn is_type_alias<TNode: NodeInterface>(node: &TNode) -> bool {
+    is_jsdoc_type_alias(node) || is_type_alias_declaration(node)
 }
 
 fn walk_up<TNode: NodeInterface>(node: &TNode, kind: SyntaxKind) -> Option<Rc<Node>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub use compiler::factory::node_tests::{
     is_big_int_literal, is_binding_element, is_block, is_class_static_block_declaration,
     is_identifier, is_module_block, is_object_literal_expression, is_omitted_expression,
     is_private_identifier, is_property_assignment, is_property_declaration, is_property_signature,
-    is_source_file, is_variable_declaration,
+    is_source_file, is_type_alias_declaration, is_variable_declaration,
 };
 pub use compiler::parser::{create_source_file, for_each_child, MissingNode};
 pub use compiler::path::{normalize_path, to_path};
@@ -79,9 +79,9 @@ pub use compiler::utilities::{
     get_effective_type_annotation_node, get_escaped_text_of_identifier_or_literal,
     get_first_identifier, get_literal_text, get_object_flags, get_source_file_of_node,
     has_dynamic_name, is_block_or_catch_scoped, is_external_or_common_js_module, is_keyword,
-    is_property_name_literal, is_write_only_access, node_is_missing, object_allocator,
-    parse_pseudo_big_int, position_is_synthesized, pseudo_big_int_to_string, set_parent,
-    set_text_range_pos_end, set_value_declaration, using_single_line_string_writer,
+    is_property_name_literal, is_type_alias, is_write_only_access, node_is_missing,
+    object_allocator, parse_pseudo_big_int, position_is_synthesized, pseudo_big_int_to_string,
+    set_parent, set_text_range_pos_end, set_value_declaration, using_single_line_string_writer,
     GetLiteralTextFlags, OperatorPrecedence,
 };
 pub use compiler::utilities_public::{


### PR DESCRIPTION
In this PR:
- type-check usage of a simple type alias

To test:
If you run `cargo run tmp.tsx` against a source file containing eg:
```
type Num = number;

const a: Num = true;
```
then you should see a diagnostic debug-logged with message `Type 'boolean' is not assignable to type 'number'.`
If you run `cargo run tmp.tsx` against a source file containing eg:
```
type Num = number;

const a: Num = 1;
```
then you should see no diagnostics debug-logged 

Based on `parse-type-alias-declaration`