### PR TITLE
Type-check template literal

### DIFF
--- a/src/compiler/checker/lines_0_1000.rs
+++ b/src/compiler/checker/lines_0_1000.rs
@@ -134,6 +134,9 @@ pub fn create_type_checker<TTypeCheckerHost: TypeCheckerHost>(
 
         any_type: None,
         error_type: None,
+        undefined_type: None,
+        null_type: None,
+        string_type: None,
         number_type: None,
         bigint_type: None,
         true_type: None,
@@ -143,6 +146,7 @@ pub fn create_type_checker<TTypeCheckerHost: TypeCheckerHost>(
         boolean_type: None,
         never_type: None,
         number_or_big_int_type: None,
+        template_constraint_type: None,
 
         global_array_type: None,
 
@@ -171,6 +175,21 @@ pub fn create_type_checker<TTypeCheckerHost: TypeCheckerHost>(
     type_checker.error_type = Some(
         type_checker
             .create_intrinsic_type(TypeFlags::Any, "error")
+            .into(),
+    );
+    type_checker.undefined_type = Some(
+        type_checker
+            .create_intrinsic_type(TypeFlags::Undefined, "undefined")
+            .into(),
+    );
+    type_checker.null_type = Some(
+        type_checker
+            .create_intrinsic_type(TypeFlags::Null, "null")
+            .into(),
+    );
+    type_checker.string_type = Some(
+        type_checker
+            .create_intrinsic_type(TypeFlags::String, "string")
             .into(),
     );
     type_checker.number_type = Some(
@@ -249,6 +268,17 @@ pub fn create_type_checker<TTypeCheckerHost: TypeCheckerHost>(
         vec![type_checker.number_type(), type_checker.bigint_type()],
         None,
     ));
+    type_checker.template_constraint_type = Some(type_checker.get_union_type(
+        vec![
+            type_checker.string_type(),
+            type_checker.number_type(),
+            type_checker.boolean_type(),
+            type_checker.bigint_type(),
+            type_checker.null_type(),
+            type_checker.undefined_type(),
+        ],
+        None,
+    ));
     type_checker.initialize_type_checker(host);
     type_checker
 }
@@ -306,6 +336,18 @@ impl TypeChecker {
         self.error_type.as_ref().unwrap().clone()
     }
 
+    pub(super) fn undefined_type(&self) -> Rc<Type> {
+        self.undefined_type.as_ref().unwrap().clone()
+    }
+
+    pub(super) fn null_type(&self) -> Rc<Type> {
+        self.null_type.as_ref().unwrap().clone()
+    }
+
+    pub(super) fn string_type(&self) -> Rc<Type> {
+        self.string_type.as_ref().unwrap().clone()
+    }
+
     pub(super) fn number_type(&self) -> Rc<Type> {
         self.number_type.as_ref().unwrap().clone()
     }
@@ -340,6 +382,10 @@ impl TypeChecker {
 
     pub(super) fn number_or_big_int_type(&self) -> Rc<Type> {
         self.number_or_big_int_type.as_ref().unwrap().clone()
+    }
+
+    pub(super) fn template_constraint_type(&self) -> Rc<Type> {
+        self.template_constraint_type.as_ref().unwrap().clone()
     }
 
     pub(super) fn global_array_type(&self) -> Rc<Type> {

--- a/src/compiler/checker/lines_16000_18000.rs
+++ b/src/compiler/checker/lines_16000_18000.rs
@@ -183,6 +183,7 @@ impl TypeChecker {
         let node = node.as_type_node();
         match node {
             TypeNode::KeywordTypeNode(_) => match node.kind() {
+                SyntaxKind::StringKeyword => self.string_type(),
                 SyntaxKind::NumberKeyword => self.number_type(),
                 SyntaxKind::BigIntKeyword => self.bigint_type(),
                 SyntaxKind::BooleanKeyword => self.boolean_type(),

--- a/src/compiler/checker/lines_4000_8000.rs
+++ b/src/compiler/checker/lines_4000_8000.rs
@@ -377,6 +377,13 @@ impl NodeBuilder {
         type_: &Type,
         context: &NodeBuilderContext,
     ) -> TypeNode {
+        if type_.flags().intersects(TypeFlags::String) {
+            return Into::<KeywordTypeNode>::into(
+                factory
+                    .create_keyword_type_node(&self.synthetic_factory, SyntaxKind::StringKeyword),
+            )
+            .into();
+        }
         if type_.flags().intersects(TypeFlags::Number) {
             return Into::<KeywordTypeNode>::into(
                 factory

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -1387,10 +1387,12 @@ impl ParserType {
 
     fn parse_non_array_type(&self) -> TypeNode {
         match self.token() {
-            SyntaxKind::NumberKeyword | SyntaxKind::BigIntKeyword | SyntaxKind::BooleanKeyword => {
-                self.try_parse(|| self.parse_keyword_and_no_dot())
-                    .unwrap_or_else(|| unimplemented!())
-            }
+            SyntaxKind::StringKeyword
+            | SyntaxKind::NumberKeyword
+            | SyntaxKind::BigIntKeyword
+            | SyntaxKind::BooleanKeyword => self
+                .try_parse(|| self.parse_keyword_and_no_dot())
+                .unwrap_or_else(|| unimplemented!()),
             SyntaxKind::StringLiteral => self.parse_literal_type_node(None).into(),
             _ => self.parse_type_reference(),
         }

--- a/src/compiler/scanner.rs
+++ b/src/compiler/scanner.rs
@@ -29,6 +29,7 @@ lazy_static! {
             ("if".to_string(), SyntaxKind::IfKeyword),
             ("interface".to_string(), SyntaxKind::InterfaceKeyword),
             ("number".to_string(), SyntaxKind::NumberKeyword),
+            ("string".to_string(), SyntaxKind::StringKeyword),
             ("true".to_string(), SyntaxKind::TrueKeyword),
             ("type".to_string(), SyntaxKind::TypeKeyword),
             ("var".to_string(), SyntaxKind::VarKeyword),

--- a/src/compiler/types.rs
+++ b/src/compiler/types.rs
@@ -407,6 +407,10 @@ impl Node {
     pub fn as_type_alias_declaration(&self) -> &TypeAliasDeclaration {
         enum_unwrapped!(self, [Node, Statement, TypeAliasDeclaration])
     }
+
+    pub fn as_template_span(&self) -> &TemplateSpan {
+        enum_unwrapped!(self, [Node, TemplateSpan])
+    }
 }
 
 #[derive(Debug)]
@@ -1681,6 +1685,9 @@ pub struct TypeChecker {
     pub unknown_symbol: Option<Rc<Symbol>>,
     pub any_type: Option<Rc<Type>>,
     pub error_type: Option<Rc<Type>>,
+    pub undefined_type: Option<Rc<Type>>,
+    pub null_type: Option<Rc<Type>>,
+    pub string_type: Option<Rc<Type>>,
     pub number_type: Option<Rc<Type>>,
     pub bigint_type: Option<Rc<Type>>,
     pub true_type: Option<Rc<Type>>,
@@ -1690,6 +1697,7 @@ pub struct TypeChecker {
     pub boolean_type: Option<Rc<Type>>,
     pub never_type: Option<Rc<Type>>,
     pub number_or_big_int_type: Option<Rc<Type>>,
+    pub template_constraint_type: Option<Rc<Type>>,
     pub global_array_type: Option<Rc<Type /*GenericType*/>>,
     pub symbol_links: RefCell<HashMap<SymbolId, Rc<RefCell<SymbolLinks>>>>,
     pub node_links: RefCell<HashMap<NodeId, Rc<RefCell<NodeLinks>>>>,


### PR DESCRIPTION
In this PR:
- type-check a variable declaration whose initializer is a template literal

To test:
If you run `cargo run tmp.tsx` against a source file containing eg:
```
const a: boolean = `abc${"def"}`;
```
then you should see a diagnostic debug-logged with message `Type 'string' is not assignable to type 'boolean'.`
If you run `cargo run tmp.tsx` against a source file containing eg:
```
const a: string = `abc${"def"}`;
```
then you should see no diagnostics debug-logged

Based on `parse-template-literal`