### PR TITLE
Gc old tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,7 +369,7 @@ dependencies = [
 [[package]]
 name = "gc"
 version = "0.4.1"
-source = "git+https://github.com/manishearth/rust-gc?rev=6c5f754#6c5f754682e573e4590b52168dce835bba28beaf"
+source = "git+https://github.com/helixbass/rust-gc?rev=deaff036b#deaff036bebaa0d80cf81d1238cdf66766cf4c1c"
 dependencies = [
  "gc_derive",
  "serde",
@@ -378,7 +378,7 @@ dependencies = [
 [[package]]
 name = "gc_derive"
 version = "0.4.1"
-source = "git+https://github.com/manishearth/rust-gc?rev=6c5f754#6c5f754682e573e4590b52168dce835bba28beaf"
+source = "git+https://github.com/helixbass/rust-gc?rev=deaff036b#deaff036bebaa0d80cf81d1238cdf66766cf4c1c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/typescript_rust/Cargo.toml
+++ b/typescript_rust/Cargo.toml
@@ -19,7 +19,9 @@ indexmap = { path = "../../indexmap", features = ["gc"] }
 encoding_rs = "0.8.31"
 encoding_rs_io = "0.1.7"
 itertools = "0.10.5"
-gc = { git = "https://github.com/manishearth/rust-gc", rev = "6c5f754", features = ["derive", "serde"] }
+# gc = { git = "https://github.com/manishearth/rust-gc", rev = "6c5f754", features = ["derive", "serde"] }
+# gc = { path = "../../rust-gc/gc", features = ["derive", "serde", "unstable-config"] }
+gc = { git = "https://github.com/helixbass/rust-gc", rev = "deaff036b", features = ["derive", "serde"] }
 
 [dev-dependencies]
 rstest = "0.15.0"

--- a/typescript_rust/tests/baseline.rs
+++ b/typescript_rust/tests/baseline.rs
@@ -1,3 +1,4 @@
+use gc::Gc;
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use pretty_assertions::assert_str_eq;
@@ -5576,12 +5577,12 @@ fn run_compiler_baseline(#[case] case_filename: &str) {
     );
     options.no_error_truncation = Some(true);
     options.skip_default_lib_check = Some(options.skip_default_lib_check.unwrap_or(true));
-    let options = Rc::new(options);
+    let options = Gc::new(options);
     let host = create_compiler_host_worker(options.clone(), None, Some(get_sys()));
     let program = create_program(CreateProgramOptions {
         root_names: vec![case_file_path],
         options: options.clone(),
-        host: Some(Rc::new(host)),
+        host: Some(Gc::new(Box::new(host))),
         project_references: None,
         old_program: None,
         config_file_parsing_diagnostics: None,


### PR DESCRIPTION
In this PR:
- update old tests to be able to run with `gc`