### PR TITLE
Use newer gc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,7 +369,7 @@ dependencies = [
 [[package]]
 name = "gc"
 version = "0.4.1"
-source = "git+https://github.com/helixbass/rust-gc?rev=deaff036b#deaff036bebaa0d80cf81d1238cdf66766cf4c1c"
+source = "git+https://github.com/helixbass/rust-gc?rev=32dfa44#32dfa441f4fb2c1b610a4e05e6045e85e1bd5cb7"
 dependencies = [
  "gc_derive",
  "serde",
@@ -378,7 +378,7 @@ dependencies = [
 [[package]]
 name = "gc_derive"
 version = "0.4.1"
-source = "git+https://github.com/helixbass/rust-gc?rev=deaff036b#deaff036bebaa0d80cf81d1238cdf66766cf4c1c"
+source = "git+https://github.com/helixbass/rust-gc?rev=32dfa44#32dfa441f4fb2c1b610a4e05e6045e85e1bd5cb7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/local-macros/src/lib.rs
+++ b/local-macros/src/lib.rs
@@ -3161,11 +3161,11 @@ fn get_command_line_option_struct_interface_impl(
         "CommandLineOptionInterface" => {
             quote! {
                 impl crate::CommandLineOptionInterface for #command_line_option_type_name {
-                    fn command_line_option_wrapper(&self) -> ::std::rc::Rc<crate::CommandLineOption> {
+                    fn command_line_option_wrapper(&self) -> ::gc::Gc<crate::CommandLineOption> {
                         self.#first_field_name.command_line_option_wrapper()
                     }
 
-                    fn set_command_line_option_wrapper(&self, wrapper: ::std::rc::Rc<crate::CommandLineOption>) {
+                    fn set_command_line_option_wrapper(&self, wrapper: ::gc::Gc<crate::CommandLineOption>) {
                         self.#first_field_name.set_command_line_option_wrapper(wrapper)
                     }
 
@@ -3276,13 +3276,13 @@ fn get_command_line_option_enum_interface_impl(
         "CommandLineOptionInterface" => {
             quote! {
                 impl crate::CommandLineOptionInterface for #command_line_option_type_name {
-                    fn command_line_option_wrapper(&self) -> ::std::rc::Rc<crate::CommandLineOption> {
+                    fn command_line_option_wrapper(&self) -> ::gc::Gc<crate::CommandLineOption> {
                         match self {
                             #(#command_line_option_type_name::#variant_names(nested) => nested.command_line_option_wrapper()),*
                         }
                     }
 
-                    fn set_command_line_option_wrapper(&self, wrapper: ::std::rc::Rc<crate::CommandLineOption>) {
+                    fn set_command_line_option_wrapper(&self, wrapper: ::gc::Gc<crate::CommandLineOption>) {
                         match self {
                             #(#command_line_option_type_name::#variant_names(nested) => nested.set_command_line_option_wrapper(wrapper)),*
                         }
@@ -3525,9 +3525,9 @@ pub fn command_line_option_type(attr: TokenStream, item: TokenStream) -> TokenSt
         quote! {
             #into_implementations
 
-            impl ::std::convert::From<#command_line_option_type_name> for ::std::rc::Rc<crate::CommandLineOption> {
+            impl ::std::convert::From<#command_line_option_type_name> for ::gc::Gc<crate::CommandLineOption> {
                 fn from(concrete: #command_line_option_type_name) -> Self {
-                    let rc = ::std::rc::Rc::new(#construct_variant);
+                    let rc = ::gc::Gc::new(#construct_variant);
                     crate::CommandLineOptionInterface::set_command_line_option_wrapper(&*rc, rc.clone());
                     rc
                 }

--- a/typescript_rust/Cargo.toml
+++ b/typescript_rust/Cargo.toml
@@ -21,7 +21,7 @@ encoding_rs_io = "0.1.7"
 itertools = "0.10.5"
 # gc = { git = "https://github.com/manishearth/rust-gc", rev = "6c5f754", features = ["derive", "serde"] }
 # gc = { path = "../../rust-gc/gc", features = ["derive", "serde", "unstable-config"] }
-gc = { git = "https://github.com/helixbass/rust-gc", rev = "deaff036b", features = ["derive", "serde"] }
+gc = { git = "https://github.com/helixbass/rust-gc", rev = "32dfa44", features = ["derive", "serde"] }
 
 [dev-dependencies]
 rstest = "0.15.0"

--- a/typescript_rust/src/compiler/command_line_parser/lines_0_1000.rs
+++ b/typescript_rust/src/compiler/command_line_parser/lines_0_1000.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 thread_local! {
-    pub(crate) static compile_on_save_command_line_option_: Rc<CommandLineOption> =
+    pub(crate) static compile_on_save_command_line_option_: Gc<CommandLineOption> =
         CommandLineOptionOfBooleanType::new(CommandLineOptionBase {
             _command_line_option_wrapper: RefCell::new(None),
             name: "compileOnSave".to_string(),
@@ -40,7 +40,7 @@ thread_local! {
         .into();
 }
 
-pub(crate) fn compile_on_save_command_line_option() -> Rc<CommandLineOption> {
+pub(crate) fn compile_on_save_command_line_option() -> Gc<CommandLineOption> {
     compile_on_save_command_line_option_
         .with(|compile_on_save_command_line_option| compile_on_save_command_line_option.clone())
 }
@@ -147,7 +147,7 @@ thread_local! {
 }
 
 thread_local! {
-    pub(crate) static options_for_watch: Vec<Rc<CommandLineOption>> = vec![
+    pub(crate) static options_for_watch: Vec<Gc<CommandLineOption>> = vec![
         CommandLineOptionOfCustomType::new(CommandLineOptionBase {
             _command_line_option_wrapper: RefCell::new(None),
             name: "watchFile".to_string(),
@@ -362,7 +362,7 @@ thread_local! {
 }
 
 thread_local! {
-    pub(crate) static common_options_with_build: Vec<Rc<CommandLineOption>> = vec![
+    pub(crate) static common_options_with_build: Vec<Gc<CommandLineOption>> = vec![
         CommandLineOptionOfBooleanType::new(CommandLineOptionBase {
             _command_line_option_wrapper: RefCell::new(None),
             name: "help".to_string(),
@@ -735,7 +735,7 @@ thread_local! {
 }
 
 thread_local! {
-    pub(crate) static target_option_declaration: Rc<CommandLineOption /*CommandLineOptionOfCustomType*/> =
+    pub(crate) static target_option_declaration: Gc<CommandLineOption /*CommandLineOptionOfCustomType*/> =
         CommandLineOptionOfCustomType::new(CommandLineOptionBase {
             _command_line_option_wrapper: RefCell::new(None),
             name: "target".to_string(),
@@ -775,7 +775,7 @@ thread_local! {
 }
 
 thread_local! {
-    pub(crate) static command_options_without_build: Vec<Rc<CommandLineOption>> = vec![
+    pub(crate) static command_options_without_build: Vec<Gc<CommandLineOption>> = vec![
         CommandLineOptionOfBooleanType::new(CommandLineOptionBase {
             _command_line_option_wrapper: RefCell::new(None),
             name: "all".to_string(),

--- a/typescript_rust/src/compiler/command_line_parser/lines_1000_1500.rs
+++ b/typescript_rust/src/compiler/command_line_parser/lines_1000_1500.rs
@@ -21,7 +21,7 @@ use crate::{
 use local_macros::enum_unwrapped;
 
 thread_local! {
-    pub static option_declarations: Vec<Rc<CommandLineOption>> =
+    pub static option_declarations: Vec<Gc<CommandLineOption>> =
         common_options_with_build.with(|common_options_with_build_| {
             command_options_without_build.with(|command_options_without_build_| {
                 common_options_with_build_
@@ -34,7 +34,7 @@ thread_local! {
 }
 
 thread_local! {
-    pub(crate) static semantic_diagnostics_option_declarations: Vec<Rc<CommandLineOption>> =
+    pub(crate) static semantic_diagnostics_option_declarations: Vec<Gc<CommandLineOption>> =
         option_declarations.with(|option_declarations_| {
             option_declarations_
                 .iter()
@@ -45,7 +45,7 @@ thread_local! {
 }
 
 thread_local! {
-    pub(crate) static affects_emit_option_declarations: Vec<Rc<CommandLineOption>> =
+    pub(crate) static affects_emit_option_declarations: Vec<Gc<CommandLineOption>> =
         option_declarations.with(|option_declarations_| {
             option_declarations_
                 .iter()
@@ -56,7 +56,7 @@ thread_local! {
 }
 
 thread_local! {
-    pub(crate) static module_resolution_option_declarations: Vec<Rc<CommandLineOption>> =
+    pub(crate) static module_resolution_option_declarations: Vec<Gc<CommandLineOption>> =
         option_declarations.with(|option_declarations_| {
             option_declarations_
                 .iter()
@@ -67,7 +67,7 @@ thread_local! {
 }
 
 thread_local! {
-    pub(crate) static source_file_affecting_compiler_options: Vec<Rc<CommandLineOption>> =
+    pub(crate) static source_file_affecting_compiler_options: Vec<Gc<CommandLineOption>> =
         option_declarations.with(|option_declarations_| {
             option_declarations_
                 .iter()
@@ -82,7 +82,7 @@ thread_local! {
 }
 
 thread_local! {
-    pub(crate) static options_affecting_program_structure: Vec<Rc<CommandLineOption>> =
+    pub(crate) static options_affecting_program_structure: Vec<Gc<CommandLineOption>> =
         option_declarations.with(|option_declarations_| {
             option_declarations_
                 .iter()
@@ -93,7 +93,7 @@ thread_local! {
 }
 
 thread_local! {
-    pub(crate) static transpile_option_value_compiler_options: Vec<Rc<CommandLineOption>> =
+    pub(crate) static transpile_option_value_compiler_options: Vec<Gc<CommandLineOption>> =
         option_declarations.with(|option_declarations_| {
             option_declarations_
                 .iter()
@@ -104,7 +104,7 @@ thread_local! {
 }
 
 thread_local! {
-    pub(crate) static options_for_build: Vec<Rc<CommandLineOption>> = vec![
+    pub(crate) static options_for_build: Vec<Gc<CommandLineOption>> = vec![
         CommandLineOptionOfBooleanType::new(CommandLineOptionBase {
             _command_line_option_wrapper: RefCell::new(None),
             name: "verbose".to_string(),
@@ -201,7 +201,7 @@ thread_local! {
 }
 
 thread_local! {
-    pub(crate) static build_opts: Vec<Rc<CommandLineOption>> =
+    pub(crate) static build_opts: Vec<Gc<CommandLineOption>> =
         common_options_with_build.with(|common_options_with_build_| {
             options_for_build.with(|options_for_build_| {
                 common_options_with_build_
@@ -214,7 +214,7 @@ thread_local! {
 }
 
 thread_local! {
-    pub(crate) static type_acquisition_declarations: Vec<Rc<CommandLineOption>> = vec![
+    pub(crate) static type_acquisition_declarations: Vec<Gc<CommandLineOption>> = vec![
         CommandLineOptionOfBooleanType::new(CommandLineOptionBase {
             _command_line_option_wrapper: RefCell::new(None),
             name: "enableAutoDiscovery".to_string(),
@@ -382,12 +382,12 @@ thread_local! {
 }
 
 pub struct OptionsNameMap {
-    pub options_name_map: HashMap<String, Rc<CommandLineOption>>,
+    pub options_name_map: HashMap<String, Gc<CommandLineOption>>,
     pub short_option_names: HashMap<String, String>,
 }
 
 pub(crate) fn create_option_name_map(
-    option_declarations_: &[Rc<CommandLineOption>],
+    option_declarations_: &[Gc<CommandLineOption>],
 ) -> OptionsNameMap {
     let mut options_name_map = HashMap::new();
     let mut short_option_names = HashMap::new();

--- a/typescript_rust/src/compiler/command_line_parser/lines_1500_2000.rs
+++ b/typescript_rust/src/compiler/command_line_parser/lines_1500_2000.rs
@@ -252,7 +252,7 @@ impl DidYouMeanOptionsDiagnostics for CompilerOptionsDidYouMeanDiagnostics {
         Some(compiler_options_alternate_mode())
     }
 
-    fn option_declarations(&self) -> Vec<Rc<CommandLineOption>> {
+    fn option_declarations(&self) -> Vec<Gc<CommandLineOption>> {
         option_declarations.with(|option_declarations_| option_declarations_.clone())
     }
 
@@ -294,7 +294,7 @@ pub fn parse_command_line<TReadFile: Fn(&str) -> io::Result<Option<String>>>(
 pub(crate) fn get_option_from_name(
     option_name: &str,
     allow_short: Option<bool>,
-) -> Option<Rc<CommandLineOption>> {
+) -> Option<Gc<CommandLineOption>> {
     get_option_declaration_from_name(get_options_name_map, option_name, allow_short)
 }
 
@@ -302,7 +302,7 @@ pub(super) fn get_option_declaration_from_name<TGetOptionNameMap: FnMut() -> Rc<
     mut get_option_name_map: TGetOptionNameMap,
     option_name: &str,
     allow_short: Option<bool>,
-) -> Option<Rc<CommandLineOption>> {
+) -> Option<Gc<CommandLineOption>> {
     let allow_short = allow_short.unwrap_or(false);
     let mut option_name = option_name.to_lowercase();
     let option_name_map = get_option_name_map();
@@ -370,7 +370,7 @@ impl DidYouMeanOptionsDiagnostics for BuildOptionsDidYouMeanDiagnostics {
         Some(build_options_alternate_mode())
     }
 
-    fn option_declarations(&self) -> Vec<Rc<CommandLineOption>> {
+    fn option_declarations(&self) -> Vec<Gc<CommandLineOption>> {
         build_opts.with(|build_opts_| build_opts_.clone())
     }
 
@@ -656,8 +656,8 @@ pub(crate) fn try_read_file<TReadFile: FnMut(&str) -> io::Result<Option<String>>
 }
 
 pub(super) fn command_line_options_to_map(
-    options: &[Rc<CommandLineOption>],
-) -> HashMap<String, Rc<CommandLineOption>> {
+    options: &[Gc<CommandLineOption>],
+) -> HashMap<String, Gc<CommandLineOption>> {
     array_to_map(
         options,
         |option| Some(get_option_name(option).to_owned()),
@@ -682,7 +682,7 @@ impl DidYouMeanOptionsDiagnostics for TypeAcquisitionDidYouMeanDiagnostics {
         None
     }
 
-    fn option_declarations(&self) -> Vec<Rc<CommandLineOption>> {
+    fn option_declarations(&self) -> Vec<Gc<CommandLineOption>> {
         type_acquisition_declarations
             .with(|type_acquisition_declarations_| type_acquisition_declarations_.clone())
     }
@@ -736,7 +736,7 @@ impl DidYouMeanOptionsDiagnostics for WatchOptionsDidYouMeanDiagnostics {
         None
     }
 
-    fn option_declarations(&self) -> Vec<Rc<CommandLineOption>> {
+    fn option_declarations(&self) -> Vec<Gc<CommandLineOption>> {
         options_for_watch.with(|options_for_watch_| options_for_watch_.clone())
     }
 
@@ -771,10 +771,10 @@ pub(super) fn watch_options_did_you_mean_diagnostics() -> Rc<dyn ParseCommandLin
 }
 
 thread_local! {
-    static command_line_compiler_options_map_cache: RefCell<Option<Rc<HashMap<String, Rc<CommandLineOption>>>>> = RefCell::new(None);
+    static command_line_compiler_options_map_cache: RefCell<Option<Rc<HashMap<String, Gc<CommandLineOption>>>>> = RefCell::new(None);
 }
 
-pub(super) fn get_command_line_compiler_options_map() -> Rc<HashMap<String, Rc<CommandLineOption>>>
+pub(super) fn get_command_line_compiler_options_map() -> Rc<HashMap<String, Gc<CommandLineOption>>>
 {
     command_line_compiler_options_map_cache.with(|command_line_compiler_options_map_cache_| {
         let mut command_line_compiler_options_map_cache_ =
@@ -793,10 +793,10 @@ pub(super) fn get_command_line_compiler_options_map() -> Rc<HashMap<String, Rc<C
 }
 
 thread_local! {
-    static command_line_watch_options_map_cache: RefCell<Option<Rc<HashMap<String, Rc<CommandLineOption>>>>> = RefCell::new(None);
+    static command_line_watch_options_map_cache: RefCell<Option<Rc<HashMap<String, Gc<CommandLineOption>>>>> = RefCell::new(None);
 }
 
-pub(super) fn get_command_line_watch_options_map() -> Rc<HashMap<String, Rc<CommandLineOption>>> {
+pub(super) fn get_command_line_watch_options_map() -> Rc<HashMap<String, Gc<CommandLineOption>>> {
     command_line_watch_options_map_cache.with(|command_line_watch_options_map_cache_| {
         let mut command_line_watch_options_map_cache_ =
             command_line_watch_options_map_cache_.borrow_mut();
@@ -814,10 +814,10 @@ pub(super) fn get_command_line_watch_options_map() -> Rc<HashMap<String, Rc<Comm
 }
 
 thread_local! {
-    static command_line_type_acquisition_map_cache: RefCell<Option<Rc<HashMap<String, Rc<CommandLineOption>>>>> = RefCell::new(None);
+    static command_line_type_acquisition_map_cache: RefCell<Option<Rc<HashMap<String, Gc<CommandLineOption>>>>> = RefCell::new(None);
 }
 
-pub(super) fn get_command_line_type_acquisition_map() -> Rc<HashMap<String, Rc<CommandLineOption>>>
+pub(super) fn get_command_line_type_acquisition_map() -> Rc<HashMap<String, Gc<CommandLineOption>>>
 {
     command_line_type_acquisition_map_cache.with(|command_line_type_acquisition_map_cache_| {
         let mut command_line_type_acquisition_map_cache_ =
@@ -838,13 +838,13 @@ pub(super) fn get_command_line_type_acquisition_map() -> Rc<HashMap<String, Rc<C
 
 pub(super) const tsconfig_root_options_dummy_name: &str = "TSCONFIG ROOT OPTIONS";
 thread_local! {
-    static _tsconfig_root_options: RefCell<Option<Rc<CommandLineOption>>> = RefCell::new(None);
+    static _tsconfig_root_options: RefCell<Option<Gc<CommandLineOption>>> = RefCell::new(None);
 }
-pub(super) fn get_tsconfig_root_options_map() -> Rc<CommandLineOption> {
+pub(super) fn get_tsconfig_root_options_map() -> Gc<CommandLineOption> {
     _tsconfig_root_options.with(|tsconfig_root_options| {
         let mut tsconfig_root_options = tsconfig_root_options.borrow_mut();
         if tsconfig_root_options.is_none() {
-            *tsconfig_root_options = Some(Rc::new(
+            *tsconfig_root_options = Some(Gc::new(
                 TsConfigOnlyOption::new(
                     CommandLineOptionBase {
                         _command_line_option_wrapper: RefCell::new(None),
@@ -1274,7 +1274,7 @@ pub(super) fn convert_config_file_to_object<TOptionsIterator: JsonConversionNoti
         .statements()
         .get(0)
         .map(|statement| statement.as_expression_statement().expression.clone());
-    let known_root_options: Option<Rc<CommandLineOption>> = if report_options_errors {
+    let known_root_options: Option<Gc<CommandLineOption>> = if report_options_errors {
         Some(get_tsconfig_root_options_map())
     } else {
         None

--- a/typescript_rust/src/compiler/command_line_parser/lines_2000_2500.rs
+++ b/typescript_rust/src/compiler/command_line_parser/lines_2000_2500.rs
@@ -29,7 +29,7 @@ use crate::{
 
 pub(super) fn is_root_option_map(
     known_root_options: Option<&CommandLineOption>,
-    known_options: Option<&HashMap<String, Rc<CommandLineOption>>>,
+    known_options: Option<&HashMap<String, Gc<CommandLineOption>>>,
 ) -> bool {
     match known_root_options {
         None => false,
@@ -51,7 +51,7 @@ pub(super) fn convert_object_literal_expression_to_json<
     json_conversion_notifier: Option<&TJsonConversionNotifier>,
     known_root_options: Option<&CommandLineOption>,
     node: &Node, /*ObjectLiteralExpression*/
-    known_options: Option<&HashMap<String, Rc<CommandLineOption>>>,
+    known_options: Option<&HashMap<String, Gc<CommandLineOption>>>,
     extra_key_diagnostics: Option<&dyn DidYouMeanOptionsDiagnostics>,
     parent_option: Option<&str>,
 ) -> Option<serde_json::Value> {
@@ -1115,7 +1115,7 @@ fn write_configurations(
     file_names: &[String],
     new_line: &str,
 ) -> String {
-    let mut categorized_options: MultiMap<String, Rc<CommandLineOption>> = create_multi_map();
+    let mut categorized_options: MultiMap<String, Gc<CommandLineOption>> = create_multi_map();
     option_declarations.with(|option_declarations_| {
         for option in option_declarations_ {
             let category = option.maybe_category();

--- a/typescript_rust/src/compiler/command_line_parser/lines_3000_end.rs
+++ b/typescript_rust/src/compiler/command_line_parser/lines_3000_end.rs
@@ -263,7 +263,7 @@ pub(crate) fn convert_watch_options_from_json_worker(
 }
 
 pub(super) fn convert_options_from_json_compiler_options(
-    options_name_map: &HashMap<String, Rc<CommandLineOption>>,
+    options_name_map: &HashMap<String, Gc<CommandLineOption>>,
     json_options: Option<&serde_json::Value>,
     base_path: &str,
     default_options: &mut CompilerOptions,
@@ -300,7 +300,7 @@ pub(super) fn convert_options_from_json_compiler_options(
 }
 
 pub(super) fn convert_options_from_json_type_acquisition(
-    options_name_map: &HashMap<String, Rc<CommandLineOption>>,
+    options_name_map: &HashMap<String, Gc<CommandLineOption>>,
     json_options: Option<&serde_json::Value>,
     base_path: &str,
     default_options: &mut TypeAcquisition,
@@ -338,7 +338,7 @@ pub(super) fn convert_options_from_json_type_acquisition(
 }
 
 pub(super) fn convert_options_from_json_watch_options(
-    options_name_map: &HashMap<String, Rc<CommandLineOption>>,
+    options_name_map: &HashMap<String, Gc<CommandLineOption>>,
     json_options: Option<&serde_json::Value>,
     base_path: &str,
     // default_options: &mut WatchOptions,

--- a/typescript_rust/src/compiler/program/lines_1000_2000.rs
+++ b/typescript_rust/src/compiler/program/lines_1000_2000.rs
@@ -23,7 +23,7 @@ impl Program {
         module_names: &[String],
         containing_file: &Node, /*SourceFile*/
         reused_names: Option<&[String]>,
-    ) -> Vec<Option<Rc<ResolvedModuleFull>>> {
+    ) -> Vec<Option<Gc<ResolvedModuleFull>>> {
         if module_names.is_empty() {
             return vec![];
         }
@@ -54,7 +54,7 @@ impl Program {
         &self,
         type_directive_names: &[String],
         containing_file: TContainingFile,
-    ) -> Vec<Option<Rc<ResolvedTypeReferenceDirective>>> {
+    ) -> Vec<Option<Gc<ResolvedTypeReferenceDirective>>> {
         if type_directive_names.is_empty() {
             return vec![];
         }
@@ -309,7 +309,7 @@ impl Program {
         &self,
         module_names: &[String],
         file: &Node, /*SourceFile*/
-    ) -> Vec<Option<Rc<ResolvedModuleFull>>> {
+    ) -> Vec<Option<Gc<ResolvedModuleFull>>> {
         let file_as_source_file = file.as_source_file();
         if self.structure_is_reused() == StructureIsReused::Not
             && file_as_source_file
@@ -335,7 +335,7 @@ impl Program {
             if let Some(file_resolved_modules) =
                 file_as_source_file.maybe_resolved_modules().as_ref()
             {
-                let mut result: Vec<Option<Rc<ResolvedModuleFull>>> = vec![];
+                let mut result: Vec<Option<Gc<ResolvedModuleFull>>> = vec![];
                 let mut i = 0;
                 for module_name in module_names {
                     let resolved_module = file_resolved_modules
@@ -691,7 +691,7 @@ impl Program {
 
 #[derive(Clone)]
 pub(super) enum ResolveModuleNamesReusingOldStateResultItem {
-    ResolvedModuleFull(Rc<ResolvedModuleFull>),
+    ResolvedModuleFull(Gc<ResolvedModuleFull>),
     PredictedToResolveToAmbientModuleMarker,
 }
 

--- a/typescript_rust/src/compiler/program/lines_2500_3000.rs
+++ b/typescript_rust/src/compiler/program/lines_2500_3000.rs
@@ -918,7 +918,7 @@ impl Program {
     pub fn process_type_reference_directive(
         &self,
         type_reference_directive: &str,
-        resolved_type_reference_directive: Option<Rc<ResolvedTypeReferenceDirective>>,
+        resolved_type_reference_directive: Option<Gc<ResolvedTypeReferenceDirective>>,
         reason: &FileIncludeReason,
     ) {
         // tracing?.push(tracing.Phase.Program, "processTypeReferenceDirective", { directive: typeReferenceDirective, hasResolved: !!resolveModuleNamesReusingOldState, refKind: reason.kind, refPath: isReferencedFile(reason) ? reason.file : undefined });
@@ -933,7 +933,7 @@ impl Program {
     pub fn process_type_reference_directive_worker(
         &self,
         type_reference_directive: &str,
-        resolved_type_reference_directive: Option<Rc<ResolvedTypeReferenceDirective>>,
+        resolved_type_reference_directive: Option<Gc<ResolvedTypeReferenceDirective>>,
         reason: &FileIncludeReason,
     ) {
         let previous_resolution = self

--- a/typescript_rust/src/compiler/program/lines_500_1000.rs
+++ b/typescript_rust/src/compiler/program/lines_500_1000.rs
@@ -69,7 +69,7 @@ impl LoadWithLocalCacheLoaderResolveTypeReferenceDirective {
     }
 }
 
-impl LoadWithLocalCacheLoader<Rc<ResolvedTypeReferenceDirective>>
+impl LoadWithLocalCacheLoader<Gc<ResolvedTypeReferenceDirective>>
     for LoadWithLocalCacheLoaderResolveTypeReferenceDirective
 {
     fn call(
@@ -77,7 +77,7 @@ impl LoadWithLocalCacheLoader<Rc<ResolvedTypeReferenceDirective>>
         types_ref: &str,
         containing_file: &str,
         redirected_reference: Option<Gc<ResolvedProjectReference>>,
-    ) -> Rc<ResolvedTypeReferenceDirective> {
+    ) -> Gc<ResolvedTypeReferenceDirective> {
         resolve_type_reference_directive(
             types_ref,
             Some(containing_file),
@@ -198,7 +198,7 @@ impl LoadWithModeAwareCacheLoaderResolveModuleName {
     }
 }
 
-impl LoadWithModeAwareCacheLoader<Option<Rc<ResolvedModuleFull>>>
+impl LoadWithModeAwareCacheLoader<Option<Gc<ResolvedModuleFull>>>
     for LoadWithModeAwareCacheLoaderResolveModuleName
 {
     fn call(
@@ -207,7 +207,7 @@ impl LoadWithModeAwareCacheLoader<Option<Rc<ResolvedModuleFull>>>
         resolver_mode: Option<ModuleKind /*ModuleKind.CommonJS | ModuleKind.ESNext*/>,
         containing_file_name: &str,
         redirected_reference: Option<Gc<ResolvedProjectReference>>,
-    ) -> Option<Rc<ResolvedModuleFull>> {
+    ) -> Option<Gc<ResolvedModuleFull>> {
         resolve_module_name(
             module_name,
             containing_file_name,
@@ -1244,7 +1244,7 @@ impl Program {
 
     pub(super) fn resolved_type_reference_directives(
         &self,
-    ) -> RefMut<HashMap<String, Option<Rc<ResolvedTypeReferenceDirective>>>> {
+    ) -> RefMut<HashMap<String, Option<Gc<ResolvedTypeReferenceDirective>>>> {
         self.resolved_type_reference_directives.borrow_mut()
     }
 
@@ -1492,7 +1492,7 @@ pub trait ActualResolveModuleNamesWorker: Trace + Finalize {
         containing_file_name: &str,
         reused_names: Option<&[String]>,
         redirected_reference: Option<Gc<ResolvedProjectReference>>,
-    ) -> Vec<Option<Rc<ResolvedModuleFull>>>;
+    ) -> Vec<Option<Gc<ResolvedModuleFull>>>;
 }
 
 #[derive(Trace, Finalize)]
@@ -1515,7 +1515,7 @@ impl ActualResolveModuleNamesWorker for ActualResolveModuleNamesWorkerHost {
         containing_file_name: &str,
         reused_names: Option<&[String]>,
         redirected_reference: Option<Gc<ResolvedProjectReference>>,
-    ) -> Vec<Option<Rc<ResolvedModuleFull>>> {
+    ) -> Vec<Option<Gc<ResolvedModuleFull>>> {
         self.host
             .resolve_module_names(
                 /*Debug.checkEachDefined(*/ module_names, /*)*/
@@ -1532,12 +1532,12 @@ impl ActualResolveModuleNamesWorker for ActualResolveModuleNamesWorkerHost {
                     None => true,
                     Some(resolved) => resolved.extension.is_some(),
                 } {
-                    return resolved.map(Rc::new);
+                    return resolved.map(Gc::new);
                 }
                 let resolved = resolved.unwrap();
                 let mut with_extension = clone(&resolved);
                 with_extension.extension = Some(extension_from_path(&resolved.resolved_file_name));
-                Some(Rc::new(with_extension))
+                Some(Gc::new(with_extension))
             })
             .collect()
     }
@@ -1545,12 +1545,12 @@ impl ActualResolveModuleNamesWorker for ActualResolveModuleNamesWorkerHost {
 
 #[derive(Trace, Finalize)]
 struct ActualResolveModuleNamesWorkerLoadWithModeAwareCache {
-    loader: Gc<Box<dyn LoadWithModeAwareCacheLoader<Option<Rc<ResolvedModuleFull>>>>>,
+    loader: Gc<Box<dyn LoadWithModeAwareCacheLoader<Option<Gc<ResolvedModuleFull>>>>>,
 }
 
 impl ActualResolveModuleNamesWorkerLoadWithModeAwareCache {
     pub fn new(
-        loader: Gc<Box<dyn LoadWithModeAwareCacheLoader<Option<Rc<ResolvedModuleFull>>>>>,
+        loader: Gc<Box<dyn LoadWithModeAwareCacheLoader<Option<Gc<ResolvedModuleFull>>>>>,
     ) -> Self {
         Self { loader }
     }
@@ -1564,7 +1564,7 @@ impl ActualResolveModuleNamesWorker for ActualResolveModuleNamesWorkerLoadWithMo
         containing_file_name: &str,
         reused_names: Option<&[String]>,
         redirected_reference: Option<Gc<ResolvedProjectReference>>,
-    ) -> Vec<Option<Rc<ResolvedModuleFull>>> {
+    ) -> Vec<Option<Gc<ResolvedModuleFull>>> {
         load_with_mode_aware_cache(
             /*Debug.checkEachDefined(*/ module_names, /*)*/
             containing_file,
@@ -1581,7 +1581,7 @@ pub trait ActualResolveTypeReferenceDirectiveNamesWorker: Trace + Finalize {
         type_directive_names: &[String],
         containing_file: &str,
         redirected_reference: Option<Gc<ResolvedProjectReference>>,
-    ) -> Vec<Option<Rc<ResolvedTypeReferenceDirective>>>;
+    ) -> Vec<Option<Gc<ResolvedTypeReferenceDirective>>>;
 }
 
 #[derive(Trace, Finalize)]
@@ -1604,7 +1604,7 @@ impl ActualResolveTypeReferenceDirectiveNamesWorker
         type_directive_names: &[String],
         containing_file: &str,
         redirected_reference: Option<Gc<ResolvedProjectReference>>,
-    ) -> Vec<Option<Rc<ResolvedTypeReferenceDirective>>> {
+    ) -> Vec<Option<Gc<ResolvedTypeReferenceDirective>>> {
         self.host
             .resolve_type_reference_directives(
                 /*Debug.checkEachDefined(*/ type_directive_names, /*)*/
@@ -1618,12 +1618,12 @@ impl ActualResolveTypeReferenceDirectiveNamesWorker
 
 #[derive(Trace, Finalize)]
 struct ActualResolveTypeReferenceDirectiveNamesWorkerLoadWithLocalCache {
-    loader: Gc<Box<dyn LoadWithLocalCacheLoader<Rc<ResolvedTypeReferenceDirective>>>>,
+    loader: Gc<Box<dyn LoadWithLocalCacheLoader<Gc<ResolvedTypeReferenceDirective>>>>,
 }
 
 impl ActualResolveTypeReferenceDirectiveNamesWorkerLoadWithLocalCache {
     pub fn new(
-        loader: Gc<Box<dyn LoadWithLocalCacheLoader<Rc<ResolvedTypeReferenceDirective>>>>,
+        loader: Gc<Box<dyn LoadWithLocalCacheLoader<Gc<ResolvedTypeReferenceDirective>>>>,
     ) -> Self {
         Self { loader }
     }
@@ -1637,7 +1637,7 @@ impl ActualResolveTypeReferenceDirectiveNamesWorker
         type_reference_directive_names: &[String],
         containing_file: &str,
         redirected_reference: Option<Gc<ResolvedProjectReference>>,
-    ) -> Vec<Option<Rc<ResolvedTypeReferenceDirective>>> {
+    ) -> Vec<Option<Gc<ResolvedTypeReferenceDirective>>> {
         load_with_local_cache(
             /*Debug.checkEachDefined(*/ type_reference_directive_names, /*)*/
             containing_file,

--- a/typescript_rust/src/compiler/types/lines_3500_4000.rs
+++ b/typescript_rust/src/compiler/types/lines_3500_4000.rs
@@ -211,9 +211,9 @@ pub struct SourceFileContents {
     #[unsafe_ignore_trace]
     comment_directives: RefCell<Option<Vec<Rc<CommentDirective>>>>,
     resolved_modules:
-        GcCell<Option<ModeAwareCache<Option<Rc<ResolvedModuleFull /*| undefined*/>>>>>,
+        GcCell<Option<ModeAwareCache<Option<Gc<ResolvedModuleFull /*| undefined*/>>>>>,
     resolved_type_reference_directive_names:
-        GcCell<Option<ModeAwareCache<Option<Rc<ResolvedTypeReferenceDirective>>>>>,
+        GcCell<Option<ModeAwareCache<Option<Gc<ResolvedTypeReferenceDirective>>>>>,
     imports: GcCell<Option<Vec<Gc<Node /*StringLiteralLike*/>>>>,
     module_augmentations: GcCell<Option<Vec<Gc<Node /*StringLiteral | Identifier*/>>>>,
     pattern_ambient_modules: GcCell<Option<Vec<Gc<PatternAmbientModule>>>>,
@@ -611,13 +611,13 @@ impl SourceFile {
 
     pub fn maybe_resolved_modules(
         &self,
-    ) -> GcCellRefMut<Option<ModeAwareCache<Option<Rc<ResolvedModuleFull>>>>> {
+    ) -> GcCellRefMut<Option<ModeAwareCache<Option<Gc<ResolvedModuleFull>>>>> {
         self.contents.resolved_modules.borrow_mut()
     }
 
     pub fn maybe_resolved_type_reference_directive_names(
         &self,
-    ) -> GcCellRefMut<Option<ModeAwareCache<Option<Rc<ResolvedTypeReferenceDirective>>>>> {
+    ) -> GcCellRefMut<Option<ModeAwareCache<Option<Gc<ResolvedTypeReferenceDirective>>>>> {
         self.contents
             .resolved_type_reference_directive_names
             .borrow_mut()
@@ -1295,7 +1295,7 @@ pub struct Program {
 
     #[unsafe_ignore_trace]
     pub(crate) resolved_type_reference_directives:
-        RefCell<HashMap<String, Option<Rc<ResolvedTypeReferenceDirective>>>>,
+        RefCell<HashMap<String, Option<Gc<ResolvedTypeReferenceDirective>>>>,
     #[unsafe_ignore_trace]
     pub(crate) file_processing_diagnostics: RefCell<Option<Vec<FilePreprocessingDiagnostics>>>,
 

--- a/typescript_rust/src/compiler/types/lines_5000_5250.rs
+++ b/typescript_rust/src/compiler/types/lines_5000_5250.rs
@@ -107,6 +107,7 @@ pub type SymbolTable = IndexMap<__String, Gc<Symbol>>;
 
 #[derive(Clone, Debug, Trace, Finalize)]
 pub struct PatternAmbientModule {
+    #[unsafe_ignore_trace]
     pub pattern: Rc<Pattern>,
     pub symbol: Gc<Symbol>,
 }

--- a/typescript_rust/src/compiler/types/lines_6000_6500.rs
+++ b/typescript_rust/src/compiler/types/lines_6000_6500.rs
@@ -2054,8 +2054,8 @@ pub enum StringOrDiagnosticMessage {
 }
 
 pub trait CommandLineOptionInterface {
-    fn command_line_option_wrapper(&self) -> Rc<CommandLineOption>;
-    fn set_command_line_option_wrapper(&self, wrapper: Rc<CommandLineOption>);
+    fn command_line_option_wrapper(&self) -> Gc<CommandLineOption>;
+    fn set_command_line_option_wrapper(&self, wrapper: Gc<CommandLineOption>);
     fn name(&self) -> &str;
     fn type_(&self) -> &CommandLineOptionType;
     fn is_file_path(&self) -> bool;
@@ -2089,7 +2089,7 @@ pub trait CommandLineOptionInterface {
 }
 
 pub struct CommandLineOptionBase {
-    pub _command_line_option_wrapper: RefCell<Option<Rc<CommandLineOption>>>,
+    pub _command_line_option_wrapper: RefCell<Option<Gc<CommandLineOption>>>,
     pub name: String,
     pub type_: CommandLineOptionType,
     pub is_file_path: Option<bool>,
@@ -2113,11 +2113,11 @@ pub struct CommandLineOptionBase {
 }
 
 impl CommandLineOptionInterface for CommandLineOptionBase {
-    fn command_line_option_wrapper(&self) -> Rc<CommandLineOption> {
+    fn command_line_option_wrapper(&self) -> Gc<CommandLineOption> {
         self._command_line_option_wrapper.borrow().clone().unwrap()
     }
 
-    fn set_command_line_option_wrapper(&self, wrapper: Rc<CommandLineOption>) {
+    fn set_command_line_option_wrapper(&self, wrapper: Gc<CommandLineOption>) {
         *self._command_line_option_wrapper.borrow_mut() = Some(wrapper);
     }
 
@@ -2273,7 +2273,7 @@ pub struct AlternateModeDiagnostics {
 
 pub trait DidYouMeanOptionsDiagnostics {
     fn maybe_alternate_mode(&self) -> Option<Rc<AlternateModeDiagnostics>>;
-    fn option_declarations(&self) -> Vec<Rc<CommandLineOption>>;
+    fn option_declarations(&self) -> Vec<Gc<CommandLineOption>>;
     fn unknown_option_diagnostic(&self) -> &DiagnosticMessage;
     fn unknown_did_you_mean_diagnostic(&self) -> &DiagnosticMessage;
 }
@@ -2281,7 +2281,7 @@ pub trait DidYouMeanOptionsDiagnostics {
 #[command_line_option_type]
 pub struct TsConfigOnlyOption {
     _command_line_option_base: CommandLineOptionBase,
-    pub element_options: Option<Rc<HashMap<String, Rc<CommandLineOption>>>>,
+    pub element_options: Option<Rc<HashMap<String, Gc<CommandLineOption>>>>,
     pub extra_key_diagnostics:
         Option<RcDynDidYouMeanOptionsDiagnosticsOrRcDynParseCommandLineWorkerDiagnostics>,
 }
@@ -2289,7 +2289,7 @@ pub struct TsConfigOnlyOption {
 impl TsConfigOnlyOption {
     pub(crate) fn new(
         command_line_option_base: CommandLineOptionBase,
-        element_options: Option<Rc<HashMap<String, Rc<CommandLineOption>>>>,
+        element_options: Option<Rc<HashMap<String, Gc<CommandLineOption>>>>,
         extra_key_diagnostics: Option<
             RcDynDidYouMeanOptionsDiagnosticsOrRcDynParseCommandLineWorkerDiagnostics,
         >,
@@ -2337,13 +2337,13 @@ impl From<Rc<dyn ParseCommandLineWorkerDiagnostics>>
 #[command_line_option_type]
 pub struct CommandLineOptionOfListType {
     _command_line_option_base: CommandLineOptionBase,
-    pub element: Rc<CommandLineOption>,
+    pub element: Gc<CommandLineOption>,
 }
 
 impl CommandLineOptionOfListType {
     pub(crate) fn new(
         command_line_option_base: CommandLineOptionBase,
-        element: Rc<CommandLineOption>,
+        element: Gc<CommandLineOption>,
     ) -> Self {
         Self {
             _command_line_option_base: command_line_option_base,

--- a/typescript_rust/src/compiler/types/lines_6500_7000.rs
+++ b/typescript_rust/src/compiler/types/lines_6500_7000.rs
@@ -272,7 +272,7 @@ impl AsRef<str> for Extension {
 
 #[derive(Trace, Finalize)]
 pub struct ResolvedModuleWithFailedLookupLocations {
-    pub resolved_module: Option<Rc<ResolvedModuleFull>>,
+    pub resolved_module: Option<Gc<ResolvedModuleFull>>,
     #[unsafe_ignore_trace]
     pub failed_lookup_locations: RefCell<Vec<String>>,
 }
@@ -289,7 +289,7 @@ pub struct ResolvedTypeReferenceDirective {
 
 #[derive(Trace, Finalize)]
 pub struct ResolvedTypeReferenceDirectiveWithFailedLookupLocations {
-    pub resolved_type_reference_directive: Option<Rc<ResolvedTypeReferenceDirective>>,
+    pub resolved_type_reference_directive: Option<Gc<ResolvedTypeReferenceDirective>>,
     pub failed_lookup_locations: Vec<String>,
 }
 
@@ -378,7 +378,7 @@ pub trait CompilerHost: ModuleResolutionHost + Trace + Finalize {
         containing_file: &str,
         redirected_reference: Option<&ResolvedProjectReference>,
         options: &CompilerOptions,
-    ) -> Option<Vec<Option<Rc<ResolvedTypeReferenceDirective>>>> {
+    ) -> Option<Vec<Option<Gc<ResolvedTypeReferenceDirective>>>> {
         None
     }
     fn get_environment_variable(&self, name: &str) -> Option<String> {

--- a/typescript_rust/src/compiler/utilities/lines_0_1000.rs
+++ b/typescript_rust/src/compiler/utilities/lines_0_1000.rs
@@ -431,7 +431,7 @@ pub fn changes_affecting_program_structure(
 pub fn options_have_changes(
     old_options: &CompilerOptions,
     new_options: &CompilerOptions,
-    option_declarations: &[Rc<CommandLineOption>],
+    option_declarations: &[Gc<CommandLineOption>],
 ) -> bool {
     !ptr::eq(old_options, new_options)
         && option_declarations.iter().any(|o| {
@@ -565,7 +565,7 @@ pub fn get_resolved_module<TSourceFile: Borrow<Node>>(
     source_file: Option<TSourceFile>, /*SourceFile*/
     module_name_text: &str,
     mode: Option<ModuleKind /*ModuleKind.CommonJS | ModuleKind.ESNext*/>,
-) -> Option<Rc<ResolvedModuleFull>> {
+) -> Option<Gc<ResolvedModuleFull>> {
     if let Some(source_file) = source_file {
         let source_file = source_file.borrow();
         if let Some(source_file_resolved_modules) = source_file
@@ -584,7 +584,7 @@ pub fn get_resolved_module<TSourceFile: Borrow<Node>>(
 pub fn set_resolved_module(
     source_file: &Node, /*SourceFile*/
     module_name_text: &str,
-    resolved_module: Option<Rc<ResolvedModuleFull>>,
+    resolved_module: Option<Gc<ResolvedModuleFull>>,
     mode: Option<ModuleKind /*ModuleKind.CommonJS | ModuleKind.ESNext*/>,
 ) {
     let mut source_file_resolved_modules = source_file.as_source_file().maybe_resolved_modules();
@@ -601,7 +601,7 @@ pub fn set_resolved_module(
 pub fn set_resolved_type_reference_directive(
     source_file: &Node, /*SourceFile*/
     type_reference_directive_name: &str,
-    resolved_type_reference_directive: Option<Rc<ResolvedTypeReferenceDirective>>,
+    resolved_type_reference_directive: Option<Gc<ResolvedTypeReferenceDirective>>,
 ) {
     let mut source_file_resolved_type_reference_directive_names = source_file
         .as_source_file()

--- a/typescript_rust/src/compiler/utilities/lines_6000_7000.rs
+++ b/typescript_rust/src/compiler/utilities/lines_6000_7000.rs
@@ -961,7 +961,7 @@ impl SymlinkCache {
         &self,
         files: &[Gc<Node /*SourceFile*/>],
         type_reference_directives: Option<
-            &HashMap<String, Option<Rc<ResolvedTypeReferenceDirective>>>,
+            &HashMap<String, Option<Gc<ResolvedTypeReferenceDirective>>>,
         >,
     ) {
         Debug_.assert(!self.has_processed_resolutions(), None);
@@ -1028,8 +1028,8 @@ impl SymlinkCache {
 }
 
 enum ResolvedModuleFullOrResolvedTypeReferenceDirective {
-    ResolvedModuleFull(Rc<ResolvedModuleFull>),
-    ResolvedTypeReferenceDirective(Rc<ResolvedTypeReferenceDirective>),
+    ResolvedModuleFull(Gc<ResolvedModuleFull>),
+    ResolvedTypeReferenceDirective(Gc<ResolvedTypeReferenceDirective>),
 }
 
 impl ResolvedModuleFullOrResolvedTypeReferenceDirective {
@@ -1048,16 +1048,16 @@ impl ResolvedModuleFullOrResolvedTypeReferenceDirective {
     }
 }
 
-impl From<Rc<ResolvedModuleFull>> for ResolvedModuleFullOrResolvedTypeReferenceDirective {
-    fn from(value: Rc<ResolvedModuleFull>) -> Self {
+impl From<Gc<ResolvedModuleFull>> for ResolvedModuleFullOrResolvedTypeReferenceDirective {
+    fn from(value: Gc<ResolvedModuleFull>) -> Self {
         Self::ResolvedModuleFull(value)
     }
 }
 
-impl From<Rc<ResolvedTypeReferenceDirective>>
+impl From<Gc<ResolvedTypeReferenceDirective>>
     for ResolvedModuleFullOrResolvedTypeReferenceDirective
 {
-    fn from(value: Rc<ResolvedTypeReferenceDirective>) -> Self {
+    fn from(value: Gc<ResolvedTypeReferenceDirective>) -> Self {
         Self::ResolvedTypeReferenceDirective(value)
     }
 }

--- a/typescript_rust/src/execute_command_line/execute_command_line/lines_0_500.rs
+++ b/typescript_rust/src/execute_command_line/execute_command_line/lines_0_500.rs
@@ -9,7 +9,7 @@ use super::{
     ProgramOrEmitAndSemanticDiagnosticsBuilderProgramOrParsedCommandLine,
 };
 use crate::{
-    combine_paths, compare_strings_case_insensitive, contains, contains_rc,
+    combine_paths, compare_strings_case_insensitive, contains, contains_gc, contains_rc,
     convert_to_options_with_absolute_paths, convert_to_tsconfig, create_compiler_diagnostic,
     create_diagnostic_reporter, file_extension_is, file_extension_is_one_of, filter,
     find_config_file, for_each, format_message, get_diagnostic_text, get_line_starts,
@@ -149,7 +149,7 @@ pub(super) fn should_be_pretty(sys: &dyn System, options: CompilerOptionsOrBuild
     options.pretty().unwrap()
 }
 
-pub(super) fn get_options_for_help(command_line: &ParsedCommandLine) -> Vec<Rc<CommandLineOption>> {
+pub(super) fn get_options_for_help(command_line: &ParsedCommandLine) -> Vec<Gc<CommandLineOption>> {
     option_declarations.with(|option_declarations_| {
         if matches!(command_line.options.all, Some(true)) {
             sort(option_declarations_, |a, b| {
@@ -157,7 +157,7 @@ pub(super) fn get_options_for_help(command_line: &ParsedCommandLine) -> Vec<Rc<C
             })
             .to_vec()
         } else {
-            filter(option_declarations_, |v: &Rc<CommandLineOption>| {
+            filter(option_declarations_, |v: &Gc<CommandLineOption>| {
                 v.show_in_simplified_help_view()
             })
         }
@@ -510,7 +510,7 @@ pub(super) fn get_possible_values(option: &CommandLineOption) -> String {
 
 pub(super) fn generate_group_option_output(
     sys: &dyn System,
-    options_list: &[Rc<CommandLineOption>],
+    options_list: &[Gc<CommandLineOption>],
 ) -> Vec<String> {
     let mut max_length = 0;
     for option in options_list {
@@ -543,7 +543,7 @@ pub(super) fn generate_group_option_output(
 pub(super) fn generate_section_options_output(
     sys: &dyn System,
     section_name: &str,
-    options: &[Rc<CommandLineOption>],
+    options: &[Gc<CommandLineOption>],
     sub_category: bool,
     before_options_description: Option<&str>,
     after_options_description: Option<&str>,
@@ -599,7 +599,7 @@ pub(super) fn generate_section_options_output(
     res
 }
 
-pub(super) fn print_easy_help(sys: &dyn System, simple_options: &[Rc<CommandLineOption>]) {
+pub(super) fn print_easy_help(sys: &dyn System, simple_options: &[Gc<CommandLineOption>]) {
     let colors = create_colors(sys);
     let mut output = get_header(
         sys,
@@ -657,7 +657,7 @@ pub(super) fn print_easy_help(sys: &dyn System, simple_options: &[Rc<CommandLine
     let cli_commands = simple_options.iter().filter(|opt| opt.is_command_line_only() || matches!(opt.maybe_category(), Some(category) if category == &*Diagnostics::Command_line_Options)).map(Clone::clone).collect::<Vec<_>>();
     let config_opts = simple_options
         .iter()
-        .filter(|opt| !contains_rc(Some(&cli_commands), opt))
+        .filter(|opt| !contains_gc(Some(&cli_commands), opt))
         .map(Clone::clone)
         .collect::<Vec<_>>();
 
@@ -708,9 +708,9 @@ pub(super) fn example(
 
 pub(super) fn print_all_help(
     sys: &dyn System,
-    compiler_options: &[Rc<CommandLineOption>],
-    build_options: &[Rc<CommandLineOption>],
-    watch_options: &[Rc<CommandLineOption>],
+    compiler_options: &[Gc<CommandLineOption>],
+    build_options: &[Gc<CommandLineOption>],
+    watch_options: &[Gc<CommandLineOption>],
 ) {
     let mut output = get_header(
         sys,
@@ -757,7 +757,7 @@ pub(super) fn print_all_help(
     }
 }
 
-pub(super) fn print_build_help(sys: &dyn System, build_options: &[Rc<CommandLineOption>]) {
+pub(super) fn print_build_help(sys: &dyn System, build_options: &[Gc<CommandLineOption>]) {
     let mut output = get_header(
         sys,
         &format!(

--- a/typescript_rust/tests/baseline.rs
+++ b/typescript_rust/tests/baseline.rs
@@ -5646,9 +5646,9 @@ fn option_value(
 }
 
 thread_local! {
-    static options_index: RefCell<Option<HashMap<String, Rc<CommandLineOption>>>> = RefCell::new(None);
+    static options_index: RefCell<Option<HashMap<String, Gc<CommandLineOption>>>> = RefCell::new(None);
 }
-fn get_command_line_option(name: &str) -> Option<Rc<CommandLineOption>> {
+fn get_command_line_option(name: &str) -> Option<Gc<CommandLineOption>> {
     options_index.with(|options_index_| {
         options_index_
             .borrow_mut()


### PR DESCRIPTION
In this PR:
- update `gc` branch to incorporate latest `gc` `master` (including no longer deriving `Trace` for `Rc<T>`)