### PR TITLE
Parse block comment

### DIFF
--- a/src/compiler/checker/lines_0_1000.rs
+++ b/src/compiler/checker/lines_0_1000.rs
@@ -8,8 +8,8 @@ use std::rc::Rc;
 use super::create_node_builder;
 use crate::{
     __String, create_diagnostic_collection, create_symbol_table, object_allocator,
-    DiagnosticCollection, FreshableIntrinsicType, IntrinsicType, NodeId, NodeInterface, Number,
-    ObjectFlags, Symbol, SymbolFlags, SymbolId, SymbolInterface, SymbolTable, Type, TypeChecker,
+    DiagnosticCollection, FreshableIntrinsicType, NodeId, NodeInterface, Number, ObjectFlags,
+    Symbol, SymbolFlags, SymbolId, SymbolInterface, SymbolTable, Type, TypeChecker,
     TypeCheckerHost, TypeFlags,
 };
 

--- a/src/compiler/checker/lines_16000_18000.rs
+++ b/src/compiler/checker/lines_16000_18000.rs
@@ -8,8 +8,8 @@ use std::rc::Rc;
 use super::{CheckMode, CheckTypeRelatedTo};
 use crate::{
     get_check_flags, pseudo_big_int_to_string, ArrayTypeNode, BaseLiteralType, BigIntLiteralType,
-    CheckFlags, Debug_, DiagnosticMessage, Expression, IntrinsicType, LiteralTypeInterface,
-    LiteralTypeNode, NamedDeclarationInterface, Node, NodeInterface, Number, NumberLiteralType,
+    CheckFlags, Debug_, DiagnosticMessage, Expression, LiteralTypeInterface, LiteralTypeNode,
+    NamedDeclarationInterface, Node, NodeInterface, Number, NumberLiteralType,
     ObjectLiteralExpression, PseudoBigInt, RelationComparisonResult, StringLiteralType, Symbol,
     SymbolInterface, SyntaxKind, TransientSymbolInterface, Type, TypeChecker, TypeFlags,
     TypeInterface, TypeMapper, TypeNode, UnionOrIntersectionType,

--- a/src/compiler/checker/lines_18000_20000.rs
+++ b/src/compiler/checker/lines_18000_20000.rs
@@ -74,7 +74,7 @@ impl<'type_checker> CheckTypeRelatedTo<'type_checker> {
         } else if false {
             unimplemented!()
         } else if self.error_info().is_some() {
-            let related_information: Option<Vec<DiagnosticRelatedInformation>> = None;
+            let related_information: Option<Vec<Rc<DiagnosticRelatedInformation>>> = None;
             let diag = create_diagnostic_for_node_from_message_chain(
                 &*self.error_node.unwrap(),
                 self.error_info().clone().unwrap(),

--- a/src/compiler/checker/lines_20000_24000.rs
+++ b/src/compiler/checker/lines_20000_24000.rs
@@ -5,8 +5,8 @@ use std::rc::Rc;
 
 use crate::{
     every, for_each, get_object_flags, is_write_only_access, node_is_missing, Debug_,
-    DiagnosticMessage, Diagnostics, Expression, Identifier, Node, NodeInterface, ObjectFlags,
-    Symbol, SymbolFlags, Type, TypeChecker, TypeFlags, TypeInterface, UnionReduction,
+    DiagnosticMessage, Diagnostics, Identifier, Node, NodeInterface, ObjectFlags, Symbol,
+    SymbolFlags, Type, TypeChecker, TypeFlags, TypeInterface, UnionReduction,
 };
 
 impl TypeChecker {

--- a/src/compiler/checker/lines_24000_32000.rs
+++ b/src/compiler/checker/lines_24000_32000.rs
@@ -7,10 +7,10 @@ use std::rc::Rc;
 use super::CheckMode;
 use crate::{
     __String, create_symbol_table, get_effective_type_annotation_node, get_object_flags,
-    has_initializer, is_object_literal_expression, Expression, HasExpressionInitializerInterface,
-    Identifier, Node, NodeInterface, ObjectFlags, ObjectFlagsTypeInterface,
-    ObjectLiteralExpression, PropertyAssignment, Symbol, SymbolInterface, SyntaxKind, Type,
-    TypeChecker, TypeFlags, TypeInterface,
+    has_initializer, is_object_literal_expression, HasExpressionInitializerInterface, Identifier,
+    Node, NodeInterface, ObjectFlags, ObjectFlagsTypeInterface, ObjectLiteralExpression,
+    PropertyAssignment, Symbol, SymbolInterface, SyntaxKind, Type, TypeChecker, TypeFlags,
+    TypeInterface,
 };
 
 impl TypeChecker {

--- a/src/compiler/checker/lines_40000_end.rs
+++ b/src/compiler/checker/lines_40000_end.rs
@@ -78,7 +78,9 @@ impl TypeChecker {
     ) -> Vec<Rc<Diagnostic>> {
         self.check_source_file(source_file);
 
-        let semantic_diagnostics = self.diagnostics().get_diagnostics(&source_file.file_name);
+        let semantic_diagnostics = self
+            .diagnostics()
+            .get_diagnostics(&*source_file.file_name());
 
         semantic_diagnostics
     }

--- a/src/compiler/checker/lines_4000_8000.rs
+++ b/src/compiler/checker/lines_4000_8000.rs
@@ -9,11 +9,10 @@ use crate::{
     get_source_file_of_node, get_synthetic_factory, is_expression, is_identifier_text,
     unescape_leading_underscores, using_single_line_string_writer, BaseIntrinsicType,
     BaseNodeFactorySynthetic, BaseObjectType, BaseType, CharacterCodes, Debug_, EmitHint,
-    EmitTextWriter, Expression, KeywordTypeNode, LiteralType, Node, NodeArray, NodeBuilderFlags,
-    NodeInterface, Number, ObjectFlags, PrinterOptions, ResolvableTypeInterface,
-    ResolvedTypeInterface, SourceFile, Symbol, SymbolFlags, SymbolFormatFlags, SymbolInterface,
-    SymbolTable, SymbolTracker, SyntaxKind, Type, TypeChecker, TypeFlags, TypeFormatFlags,
-    TypeInterface, TypeParameter,
+    EmitTextWriter, Expression, KeywordTypeNode, Node, NodeArray, NodeBuilderFlags, NodeInterface,
+    ObjectFlags, PrinterOptions, ResolvableTypeInterface, ResolvedTypeInterface, SourceFile,
+    Symbol, SymbolFlags, SymbolFormatFlags, SymbolInterface, SymbolTable, SymbolTracker,
+    SyntaxKind, Type, TypeChecker, TypeFlags, TypeFormatFlags, TypeInterface, TypeParameter,
 };
 
 impl TypeChecker {

--- a/src/compiler/debug.rs
+++ b/src/compiler/debug.rs
@@ -1,5 +1,7 @@
 #![allow(non_upper_case_globals)]
 
+use std::fmt;
+
 pub struct DebugType {}
 
 impl DebugType {
@@ -17,6 +19,29 @@ impl DebugType {
                 format!("False expression: {}", message)
             });
             self.fail(Some(&message));
+        }
+    }
+
+    pub fn assert_equal<TValue: Eq + fmt::Debug>(
+        &self,
+        a: &TValue,
+        b: &TValue,
+        msg: Option<&str>,
+        msg2: Option<&str>,
+    ) {
+        if a != b {
+            let message = match (msg, msg2) {
+                (Some(msg), Some(msg2)) => format!("{} {}", msg, msg2),
+                (Some(msg), _) => msg.to_string(),
+                _ => "".to_string(),
+            };
+            self.fail(Some(&format!("Expected {:?} === {:?}. {}", a, b, &message)));
+        }
+    }
+
+    pub fn assert_less_than_or_equal<TValue: Ord + fmt::Debug>(&self, a: TValue, b: TValue) {
+        if a > b {
+            self.fail(Some(&format!("Expected {:?} <= {:?}", a, b)));
         }
     }
 

--- a/src/compiler/utilities.rs
+++ b/src/compiler/utilities.rs
@@ -7,6 +7,7 @@ use std::cell::RefCell;
 use std::cmp;
 use std::cmp::Ordering;
 use std::collections::HashMap;
+use std::convert::TryInto;
 use std::rc::Rc;
 
 use crate::{
@@ -315,7 +316,7 @@ fn create_diagnostic_for_node_in_source_file<TNode: NodeInterface>(
 pub fn create_diagnostic_for_node_from_message_chain<TNode: NodeInterface>(
     node: &TNode,
     message_chain: DiagnosticMessageChain,
-    related_information: Option<Vec<DiagnosticRelatedInformation>>,
+    related_information: Option<Vec<Rc<DiagnosticRelatedInformation>>>,
 ) -> DiagnosticWithLocation {
     let source_file = get_source_file_of_node(node);
     let span = get_error_span_for_node(source_file.clone(), node);
@@ -333,7 +334,7 @@ fn create_file_diagnostic_from_message_chain(
     start: isize,
     length: isize,
     message_chain: DiagnosticMessageChain,
-    related_information: Option<Vec<DiagnosticRelatedInformation>>,
+    related_information: Option<Vec<Rc<DiagnosticRelatedInformation>>>,
 ) -> DiagnosticWithLocation {
     // assert_diagnostic_location(&*file, start, length);
     DiagnosticWithLocation::new(BaseDiagnostic::new(
@@ -504,7 +505,7 @@ impl DiagnosticCollection {
     pub fn add(&mut self, diagnostic: Rc<Diagnostic>) {
         if let Some(diagnostics) = self
             .file_diagnostics
-            .get_mut(&diagnostic.file().unwrap().file_name)
+            .get_mut(&*diagnostic.file().unwrap().file_name())
         {
             insert_sorted(
                 diagnostics,
@@ -517,12 +518,12 @@ impl DiagnosticCollection {
         }
         let diagnostics: SortedArray<Rc<Diagnostic>> = SortedArray::new(vec![]);
         self.file_diagnostics.insert(
-            diagnostic.file().unwrap().file_name.to_string(),
+            diagnostic.file().unwrap().file_name().to_string(),
             diagnostics,
         );
         let diagnostics = self
             .file_diagnostics
-            .get_mut(&diagnostic.file().unwrap().file_name)
+            .get_mut(&*diagnostic.file().unwrap().file_name())
             .unwrap();
         insert_sorted(
             diagnostics,
@@ -814,6 +815,77 @@ pub fn create_detached_diagnostic(
     )
 }
 
+fn is_diagnostic_with_detached_location(
+    diagnostic: &DiagnosticRelatedInformation, /*DiagnosticRelatedInformation | DiagnosticWithDetachedLocation*/
+) -> bool {
+    matches!(
+        diagnostic,
+        DiagnosticRelatedInformation::Diagnostic(Diagnostic::DiagnosticWithDetachedLocation(_))
+    )
+}
+
+pub fn attach_file_to_diagnostic(
+    diagnostic: &DiagnosticWithDetachedLocation,
+    file: &Rc<SourceFile>,
+) -> DiagnosticWithLocation {
+    let file_name = file.file_name();
+    let length: isize = file.text.len().try_into().unwrap();
+    Debug_.assert_equal(&diagnostic.file_name, &*file_name, None, None);
+    Debug_.assert_less_than_or_equal(diagnostic.start(), length);
+    Debug_.assert_less_than_or_equal(diagnostic.start() + diagnostic.length(), length);
+    let mut diagnostic_with_location = DiagnosticWithLocation::new(BaseDiagnostic::new(
+        BaseDiagnosticRelatedInformation::new(
+            diagnostic.code(),
+            Some(file.clone()),
+            diagnostic.start(),
+            diagnostic.length(),
+            diagnostic.message_text().clone(),
+        ),
+        None,
+    ));
+    if let Some(related_information) = diagnostic.maybe_related_information() {
+        diagnostic_with_location.set_related_information(
+            related_information
+                .iter()
+                .map(|related| {
+                    if is_diagnostic_with_detached_location(related)
+                        && &related.as_diagnostic_with_detached_location().file_name == &*file_name
+                    {
+                        Debug_.assert_less_than_or_equal(related.start(), length);
+                        Debug_
+                            .assert_less_than_or_equal(related.start() + related.length(), length);
+                        Rc::new(
+                            attach_file_to_diagnostic(
+                                related.as_diagnostic_with_detached_location(),
+                                file,
+                            )
+                            .into(),
+                        )
+                    } else {
+                        related.clone()
+                    }
+                })
+                .collect(),
+        );
+    }
+    diagnostic_with_location
+}
+
+pub fn attach_file_to_diagnostics(
+    diagnostics: &[Rc<Diagnostic /*DiagnosticWithDetachedLocation*/>],
+    file: &Rc<SourceFile>,
+) -> Vec<Rc<Diagnostic /*DiagnosticWithLocation*/>> {
+    diagnostics
+        .iter()
+        .map(|diagnostic| {
+            Rc::new(
+                attach_file_to_diagnostic(diagnostic.as_diagnostic_with_detached_location(), file)
+                    .into(),
+            )
+        })
+        .collect()
+}
+
 fn create_file_diagnostic(
     file: Rc<SourceFile>,
     start: isize,
@@ -855,7 +927,7 @@ fn get_diagnostic_file_path<
 ) -> Option<String> {
     diagnostic
         .file()
-        .and_then(|file| file.path.as_ref().map(|path| path.to_string()))
+        .and_then(|file| file.maybe_path().as_ref().map(|path| path.to_string()))
 }
 
 fn compare_diagnostics<TDiagnosticRelatedInformation: DiagnosticRelatedInformationInterface>(
@@ -924,7 +996,7 @@ fn compare_related_information(d1: &Diagnostic, d2: &Diagnostic) -> Comparison {
             }
             let compared_maybe = for_each(d1_related_information, |d1i, index| {
                 let d2i = &d2_related_information[index];
-                let compared = compare_diagnostics(d1i, d2i);
+                let compared = compare_diagnostics(&**d1i, &**d2i);
                 match compared {
                     Comparison::EqualTo => None,
                     compared => Some(compared),

--- a/src/compiler/utilities.rs
+++ b/src/compiler/utilities.rs
@@ -930,7 +930,7 @@ fn get_diagnostic_file_path<
         .and_then(|file| file.maybe_path().as_ref().map(|path| path.to_string()))
 }
 
-fn compare_diagnostics<TDiagnosticRelatedInformation: DiagnosticRelatedInformationInterface>(
+pub fn compare_diagnostics<TDiagnosticRelatedInformation: DiagnosticRelatedInformationInterface>(
     d1: &TDiagnosticRelatedInformation,
     d2: &TDiagnosticRelatedInformation,
 ) -> Comparison {

--- a/src/compiler/utilities_public.rs
+++ b/src/compiler/utilities_public.rs
@@ -2,8 +2,8 @@ use std::borrow::Borrow;
 use std::rc::Rc;
 
 use crate::{
-    CharacterCodes, Expression, Node, NodeFlags, NodeInterface, SyntaxKind, TextSpan, __String,
-    is_block, is_module_block, is_source_file,
+    CharacterCodes, Node, NodeFlags, NodeInterface, SyntaxKind, TextSpan, __String, is_block,
+    is_module_block, is_source_file,
 };
 
 fn create_text_span(start: isize, length: isize) -> TextSpan {

--- a/src/compiler/utilities_public.rs
+++ b/src/compiler/utilities_public.rs
@@ -2,9 +2,20 @@ use std::borrow::Borrow;
 use std::rc::Rc;
 
 use crate::{
-    CharacterCodes, Node, NodeFlags, NodeInterface, SyntaxKind, TextSpan, __String, is_block,
-    is_module_block, is_source_file,
+    CharacterCodes, Node, NodeFlags, NodeInterface, SyntaxKind, TextSpan, __String,
+    compare_diagnostics, is_block, is_module_block, is_source_file, sort_and_deduplicate,
+    Diagnostic, SortedArray,
 };
+
+pub fn sort_and_deduplicate_diagnostics(
+    diagnostics: &[Rc<Diagnostic>],
+) -> SortedArray<Rc<Diagnostic>> {
+    sort_and_deduplicate(
+        diagnostics,
+        &|a, b| compare_diagnostics(&**a, &**b),
+        Option::<&fn(&Rc<Diagnostic>, &Rc<Diagnostic>) -> bool>::None,
+    )
+}
 
 fn create_text_span(start: isize, length: isize) -> TextSpan {
     TextSpan { start, length }
@@ -25,7 +36,7 @@ fn get_combined_flags<TNode: NodeInterface, TCallback: FnMut(&Node) -> NodeFlags
     }
     if let Some(node_present) = node.as_ref() {
         if node_present.kind() == SyntaxKind::VariableDeclarationList {
-            flags |= get_flags(&node_present);
+            flags |= get_flags(node_present);
             node = node_present.maybe_parent();
         }
     }

--- a/src/compiler/watch.rs
+++ b/src/compiler/watch.rs
@@ -1,15 +1,37 @@
 use std::rc::Rc;
 
-use crate::{Diagnostic, ExitStatus, Program};
+use crate::{
+    add_range, sort_and_deduplicate_diagnostics, Diagnostic, ExitStatus, Program, SortedArray,
+};
 
 struct EmitFilesAndReportErrorsReturn {
-    diagnostics: Vec<Rc<Diagnostic>>,
+    diagnostics: SortedArray<Rc<Diagnostic>>,
 }
 
 fn emit_files_and_report_errors<TProgram: Program>(
     mut program: TProgram,
 ) -> EmitFilesAndReportErrorsReturn {
-    let diagnostics = program.get_semantic_diagnostics();
+    let mut all_diagnostics: Vec<Rc<Diagnostic>> = vec![];
+    let config_file_parsing_diagnostics_length = all_diagnostics.len();
+    add_range(
+        &mut all_diagnostics,
+        Some(&program.get_syntactic_diagnostics()),
+        None,
+        None,
+    );
+
+    if all_diagnostics.len() == config_file_parsing_diagnostics_length {
+        if true {
+            add_range(
+                &mut all_diagnostics,
+                Some(&program.get_semantic_diagnostics()),
+                None,
+                None,
+            );
+        }
+    }
+
+    let diagnostics = sort_and_deduplicate_diagnostics(&all_diagnostics);
 
     EmitFilesAndReportErrorsReturn { diagnostics }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,10 @@ pub use compiler::binder::bind_source_file;
 pub use compiler::checker::{create_type_checker, NodeBuilder};
 pub use compiler::command_line_parser::parse_command_line;
 pub use compiler::core::{
-    append_if_unique, binary_search, binary_search_copy_key, compare_strings_case_sensitive,
-    compare_values, concatenate, every, first_defined, first_or_undefined, for_each, insert_sorted,
-    last_or_undefined, map, maybe_for_each, range_equals, some,
+    add_range, append_if_unique, binary_search, binary_search_copy_key,
+    compare_strings_case_sensitive, compare_values, concatenate, every, first_defined,
+    first_or_undefined, for_each, insert_sorted, last_or_undefined, map, maybe_for_each,
+    range_equals, some, sort_and_deduplicate,
 };
 pub use compiler::core_public::{Comparer, Comparison, SortedArray};
 pub use compiler::debug::Debug_;
@@ -72,8 +73,8 @@ pub use compiler::types::{
     VariableStatement, __String,
 };
 pub use compiler::utilities::{
-    attach_file_to_diagnostics, chain_diagnostic_messages, create_detached_diagnostic,
-    create_diagnostic_collection, create_diagnostic_for_node,
+    attach_file_to_diagnostics, chain_diagnostic_messages, compare_diagnostics,
+    create_detached_diagnostic, create_diagnostic_collection, create_diagnostic_for_node,
     create_diagnostic_for_node_from_message_chain, create_symbol_table, create_text_writer,
     declaration_name_to_string, get_binary_operator_precedence, get_check_flags,
     get_declaration_of_kind, get_effective_initializer, get_effective_type_annotation_node,
@@ -89,7 +90,8 @@ pub use compiler::utilities_public::{
     create_text_span_from_bounds, escape_leading_underscores, get_combined_node_flags,
     get_effective_type_parameter_declarations, get_name_of_declaration, has_initializer,
     has_only_expression_initializer, id_text, is_binding_pattern, is_expression, is_function_like,
-    is_function_or_module_block, is_literal_kind, is_member_name, unescape_leading_underscores,
+    is_function_or_module_block, is_literal_kind, is_member_name, sort_and_deduplicate_diagnostics,
+    unescape_leading_underscores,
 };
 pub use compiler::watch::emit_files_and_report_errors_and_get_exit_status;
 pub use execute_command_line::execute_command_line::execute_command_line;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,8 @@ pub use compiler::scanner::{
 };
 pub use compiler::sys::{get_sys, System};
 pub use compiler::types::{
-    ArrayLiteralExpression, ArrayTypeNode, BaseBindingLikeDeclaration, BaseDiagnostic,
-    BaseDiagnosticRelatedInformation, BaseGenericNamedDeclaration,
+    rc_source_file_into_rc_node, ArrayLiteralExpression, ArrayTypeNode, BaseBindingLikeDeclaration,
+    BaseDiagnostic, BaseDiagnosticRelatedInformation, BaseGenericNamedDeclaration,
     BaseInterfaceOrClassLikeDeclaration, BaseInterfaceType, BaseIntrinsicType, BaseLiteralLikeNode,
     BaseLiteralType, BaseNamedDeclaration, BaseNode, BaseObjectType, BaseSymbol,
     BaseTransientSymbol, BaseType, BaseUnionOrIntersectionType, BaseVariableLikeDeclaration,
@@ -72,17 +72,18 @@ pub use compiler::types::{
     VariableStatement, __String,
 };
 pub use compiler::utilities::{
-    chain_diagnostic_messages, create_detached_diagnostic, create_diagnostic_collection,
-    create_diagnostic_for_node, create_diagnostic_for_node_from_message_chain, create_symbol_table,
-    create_text_writer, declaration_name_to_string, get_binary_operator_precedence,
-    get_check_flags, get_declaration_of_kind, get_effective_initializer,
-    get_effective_type_annotation_node, get_escaped_text_of_identifier_or_literal,
-    get_first_identifier, get_literal_text, get_object_flags, get_source_file_of_node,
-    has_dynamic_name, is_block_or_catch_scoped, is_external_or_common_js_module, is_keyword,
-    is_property_name_literal, is_type_alias, is_write_only_access, node_is_missing,
-    object_allocator, parse_pseudo_big_int, position_is_synthesized, pseudo_big_int_to_string,
-    set_parent, set_text_range_pos_end, set_value_declaration, using_single_line_string_writer,
-    GetLiteralTextFlags, OperatorPrecedence,
+    attach_file_to_diagnostics, chain_diagnostic_messages, create_detached_diagnostic,
+    create_diagnostic_collection, create_diagnostic_for_node,
+    create_diagnostic_for_node_from_message_chain, create_symbol_table, create_text_writer,
+    declaration_name_to_string, get_binary_operator_precedence, get_check_flags,
+    get_declaration_of_kind, get_effective_initializer, get_effective_type_annotation_node,
+    get_escaped_text_of_identifier_or_literal, get_first_identifier, get_literal_text,
+    get_object_flags, get_source_file_of_node, has_dynamic_name, is_block_or_catch_scoped,
+    is_external_or_common_js_module, is_keyword, is_property_name_literal, is_type_alias,
+    is_write_only_access, node_is_missing, object_allocator, parse_pseudo_big_int,
+    position_is_synthesized, pseudo_big_int_to_string, set_parent, set_text_range_pos_end,
+    set_value_declaration, using_single_line_string_writer, GetLiteralTextFlags,
+    OperatorPrecedence,
 };
 pub use compiler::utilities_public::{
     create_text_span_from_bounds, escape_leading_underscores, get_combined_node_flags,


### PR DESCRIPTION
In this PR:
- parse block comment
- include parsing diagnostics in emitted diagnostics

To test:
If you run `cargo run tmp.tsx` against a source file containing eg:
```
/* abc
 * def */
++a
```
then you should see a diagnostic debug-logged with message `Cannot find name 'a'.`
If you run `cargo run tmp.tsx` against a source file containing eg:
```
/* a
```
then you should see a diagnostic debug-logged with message `'*/' expected.`

Based on `type-check-type-alias`