### PR TITLE
Gc-ify harness; harness thread pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,8 +400,7 @@ dependencies = [
  "once_cell",
  "pretty_assertions",
  "regex",
- "tokio",
- "tokio-stream",
+ "threadpool",
  "typescript_rust",
  "typescript_services_rust",
 ]
@@ -882,6 +881,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
 name = "tokio"
 version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -910,17 +918,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,6 +394,7 @@ dependencies = [
  "clap",
  "fancy-regex",
  "futures",
+ "gc",
  "lazy_static",
  "local-macros",
  "once_cell",
@@ -946,6 +947,7 @@ dependencies = [
 name = "typescript_services_rust"
 version = "0.1.0"
 dependencies = [
+ "gc",
  "typescript_rust",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,6 +873,7 @@ name = "test_runner"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "gc",
  "harness",
  "lazy_static",
  "regex",

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -10,6 +10,7 @@ bitflags = "1.3.2"
 clap = { version = "4.0.29", features = ["derive"] }
 fancy-regex = "0.10.0"
 futures = "0.3.25"
+gc = { git = "https://github.com/helixbass/rust-gc", rev = "deaff036b", features = ["derive", "serde"] }
 lazy_static = "1.4.0"
 local-macros = { path = "../local-macros" }
 once_cell = "1.16.0"

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -10,7 +10,7 @@ bitflags = "1.3.2"
 clap = { version = "4.0.29", features = ["derive"] }
 fancy-regex = "0.10.0"
 futures = "0.3.25"
-gc = { git = "https://github.com/helixbass/rust-gc", rev = "deaff036b", features = ["derive", "serde"] }
+gc = { git = "https://github.com/helixbass/rust-gc", rev = "32dfa44", features = ["derive", "serde"] }
 lazy_static = "1.4.0"
 local-macros = { path = "../local-macros" }
 once_cell = "1.16.0"

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -16,8 +16,7 @@ local-macros = { path = "../local-macros" }
 once_cell = "1.16.0"
 pretty_assertions = "1.3.0"
 regex = "1.5.4"
-tokio = { version = "1.23.0", features = ["full"] }
-tokio-stream = "0.1.11"
+threadpool = "1.8.1"
 typescript_rust = { path = "../typescript_rust" }
 typescript_services_rust = { path = "../typescript_services_rust" }
 

--- a/harness/src/harness/collections_impl.rs
+++ b/harness/src/harness/collections_impl.rs
@@ -362,8 +362,8 @@ pub mod collections {
     unsafe impl<TValue: Trace + Finalize + 'static> Trace for Metadata<TValue> {
         gc::custom_trace!(this, {
             unsafe {
-                this._parent.trace();
-                this._map.trace();
+                mark(&this._parent);
+                mark(&this._map);
             }
         });
     }

--- a/harness/src/harness/compiler_impl.rs
+++ b/harness/src/harness/compiler_impl.rs
@@ -1,7 +1,9 @@
 pub mod compiler {
+    use gc::{Finalize, Gc, Trace};
     use std::collections::HashMap;
     use std::ptr;
     use std::rc::Rc;
+
     use typescript_rust::{
         add_related_info, compare_diagnostics, create_compiler_diagnostic, create_program,
         file_extension_is, filter, get_declaration_emit_extension_for_path, get_output_extension,
@@ -13,35 +15,36 @@ pub mod compiler {
 
     use crate::{collections, documents, fakes, vfs, vpath};
 
+    #[derive(Trace, Finalize)]
     pub struct CompilationOutput {
-        pub inputs: Vec<Rc<documents::TextDocument>>,
-        pub js: Option<Rc<documents::TextDocument>>,
-        pub dts: Option<Rc<documents::TextDocument>>,
-        pub map: Option<Rc<documents::TextDocument>>,
+        pub inputs: Vec<Gc<documents::TextDocument>>,
+        pub js: Option<Gc<documents::TextDocument>>,
+        pub dts: Option<Gc<documents::TextDocument>>,
+        pub map: Option<Gc<documents::TextDocument>>,
     }
 
     pub struct CompilationResult {
-        pub host: Rc<fakes::CompilerHost>,
-        pub program: Option<Rc<Program>>,
+        pub host: Gc<Box<fakes::CompilerHost>>,
+        pub program: Option<Gc<Box<Program>>>,
         pub result: Option<EmitResult>,
-        pub options: Rc<CompilerOptions>,
-        pub diagnostics: Vec<Rc<Diagnostic>>,
-        pub js: collections::SortedMap<String, Rc<documents::TextDocument>>,
-        pub dts: collections::SortedMap<String, Rc<documents::TextDocument>>,
-        pub maps: collections::SortedMap<String, Rc<documents::TextDocument>>,
+        pub options: Gc<CompilerOptions>,
+        pub diagnostics: Vec<Gc<Diagnostic>>,
+        pub js: collections::SortedMap<String, Gc<documents::TextDocument>>,
+        pub dts: collections::SortedMap<String, Gc<documents::TextDocument>>,
+        pub maps: collections::SortedMap<String, Gc<documents::TextDocument>>,
         pub symlinks: Option<vfs::FileSet>,
 
-        _inputs: Vec<Rc<documents::TextDocument>>,
-        _inputs_and_outputs: collections::SortedMap<String, Rc<CompilationOutput>>,
+        _inputs: Vec<Gc<documents::TextDocument>>,
+        _inputs_and_outputs: collections::SortedMap<String, Gc<CompilationOutput>>,
     }
 
     impl CompilationResult {
         pub fn new(
-            host: Rc<fakes::CompilerHost>,
-            options: Rc<CompilerOptions>,
-            program: Option<Rc<Program>>,
+            host: Gc<Box<fakes::CompilerHost>>,
+            options: Gc<CompilerOptions>,
+            program: Option<Gc<Box<Program>>>,
             result: Option<EmitResult>,
-            diagnostics: Vec<Rc<Diagnostic>>,
+            diagnostics: Vec<Gc<Diagnostic>>,
         ) -> Self {
             let options = if let Some(program) = program.as_ref() {
                 program.get_compiler_options()
@@ -57,7 +60,7 @@ pub mod compiler {
                     }),
                     sort: Some(collections::SortOptionsSort::Insertion),
                 },
-                Option::<HashMap<String, Rc<documents::TextDocument>>>::None,
+                Option::<HashMap<String, Gc<documents::TextDocument>>>::None,
             );
             let mut dts = collections::SortedMap::new(
                 collections::SortOptions {
@@ -67,7 +70,7 @@ pub mod compiler {
                     }),
                     sort: Some(collections::SortOptionsSort::Insertion),
                 },
-                Option::<HashMap<String, Rc<documents::TextDocument>>>::None,
+                Option::<HashMap<String, Gc<documents::TextDocument>>>::None,
             );
             let mut maps = collections::SortedMap::new(
                 collections::SortOptions {
@@ -77,7 +80,7 @@ pub mod compiler {
                     }),
                     sort: Some(collections::SortOptionsSort::Insertion),
                 },
-                Option::<HashMap<String, Rc<documents::TextDocument>>>::None,
+                Option::<HashMap<String, Gc<documents::TextDocument>>>::None,
             );
             for document in &*host.outputs() {
                 if vpath::is_java_script(&document.file)
@@ -107,7 +110,7 @@ pub mod compiler {
                         }),
                         sort: Some(collections::SortOptionsSort::Insertion),
                     },
-                    Option::<HashMap<String, Rc<CompilationOutput>>>::None,
+                    Option::<HashMap<String, Gc<CompilationOutput>>>::None,
                 ),
                 _inputs: Default::default(),
                 symlinks: Default::default(),
@@ -126,11 +129,11 @@ pub mod compiler {
                                 .unwrap_or_else(|| options.out_file.as_deref().unwrap()),
                         )],
                     );
-                    let mut inputs: Vec<Rc<documents::TextDocument>> = vec![];
+                    let mut inputs: Vec<Gc<documents::TextDocument>> = vec![];
                     for source_file in &*program.get_source_files() {
                         // if (sourceFile) {
                         let source_file_as_source_file = source_file.as_source_file();
-                        let input = Rc::new(documents::TextDocument::new(
+                        let input = Gc::new(documents::TextDocument::new(
                             source_file_as_source_file.file_name().clone(),
                             source_file_as_source_file.text().clone(),
                             None,
@@ -142,7 +145,7 @@ pub mod compiler {
                         // }
                     }
 
-                    let outputs = Rc::new(CompilationOutput {
+                    let outputs = Gc::new(CompilationOutput {
                         inputs: inputs.clone(),
                         js: ret.js.get(&out_file).cloned(),
                         dts: ret
@@ -178,7 +181,7 @@ pub mod compiler {
                     for source_file in &*program.get_source_files() {
                         // if (sourceFile) {
                         let source_file_as_source_file = source_file.as_source_file();
-                        let input = Rc::new(documents::TextDocument::new(
+                        let input = Gc::new(documents::TextDocument::new(
                             source_file_as_source_file.file_name().clone(),
                             source_file_as_source_file.text().clone(),
                             None,
@@ -189,7 +192,7 @@ pub mod compiler {
                                 &source_file_as_source_file.file_name(),
                                 &ret.options,
                             );
-                            let outputs = Rc::new(CompilationOutput {
+                            let outputs = Gc::new(CompilationOutput {
                                 inputs: vec![input],
                                 js: ret
                                     .js
@@ -240,7 +243,7 @@ pub mod compiler {
             ret
         }
 
-        pub fn vfs(&self) -> Rc<vfs::FileSystem> {
+        pub fn vfs(&self) -> Gc<vfs::FileSystem> {
             self.host.vfs()
         }
 
@@ -304,7 +307,7 @@ pub mod compiler {
     }
 
     pub fn compile_files(
-        host: Rc<fakes::CompilerHost>,
+        host: Gc<Box<fakes::CompilerHost>>,
         root_files: Option<&[String]>,
         compiler_options: &CompilerOptions,
     ) -> CompilationResult {
@@ -350,9 +353,9 @@ pub mod compiler {
                 options: {
                     let mut options = compiler_options.clone();
                     options.trace_resolution = Some(false);
-                    Rc::new(options)
+                    Gc::new(options)
                 },
-                host: Some(host.clone()),
+                host: Some(host.as_dyn_compiler_host()),
                 project_references: None,
                 old_program: None,
                 config_file_parsing_diagnostics: None,
@@ -364,11 +367,11 @@ pub mod compiler {
             get_pre_emit_diagnostics(&pre_program.into(), Option::<&Node>::None, None)
         });
 
-        let compiler_options = Rc::new(compiler_options);
+        let compiler_options = Gc::new(compiler_options);
         let program = create_program(CreateProgramOptions {
             root_names: root_files.map_or_else(|| vec![], ToOwned::to_owned),
             options: compiler_options.clone(),
-            host: Some(host.clone()),
+            host: Some(host.as_dyn_compiler_host()),
             project_references: None,
             old_program: None,
             config_file_parsing_diagnostics: None,
@@ -399,7 +402,7 @@ pub mod compiler {
         ) {
             let mut errors = shorter_errors.unwrap().clone();
             errors.push({
-                let diagnostic: Rc<Diagnostic> = Rc::new(
+                let diagnostic: Gc<Diagnostic> = Gc::new(
                     create_compiler_diagnostic(
                         &DiagnosticMessage::new(
                             0, // -1
@@ -418,8 +421,8 @@ pub mod compiler {
                 add_related_info(
                     &diagnostic,
                     {
-                        let mut related_info: Vec<Rc<DiagnosticRelatedInformation>> = vec![
-                            Rc::new(
+                        let mut related_info: Vec<Gc<DiagnosticRelatedInformation>> = vec![
+                            Gc::new(
                                 create_compiler_diagnostic(
                                     &DiagnosticMessage::new(
                                         0, // -1
@@ -434,10 +437,10 @@ pub mod compiler {
                         ];
                         related_info.append(
                             &mut filter(
-                                &longer_errors.into_iter().map(|error| Rc::new((**error).clone().into())).collect::<Vec<_>>(),
-                                |p: &Rc<DiagnosticRelatedInformation>| !some(
+                                &longer_errors.into_iter().map(|error| Gc::new((**error).clone().into())).collect::<Vec<_>>(),
+                                |p: &Gc<DiagnosticRelatedInformation>| !some(
                                     shorter_errors.map(|shorter_errors| &**shorter_errors),
-                                    Some(|p2: &Rc<Diagnostic>| compare_diagnostics(&**p, &**p2) == Comparison::EqualTo)
+                                    Some(|p2: &Gc<Diagnostic>| compare_diagnostics(&**p, &**p2) == Comparison::EqualTo)
                                 )
                             )
                         );

--- a/harness/src/harness/compiler_impl.rs
+++ b/harness/src/harness/compiler_impl.rs
@@ -13,7 +13,11 @@ pub mod compiler {
         Program, ScriptTarget, SourceFileLike,
     };
 
-    use crate::{collections, documents, fakes, vfs, vpath};
+    use crate::{
+        collections, documents, fakes,
+        vfs::{self, SortOptionsComparerFromStringComparer},
+        vpath,
+    };
 
     #[derive(Trace, Finalize)]
     pub struct CompilationOutput {
@@ -54,30 +58,27 @@ pub mod compiler {
 
             let mut js = collections::SortedMap::new(
                 collections::SortOptions {
-                    comparer: Rc::new({
-                        let string_comparer = host.vfs().string_comparer.clone();
-                        move |a: &String, b: &String| string_comparer(a, b)
-                    }),
+                    comparer: Gc::new(Box::new(SortOptionsComparerFromStringComparer::new(
+                        host.vfs().string_comparer.clone(),
+                    ))),
                     sort: Some(collections::SortOptionsSort::Insertion),
                 },
                 Option::<HashMap<String, Gc<documents::TextDocument>>>::None,
             );
             let mut dts = collections::SortedMap::new(
                 collections::SortOptions {
-                    comparer: Rc::new({
-                        let string_comparer = host.vfs().string_comparer.clone();
-                        move |a: &String, b: &String| string_comparer(a, b)
-                    }),
+                    comparer: Gc::new(Box::new(SortOptionsComparerFromStringComparer::new(
+                        host.vfs().string_comparer.clone(),
+                    ))),
                     sort: Some(collections::SortOptionsSort::Insertion),
                 },
                 Option::<HashMap<String, Gc<documents::TextDocument>>>::None,
             );
             let mut maps = collections::SortedMap::new(
                 collections::SortOptions {
-                    comparer: Rc::new({
-                        let string_comparer = host.vfs().string_comparer.clone();
-                        move |a: &String, b: &String| string_comparer(a, b)
-                    }),
+                    comparer: Gc::new(Box::new(SortOptionsComparerFromStringComparer::new(
+                        host.vfs().string_comparer.clone(),
+                    ))),
                     sort: Some(collections::SortOptionsSort::Insertion),
                 },
                 Option::<HashMap<String, Gc<documents::TextDocument>>>::None,
@@ -104,10 +105,9 @@ pub mod compiler {
                 maps,
                 _inputs_and_outputs: collections::SortedMap::new(
                     collections::SortOptions {
-                        comparer: Rc::new({
-                            let string_comparer = host.vfs().string_comparer.clone();
-                            move |a: &String, b: &String| string_comparer(a, b)
-                        }),
+                        comparer: Gc::new(Box::new(SortOptionsComparerFromStringComparer::new(
+                            host.vfs().string_comparer.clone(),
+                        ))),
                         sort: Some(collections::SortOptionsSort::Insertion),
                     },
                     Option::<HashMap<String, Gc<CompilationOutput>>>::None,

--- a/harness/src/harness/compiler_impl.rs
+++ b/harness/src/harness/compiler_impl.rs
@@ -2,7 +2,6 @@ pub mod compiler {
     use gc::{Finalize, Gc, Trace};
     use std::collections::HashMap;
     use std::ptr;
-    use std::rc::Rc;
 
     use typescript_rust::{
         add_related_info, compare_diagnostics, create_compiler_diagnostic, create_program,

--- a/harness/src/harness/documents_util.rs
+++ b/harness/src/harness/documents_util.rs
@@ -1,8 +1,10 @@
 pub mod documents {
+    use gc::{Finalize, Trace};
     use std::collections::HashMap;
 
     use crate::Compiler;
 
+    #[derive(Trace, Finalize)]
     pub struct TextDocument {
         pub meta: HashMap<String, String>,
         pub file: String,

--- a/harness/src/harness/fakes_hosts.rs
+++ b/harness/src/harness/fakes_hosts.rs
@@ -17,6 +17,7 @@ pub mod fakes {
     };
     use typescript_services_rust::{get_default_compiler_options, NodeServicesInterface};
 
+    use crate::vfs::SortOptionsComparerFromStringComparer;
     use crate::{collections, documents, get_light_mode, vfs, vpath, Utils};
 
     // const processExitSentinel = new Error("System exit");
@@ -418,10 +419,9 @@ pub mod fakes {
                 ),
                 _source_files: GcCell::new(collections::SortedMap::new(
                     collections::SortOptions {
-                        comparer: {
-                            let sys_vfs_string_comparer = sys.vfs.string_comparer.clone();
-                            Rc::new(move |a: &String, b: &String| sys_vfs_string_comparer(a, b))
-                        },
+                        comparer: Gc::new(Box::new(SortOptionsComparerFromStringComparer::new(
+                            sys.vfs.string_comparer.clone(),
+                        ))),
                         sort: Some(collections::SortOptionsSort::Insertion),
                     },
                     Option::<HashMap<String, Gc<Node>>>::None,
@@ -429,10 +429,9 @@ pub mod fakes {
                 _set_parent_nodes: set_parent_nodes,
                 _outputs_map: RefCell::new(collections::SortedMap::new(
                     collections::SortOptions {
-                        comparer: {
-                            let sys_vfs_string_comparer = sys.vfs.string_comparer.clone();
-                            Rc::new(move |a: &String, b: &String| sys_vfs_string_comparer(a, b))
-                        },
+                        comparer: Gc::new(Box::new(SortOptionsComparerFromStringComparer::new(
+                            sys.vfs.string_comparer.clone(),
+                        ))),
                         sort: None,
                     },
                     Option::<HashMap<String, usize>>::None,

--- a/harness/src/harness/fakes_hosts.rs
+++ b/harness/src/harness/fakes_hosts.rs
@@ -369,8 +369,7 @@ pub mod fakes {
         pub default_lib_location: String,
         #[unsafe_ignore_trace]
         outputs: GcCell<Vec<Gc<documents::TextDocument>>>,
-        #[unsafe_ignore_trace]
-        _outputs_map: RefCell<collections::SortedMap<String, usize>>,
+        _outputs_map: GcCell<collections::SortedMap<String, usize>>,
         #[unsafe_ignore_trace]
         traces: RefCell<Vec<String>>,
         pub should_assert_invariants: bool,
@@ -427,7 +426,7 @@ pub mod fakes {
                     Option::<HashMap<String, Gc<Node>>>::None,
                 )),
                 _set_parent_nodes: set_parent_nodes,
-                _outputs_map: RefCell::new(collections::SortedMap::new(
+                _outputs_map: GcCell::new(collections::SortedMap::new(
                     collections::SortOptions {
                         comparer: Gc::new(Box::new(SortOptionsComparerFromStringComparer::new(
                             sys.vfs.string_comparer.clone(),

--- a/harness/src/harness/fakes_hosts.rs
+++ b/harness/src/harness/fakes_hosts.rs
@@ -1,10 +1,12 @@
 pub mod fakes {
+    use gc::{Finalize, Gc, GcCell, Trace};
     use std::borrow::Cow;
     use std::cell::{Cell, Ref, RefCell};
     use std::collections::HashMap;
     use std::io;
     use std::rc::Rc;
     use std::time::SystemTime;
+
     use typescript_rust::{
         create_source_file, generate_djb2_hash, get_default_lib_file_name, get_new_line_character,
         match_files, millis_since_epoch_to_system_time, not_implemented, CompilerOptions,
@@ -25,9 +27,11 @@ pub mod fakes {
         pub env: Option<HashMap<String, String>>,
     }
 
+    #[derive(Trace, Finalize)]
     pub struct System {
-        pub vfs: Rc<vfs::FileSystem>,
+        pub vfs: Gc<vfs::FileSystem>,
         pub args: Vec<String>,
+        #[unsafe_ignore_trace]
         output: RefCell<Vec<String>>,
         pub new_line: &'static str,
         pub use_case_sensitive_file_names: bool,
@@ -35,6 +39,7 @@ pub mod fakes {
 
         _executing_file_path: Option<String>,
         _env: Option<HashMap<String, String>>,
+        #[unsafe_ignore_trace]
         test_terminal_width: Cell<Option<Option<usize>>>,
     }
 
@@ -340,7 +345,7 @@ pub mod fakes {
     }
 
     pub struct ParseConfigHost {
-        pub sys: Rc<System>,
+        pub sys: Gc<System>,
     }
 
     impl ParseConfigHost {
@@ -354,16 +359,20 @@ pub mod fakes {
         }
     }
 
+    #[derive(Trace, Finalize)]
     pub struct CompilerHost {
-        pub sys: Rc<System>,
+        pub sys: Gc<System>,
         pub default_lib_location: String,
+        #[unsafe_ignore_trace]
         outputs: RefCell<Vec<Rc<documents::TextDocument>>>,
+        #[unsafe_ignore_trace]
         _outputs_map: RefCell<collections::SortedMap<String, usize>>,
+        #[unsafe_ignore_trace]
         traces: RefCell<Vec<String>>,
         pub should_assert_invariants: bool,
 
         _set_parent_nodes: bool,
-        _source_files: RefCell<collections::SortedMap<String, Rc<Node /*SourceFile*/>>>,
+        _source_files: GcCell<collections::SortedMap<String, Gc<Node /*SourceFile*/>>>,
         _parse_config_host: RefCell<Option<Rc<ParseConfigHost>>>,
         _new_line: String,
 

--- a/harness/src/harness/harness_io.rs
+++ b/harness/src/harness/harness_io.rs
@@ -6,7 +6,6 @@ use std::io;
 use std::iter::FromIterator;
 use std::mem;
 use std::path::{Path as StdPath, PathBuf};
-use std::rc::Rc;
 
 use typescript_rust::{
     compare_strings_case_insensitive, compare_strings_case_sensitive, comparison_to_ordering,
@@ -259,13 +258,12 @@ pub fn set_light_mode(flag: bool) {
 }
 
 pub mod Compiler {
-    use gc::{Finalize, Gc, Trace};
+    use gc::{Finalize, Gc, GcCell, Trace};
     use regex::Regex;
     use std::cell::RefCell;
     use std::cmp;
     use std::collections::HashMap;
     use std::convert::TryInto;
-    use std::rc::Rc;
 
     use typescript_rust::{
         compare_diagnostics, compare_paths, compute_line_starts, count_where,
@@ -700,7 +698,7 @@ pub mod Compiler {
     }
 
     thread_local! {
-        static options_index: RefCell<Option<HashMap<String, Gc<CommandLineOption>>>> = RefCell::new(None);
+        static options_index: GcCell<Option<HashMap<String, Gc<CommandLineOption>>>> = GcCell::new(None);
     }
     fn get_command_line_option(name: &str) -> Option<Gc<CommandLineOption>> {
         options_index.with(|options_index_| {
@@ -1599,7 +1597,6 @@ pub mod TestCaseParser {
     use regex::Regex;
     use std::collections::HashMap;
     use std::io;
-    use std::rc::Rc;
 
     use typescript_rust::{
         for_each, get_base_file_name, get_directory_path, get_normalized_absolute_path,

--- a/harness/src/harness/harness_utils.rs
+++ b/harness/src/harness/harness_utils.rs
@@ -1,7 +1,6 @@
 use gc::{Finalize, Gc, GcCell, Trace};
 use once_cell::sync::Lazy;
-use std::cell::{Cell, RefCell};
-use std::rc::Rc;
+use std::cell::Cell;
 use typescript_rust::{
     are_option_gcs_equal, create_get_canonical_file_name, for_each_child, Node, NodeArray,
     NodeInterface, ReadonlyTextRange,

--- a/harness/src/harness/runnerbase.rs
+++ b/harness/src/harness/runnerbase.rs
@@ -1,6 +1,7 @@
 use regex::Regex;
 use std::cell::Cell;
-use std::rc::Rc;
+use gc::Gc;
+
 use typescript_rust::{map, normalize_slashes};
 
 use crate::{user_specified_root, with_io, FileBasedTest, ListFilesOptions};
@@ -48,13 +49,14 @@ fn get_shard_id() -> usize {
     shard_id_.with(|shard_id| shard_id.get())
 }
 
+#{derive(Trace, Finalize)}
 pub struct RunnerBase {
-    sub: Rc<dyn RunnerBaseSub>,
+    sub: Gc<Box<dyn RunnerBaseSub>>,
     pub tests: Vec<StringOrFileBasedTest>,
 }
 
 impl RunnerBase {
-    pub fn new(sub: Rc<dyn RunnerBaseSub>) -> Self {
+    pub fn new(sub: Gc<Box<dyn RunnerBaseSub>>) -> Self {
         Self { sub, tests: vec![] }
     }
 

--- a/harness/src/harness/runnerbase.rs
+++ b/harness/src/harness/runnerbase.rs
@@ -1,6 +1,6 @@
+use gc::{Finalize, Gc, Trace};
 use regex::Regex;
 use std::cell::Cell;
-use gc::Gc;
 
 use typescript_rust::{map, normalize_slashes};
 
@@ -49,7 +49,7 @@ fn get_shard_id() -> usize {
     shard_id_.with(|shard_id| shard_id.get())
 }
 
-#{derive(Trace, Finalize)}
+#[derive(Trace, Finalize)]
 pub struct RunnerBase {
     sub: Gc<Box<dyn RunnerBaseSub>>,
     pub tests: Vec<StringOrFileBasedTest>,
@@ -115,7 +115,7 @@ impl RunnerBase {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Trace, Finalize)]
 pub enum StringOrFileBasedTest {
     String(String),
     FileBasedTest(FileBasedTest),
@@ -137,7 +137,7 @@ pub struct EnumerateFilesOptions {
     pub recursive: bool,
 }
 
-pub trait RunnerBaseSub {
+pub trait RunnerBaseSub: Trace + Finalize {
     fn kind(&self, runner_base: &RunnerBase) -> TestRunnerKind;
     fn initialize_tests(&self, runner_base: &RunnerBase);
     fn enumerate_test_files(&self, runner_base: &RunnerBase) -> Vec<StringOrFileBasedTest>;

--- a/harness/src/harness/vfs_util.rs
+++ b/harness/src/harness/vfs_util.rs
@@ -1,4 +1,5 @@
 pub mod vfs {
+    use gc::{Finalize, Gc, GcCell, Trace, GcCellRefMut};
     use local_macros::enum_unwrapped;
     use std::borrow::Cow;
     use std::cell::{Cell, Ref, RefCell, RefMut};
@@ -6,6 +7,7 @@ pub mod vfs {
     use std::iter::FromIterator;
     use std::rc::Rc;
     use std::time::{SystemTime, UNIX_EPOCH};
+
     use typescript_rust::{
         get_sys, is_option_str_empty, millis_since_epoch_to_system_time, Buffer, Comparison,
         FileSystemEntries, Node,
@@ -54,15 +56,19 @@ pub mod vfs {
         })
     }
 
+    #[derive(Trace, Finalize)]
     pub struct FileSystem {
         pub ignore_case: bool,
         pub string_comparer: Rc<dyn Fn(&str, &str) -> Comparison>,
         _lazy: FileSystemLazy,
 
+        #[unsafe_ignore_trace]
         _cwd: RefCell<Option<String>>,
         _time: RefCell<TimestampOrNowOrSystemTimeOrCallback>,
-        _shadow_root: Option<Rc<FileSystem>>,
+        _shadow_root: Option<Gc<FileSystem>>,
+        #[unsafe_ignore_trace]
         _dir_stack: RefCell<Option<Vec<String>>>,
+        #[unsafe_ignore_trace]
         _is_readonly: Cell<bool>,
     }
 
@@ -143,9 +149,9 @@ pub mod vfs {
             self._dir_stack.borrow_mut()
         }
 
-        pub fn meta(&self) -> Rc<RefCell<collections::Metadata<String>>> {
+        pub fn meta(&self) -> Gc<GcCell<collections::Metadata<String>>> {
             self._lazy.meta.borrow_mut().get_or_insert_with(|| {
-                Rc::new(RefCell::new(collections::Metadata::new(
+                Gc::new(GcCell::new(collections::Metadata::new(
                     self._shadow_root
                         .as_ref()
                         .map(|_shadow_root| _shadow_root.meta()),
@@ -165,11 +171,11 @@ pub mod vfs {
             self
         }
 
-        pub fn shadow_root(&self) -> Option<Rc<FileSystem>> {
+        pub fn shadow_root(&self) -> Option<Gc<FileSystem>> {
             self._shadow_root.clone()
         }
 
-        pub fn shadow(self: Rc<Self>, ignore_case: Option<bool>) -> Self {
+        pub fn shadow(self: Gc<Self>, ignore_case: Option<bool>) -> Self {
             let ignore_case = ignore_case.unwrap_or(self.ignore_case);
             if !self.is_readonly() {
                 panic!("Cannot shadow a mutable file system.");
@@ -215,7 +221,7 @@ pub mod vfs {
             *self._time.borrow_mut() = value;
         }
 
-        pub fn filemeta(&self, path: &str) -> Rc<RefCell<collections::Metadata<MetaValue>>> {
+        pub fn filemeta(&self, path: &str) -> Gc<GcCell<collections::Metadata<MetaValue>>> {
             let WalkResult { node, .. } = self
                 ._walk(
                     &self._resolve(path),
@@ -231,7 +237,7 @@ pub mod vfs {
             self._filemeta(node)
         }
 
-        pub fn _filemeta(&self, node: &Inode) -> Rc<RefCell<collections::Metadata<MetaValue>>> {
+        pub fn _filemeta(&self, node: &Inode) -> Gc<GcCell<collections::Metadata<MetaValue>>> {
             node.meta_mut()
                 .get_or_insert_with(|| {
                     let parent_meta = if let (Some(node_shadow_root), Some(_shadow_root)) = (
@@ -242,7 +248,7 @@ pub mod vfs {
                     } else {
                         None
                     };
-                    Rc::new(RefCell::new(collections::Metadata::new(parent_meta)))
+                    Gc::new(GcCell::new(collections::Metadata::new(parent_meta)))
                 })
                 .clone()
         }
@@ -337,7 +343,7 @@ pub mod vfs {
             unimplemented!()
         }
 
-        pub fn mount_sync(&self, source: &str, target: &str, resolver: Rc<FileSystemResolver>) {
+        pub fn mount_sync(&self, source: &str, target: &str, resolver: Gc<FileSystemResolver>) {
             if self.is_readonly() {
                 // throw createIOError("EROFS");
                 panic!("EROFS");
@@ -380,7 +386,7 @@ pub mod vfs {
                 parent.as_deref(),
                 &mut links.borrow_mut(),
                 &basename,
-                Rc::new(node),
+                Gc::new(node),
                 Some(time),
             );
         }
@@ -499,7 +505,7 @@ pub mod vfs {
                 parent.as_deref(),
                 &mut links.borrow_mut(),
                 &basename,
-                Rc::new(node),
+                Gc::new(node),
                 Some(time),
             );
         }
@@ -590,7 +596,7 @@ pub mod vfs {
 
             let time = self.time();
             let ref node = existing_node.unwrap_or_else(|| {
-                let node = Rc::new(self._mknod(parent.dev(), S_IFREG, 0o666, Some(time)));
+                let node = Gc::new(self._mknod(parent.dev(), S_IFREG, 0o666, Some(time)));
                 self._add_link(
                     Some(parent),
                     &mut links.borrow_mut(),
@@ -642,9 +648,9 @@ pub mod vfs {
         fn _add_link(
             &self,
             parent: Option<&Inode /*DirectoryInode*/>,
-            links: &mut collections::SortedMap<String, Rc<Inode>>,
+            links: &mut collections::SortedMap<String, Gc<Inode>>,
             name: &str,
-            node: Rc<Inode>,
+            node: Gc<Inode>,
             time: Option<u128>,
         ) {
             let time = time.unwrap_or_else(|| self.time());
@@ -665,7 +671,7 @@ pub mod vfs {
             }
         }
 
-        fn _get_root_links(&self) -> Rc<RefCell<collections::SortedMap<String, Rc<Inode>>>> {
+        fn _get_root_links(&self) -> Gc<GcCell<collections::SortedMap<String, Gc<Inode>>>> {
             self._lazy
                 .links
                 .borrow_mut()
@@ -674,11 +680,11 @@ pub mod vfs {
                         collections::SortOptions {
                             comparer: {
                                 let string_comparer = self.string_comparer.clone();
-                                Rc::new(move |a: &String, b: &String| string_comparer(a, b))
+                                Gc::new(move |a: &String, b: &String| string_comparer(a, b))
                             },
                             sort: None,
                         },
-                        Option::<HashMap<String, Rc<Inode>>>::None,
+                        Option::<HashMap<String, Gc<Inode>>>::None,
                     );
                     if let Some(_shadow_root) = self._shadow_root.as_ref() {
                         self._copy_shadow_links(
@@ -686,7 +692,7 @@ pub mod vfs {
                             &mut _lazy_links,
                         );
                     }
-                    Rc::new(RefCell::new(_lazy_links))
+                    Gc::new(GcCell::new(_lazy_links))
                 })
                 .clone()
         }
@@ -694,7 +700,7 @@ pub mod vfs {
         fn _get_links(
             &self,
             node: &Inode, /*DirectoryInode*/
-        ) -> Rc<RefCell<collections::SortedMap<String, Rc<Inode>>>> {
+        ) -> Gc<GcCell<collections::SortedMap<String, Gc<Inode>>>> {
             let node_as_directory_inode = node.as_directory_inode();
             if node_as_directory_inode.maybe_links().is_none() {
                 let mut links = collections::SortedMap::new(
@@ -705,7 +711,7 @@ pub mod vfs {
                         }),
                         sort: None,
                     },
-                    Option::<HashMap<String, Rc<Inode>>>::None,
+                    Option::<HashMap<String, Gc<Inode>>>::None,
                 );
                 let source = node_as_directory_inode.maybe_source();
                 let resolver = node_as_directory_inode.maybe_resolver();
@@ -723,7 +729,7 @@ pub mod vfs {
                                     .set_source(Some(vpath::combine(&source, &[Some(&name)])));
                                 dir.as_directory_inode()
                                     .set_resolver(Some(resolver.clone()));
-                                self._add_link(Some(node), &mut links, &name, Rc::new(dir), None);
+                                self._add_link(Some(node), &mut links, &name, Gc::new(dir), None);
                             }
                             S_IFREG => {
                                 let file =
@@ -732,7 +738,7 @@ pub mod vfs {
                                     .set_source(Some(vpath::combine(&source, &[Some(&name)])));
                                 file.as_file_inode().set_resolver(Some(resolver.clone()));
                                 file.as_file_inode().set_size(Some(stats.size));
-                                self._add_link(Some(node), &mut links, &name, Rc::new(file), None);
+                                self._add_link(Some(node), &mut links, &name, Gc::new(file), None);
                             }
                             _ => (),
                         }
@@ -746,12 +752,12 @@ pub mod vfs {
                         &mut links,
                     );
                 }
-                node_as_directory_inode.set_links(Some(Rc::new(RefCell::new(links))));
+                node_as_directory_inode.set_links(Some(Gc::new(GcCell::new(links))));
             }
             node_as_directory_inode.maybe_links().unwrap()
         }
 
-        fn _get_shadow(&self, root: Rc<Inode>) -> Rc<Inode> {
+        fn _get_shadow(&self, root: Gc<Inode>) -> Gc<Inode> {
             self._lazy
                 .shadows
                 .borrow_mut()
@@ -776,18 +782,18 @@ pub mod vfs {
                             root.as_symlink_inode().symlink.clone();
                     }
 
-                    Rc::new(shadow)
+                    Gc::new(shadow)
                 })
                 .clone()
         }
 
         fn _copy_shadow_links<
             'source,
-            TSource: IntoIterator<Item = (&'source String, &'source Rc<Inode>)>,
+            TSource: IntoIterator<Item = (&'source String, &'source Gc<Inode>)>,
         >(
             &self,
             source: TSource,
-            target: &mut collections::SortedMap<String, Rc<Inode>>,
+            target: &mut collections::SortedMap<String, Gc<Inode>>,
         ) {
             let source = source.into_iter();
             for (name, root) in source {
@@ -852,7 +858,7 @@ pub mod vfs {
             mut on_error: Option<TOnError>,
         ) -> Option<WalkResult> {
             let mut links = self._get_root_links();
-            let mut parent: Option<Rc<Inode>> = None;
+            let mut parent: Option<Gc<Inode>> = None;
             let mut components = vpath::parse(path, None);
             let mut step = 0;
             let mut depth = 0;
@@ -941,10 +947,10 @@ pub mod vfs {
             step: usize,
             retry: &mut bool,
             on_error: Option<&mut TOnError>,
-            parent: Option<Rc<Inode /*DirectoryInode*/>>,
-            links: Rc<RefCell<collections::SortedMap<String, Rc<Inode>>>>,
+            parent: Option<Gc<Inode /*DirectoryInode*/>>,
+            links: Gc<GcCell<collections::SortedMap<String, Gc<Inode>>>>,
             error: NodeJSErrnoException,
-            node: Option<Rc<Inode>>,
+            node: Option<Gc<Inode>>,
         ) -> bool {
             let realpath = vpath::format(&components[..step + 1]);
             let basename = &components[step];
@@ -1029,7 +1035,7 @@ pub mod vfs {
         fn _apply_file_extended_options(
             &self,
             path: &str,
-            entry_meta: Option<&HashMap<String, Rc<documents::TextDocument>>>,
+            entry_meta: Option<&HashMap<String, Gc<documents::TextDocument>>>,
         ) {
             if let Some(meta) = entry_meta {
                 let filemeta = self.filemeta(path);
@@ -1089,24 +1095,24 @@ pub mod vfs {
 
     #[derive(Clone)]
     pub enum MetaValue {
-        RcTextDocument(Rc<documents::TextDocument>),
-        RcNode(Rc<Node>),
+        RcTextDocument(Gc<documents::TextDocument>),
+        RcNode(Gc<Node>),
     }
 
     impl MetaValue {
-        pub fn as_rc_node(&self) -> &Rc<Node> {
+        pub fn as_rc_node(&self) -> &Gc<Node> {
             enum_unwrapped!(self, [MetaValue, RcNode])
         }
     }
 
-    impl From<Rc<documents::TextDocument>> for MetaValue {
-        fn from(value: Rc<documents::TextDocument>) -> Self {
+    impl From<Gc<documents::TextDocument>> for MetaValue {
+        fn from(value: Gc<documents::TextDocument>) -> Self {
             Self::RcTextDocument(value)
         }
     }
 
-    impl From<Rc<Node>> for MetaValue {
-        fn from(value: Rc<Node>) -> Self {
+    impl From<Gc<Node>> for MetaValue {
+        fn from(value: Gc<Node>) -> Self {
             Self::RcNode(value)
         }
     }
@@ -1158,11 +1164,11 @@ pub mod vfs {
         Throw,
     }
 
-    #[derive(Default)]
+    #[derive(Default, Trace, Finalize)]
     struct FileSystemLazy {
-        links: RefCell<Option<Rc<RefCell<collections::SortedMap<String, Rc<Inode>>>>>>,
-        shadows: RefCell<Option<HashMap<u32, Rc<Inode>>>>,
-        meta: Rc<RefCell<Option<Rc<RefCell<collections::Metadata<String>>>>>>,
+        links: GcCell<Option<Gc<GcCell<collections::SortedMap<String, Gc<Inode>>>>>>,
+        shadows: GcCell<Option<HashMap<u32, Gc<Inode>>>>,
+        meta: Gc<GcCell<Option<Gc<RefCell<collections::Metadata<String>>>>>>,
     }
 
     #[derive(Clone)]
@@ -1170,7 +1176,11 @@ pub mod vfs {
         Timestamp(u128),
         Now,
         SystemTime(SystemTime),
-        Callback(Rc<dyn Fn() -> TimestampOrNowOrSystemTime>),
+        Callback(Gc<Box<dyn TimestampOrNowOrSystemTimeOrCallbackCallback>>),
+    }
+
+    pub trait TimestampOrNowOrSystemTimeOrCallbackCallback: Trace + Finalize {
+        fn call(&self) -> TimestampOrNowOrSystemTime;
     }
 
     impl From<u128> for TimestampOrNowOrSystemTimeOrCallback {
@@ -1185,8 +1195,8 @@ pub mod vfs {
         }
     }
 
-    impl From<Rc<dyn Fn() -> TimestampOrNowOrSystemTime>> for TimestampOrNowOrSystemTimeOrCallback {
-        fn from(value: Rc<dyn Fn() -> TimestampOrNowOrSystemTime>) -> Self {
+    impl From<Gc<Box<dyn TimestampOrNowOrSystemTimeOrCallbackCallback>> for TimestampOrNowOrSystemTimeOrCallback {
+        fn from(value: Gc<Box<dyn TimestampOrNowOrSystemTimeOrCallbackCallback>>) -> Self {
             Self::Callback(value)
         }
     }
@@ -1223,11 +1233,12 @@ pub mod vfs {
         pub files: Option<FileSet>,
         pub cwd: Option<String>,
         pub meta: Option<HashMap<String, String>>,
-        pub documents: Option<Vec<Rc<documents::TextDocument>>>,
+        pub documents: Option<Vec<Gc<documents::TextDocument>>>,
     }
 
+    #[derive(Trace, Finalize)]
     pub struct FileSystemResolver {
-        pub host: Rc<dyn FileSystemResolverHost>,
+        pub host: Gc<Box<dyn FileSystemResolverHost>>,
     }
 
     impl FileSystemResolver {
@@ -1268,7 +1279,7 @@ pub mod vfs {
         pub size: usize,
     }
 
-    pub trait FileSystemResolverHost {
+    pub trait FileSystemResolverHost: Trace + Finalize {
         fn get_accessible_file_system_entries(&self, path: &str) -> FileSystemEntries;
         fn directory_exists(&self, path: &str) -> bool;
         fn file_exists(&self, path: &str) -> bool;
@@ -1277,12 +1288,12 @@ pub mod vfs {
         fn get_workspace_root(&self) -> String;
     }
 
-    pub fn create_resolver(host: Rc<dyn FileSystemResolverHost>) -> FileSystemResolver {
+    pub fn create_resolver(host: Gc<Box<dyn FileSystemResolverHost>>) -> FileSystemResolver {
         FileSystemResolver { host }
     }
 
     pub fn create_from_file_system(
-        host: Rc<dyn FileSystemResolverHost>,
+        host: Gc<Box<dyn FileSystemResolverHost>>,
         ignore_case: bool,
         options: Option<FileSystemCreateOptions>,
     ) -> FileSystem {
@@ -1522,7 +1533,7 @@ pub mod vfs {
     #[derive(Clone)]
     pub struct Directory {
         pub files: FileSet,
-        pub meta: Option<HashMap<String, Rc<documents::TextDocument>>>,
+        pub meta: Option<HashMap<String, Gc<documents::TextDocument>>>,
     }
 
     impl Directory {
@@ -1535,14 +1546,14 @@ pub mod vfs {
 
     #[derive(Default)]
     pub struct DirectoryOptions {
-        pub meta: Option<HashMap<String, Rc<documents::TextDocument>>>,
+        pub meta: Option<HashMap<String, Gc<documents::TextDocument>>>,
     }
 
     #[derive(Clone)]
     pub struct File {
         pub data: String, /*Buffer | string*/
         pub encoding: Option<String>,
-        pub meta: Option<HashMap<String, Rc<documents::TextDocument>>>,
+        pub meta: Option<HashMap<String, Gc<documents::TextDocument>>>,
     }
 
     impl File {
@@ -1560,7 +1571,7 @@ pub mod vfs {
     #[derive(Default)]
     pub struct FileOptions {
         pub encoding: Option<String>,
-        pub meta: Option<HashMap<String, Rc<documents::TextDocument>>>,
+        pub meta: Option<HashMap<String, Gc<documents::TextDocument>>>,
     }
 
     #[derive(Clone)]
@@ -1583,7 +1594,7 @@ pub mod vfs {
     #[derive(Clone)]
     pub struct Symlink {
         pub symlink: String,
-        pub meta: Option<HashMap<String, Rc<documents::TextDocument>>>,
+        pub meta: Option<HashMap<String, Gc<documents::TextDocument>>>,
     }
 
     impl Symlink {
@@ -1596,20 +1607,20 @@ pub mod vfs {
     }
 
     pub struct SymlinkNewOptions {
-        meta: Option<HashMap<String, Rc<documents::TextDocument>>>,
+        meta: Option<HashMap<String, Gc<documents::TextDocument>>>,
     }
 
     #[derive(Clone)]
     pub struct Mount {
         pub source: String,
-        pub resolver: Rc<FileSystemResolver>,
-        pub meta: Option<HashMap<String, Rc<documents::TextDocument>>>,
+        pub resolver: Gc<FileSystemResolver>,
+        pub meta: Option<HashMap<String, Gc<documents::TextDocument>>>,
     }
 
     impl Mount {
         pub fn new(
             source: String,
-            resolver: Rc<FileSystemResolver>,
+            resolver: Gc<FileSystemResolver>,
             options: Option<MountOptions>,
         ) -> Self {
             let options = options.unwrap_or_default();
@@ -1624,10 +1635,10 @@ pub mod vfs {
 
     #[derive(Default)]
     pub struct MountOptions {
-        pub meta: Option<HashMap<String, Rc<documents::TextDocument>>>,
+        pub meta: Option<HashMap<String, Gc<documents::TextDocument>>>,
     }
 
-    #[derive(Clone)]
+    #[derive(Clone, Trace, Finalize)]
     pub enum Inode {
         FileInode(FileInode),
         DirectoryInode(DirectoryInode),
@@ -1645,7 +1656,7 @@ pub mod vfs {
             ctime_ms: u128,
             birthtime_ms: u128,
             nlink: usize,
-            shadow_root: Option<Rc<Inode>>,
+            shadow_root: Option<Gc<Inode>>,
         ) -> Self {
             match type_ {
                 S_IFREG => FileInode::new(
@@ -1784,7 +1795,7 @@ pub mod vfs {
             }
         }
 
-        pub fn meta_mut(&self) -> RefMut<Option<Rc<RefCell<collections::Metadata<MetaValue>>>>> {
+        pub fn meta_mut(&self) -> RefMut<Option<Gc<GcCell<collections::Metadata<MetaValue>>>>> {
             match self {
                 Self::FileInode(value) => value.meta_mut(),
                 Self::DirectoryInode(value) => value.meta_mut(),
@@ -1792,7 +1803,7 @@ pub mod vfs {
             }
         }
 
-        pub fn maybe_shadow_root(&self) -> Option<Rc<Inode>> {
+        pub fn maybe_shadow_root(&self) -> Option<Gc<Inode>> {
             match self {
                 Self::FileInode(value) => value.shadow_root.clone(),
                 Self::DirectoryInode(value) => value.shadow_root.clone(),
@@ -1845,22 +1856,28 @@ pub mod vfs {
         }
     }
 
-    #[derive(Clone)]
+    #[derive(Clone, Trace, Finalize)]
     pub struct FileInode {
         pub dev: u32,
         pub ino: u32,
         pub mode: u32,
         pub atime_ms: u128,
+        #[unsafe_ignore_trace]
         pub mtime_ms: Cell<u128>,
+        #[unsafe_ignore_trace]
         pub ctime_ms: Cell<u128>,
         pub birthtime_ms: u128,
+        #[unsafe_ignore_trace]
         nlink: Cell<usize>,
+        #[unsafe_ignore_trace]
         size: Cell<Option<usize>>,
+        #[unsafe_ignore_trace]
         buffer: RefCell<Option<Buffer>>,
+        #[unsafe_ignore_trace]
         source: RefCell<Option<String>>,
-        resolver: RefCell<Option<Rc<FileSystemResolver>>>,
-        pub shadow_root: Option<Rc<Inode /*FileInode*/>>,
-        meta: RefCell<Option<Rc<RefCell<collections::Metadata<MetaValue>>>>>,
+        resolver: GcCell<Option<Gc<FileSystemResolver>>>,
+        pub shadow_root: Option<Gc<Inode /*FileInode*/>>,
+        meta: GcCell<Option<Gc<GcCell<collections::Metadata<MetaValue>>>>>,
     }
 
     impl FileInode {
@@ -1873,7 +1890,7 @@ pub mod vfs {
             ctime_ms: u128,
             birthtime_ms: u128,
             nlink: usize,
-            shadow_root: Option<Rc<Inode>>,
+            shadow_root: Option<Gc<Inode>>,
         ) -> Self {
             Self {
                 dev,
@@ -1937,34 +1954,38 @@ pub mod vfs {
             *self.source.borrow_mut() = source;
         }
 
-        pub fn maybe_resolver(&self) -> Option<Rc<FileSystemResolver>> {
+        pub fn maybe_resolver(&self) -> Option<Gc<FileSystemResolver>> {
             self.resolver.borrow().clone()
         }
 
-        pub fn set_resolver(&self, resolver: Option<Rc<FileSystemResolver>>) {
+        pub fn set_resolver(&self, resolver: Option<Gc<FileSystemResolver>>) {
             *self.resolver.borrow_mut() = resolver;
         }
 
-        pub fn meta_mut(&self) -> RefMut<Option<Rc<RefCell<collections::Metadata<MetaValue>>>>> {
+        pub fn meta_mut(&self) -> GcCellRefMut<Option<Gc<GcCell<collections::Metadata<MetaValue>>>>> {
             self.meta.borrow_mut()
         }
     }
 
-    #[derive(Clone)]
+    #[derive(Clone, Trace, Finalize)]
     pub struct DirectoryInode {
         pub dev: u32,
         pub ino: u32,
         pub mode: u32,
         pub atime_ms: u128,
+        #[unsafe_ignore_trace]
         pub mtime_ms: Cell<u128>,
+        #[unsafe_ignore_trace]
         pub ctime_ms: Cell<u128>,
         pub birthtime_ms: u128,
+        #[unsafe_ignore_trace]
         nlink: Cell<usize>,
-        links: RefCell<Option<Rc<RefCell<collections::SortedMap<String, Rc<Inode>>>>>>,
+        links: GcCell<Option<Gc<GcCell<collections::SortedMap<String, Gc<Inode>>>>>>,
+        #[unsafe_ignore_trace]
         source: RefCell<Option<String>>,
-        resolver: RefCell<Option<Rc<FileSystemResolver>>>,
-        pub shadow_root: Option<Rc<Inode /*DirectoryInode*/>>,
-        meta: RefCell<Option<Rc<RefCell<collections::Metadata<MetaValue>>>>>,
+        resolver: GcCell<Option<Gc<FileSystemResolver>>>,
+        pub shadow_root: Option<Gc<Inode /*DirectoryInode*/>>,
+        meta: GcCell<Option<Gc<GcCell<collections::Metadata<MetaValue>>>>>,
     }
 
     impl DirectoryInode {
@@ -1977,7 +1998,7 @@ pub mod vfs {
             ctime_ms: u128,
             birthtime_ms: u128,
             nlink: usize,
-            shadow_root: Option<Rc<Inode>>,
+            shadow_root: Option<Gc<Inode>>,
         ) -> Self {
             Self {
                 dev,
@@ -2022,13 +2043,13 @@ pub mod vfs {
 
         pub fn maybe_links(
             &self,
-        ) -> Option<Rc<RefCell<collections::SortedMap<String, Rc<Inode>>>>> {
+        ) -> Option<Gc<GcCell<collections::SortedMap<String, Gc<Inode>>>>> {
             self.links.borrow().clone()
         }
 
         pub fn set_links(
             &self,
-            links: Option<Rc<RefCell<collections::SortedMap<String, Rc<Inode>>>>>,
+            links: Option<Gc<GcCell<collections::SortedMap<String, Gc<Inode>>>>>,
         ) {
             *self.links.borrow_mut() = links;
         }
@@ -2041,32 +2062,35 @@ pub mod vfs {
             *self.source.borrow_mut() = source;
         }
 
-        pub fn maybe_resolver(&self) -> Option<Rc<FileSystemResolver>> {
+        pub fn maybe_resolver(&self) -> Option<Gc<FileSystemResolver>> {
             self.resolver.borrow().clone()
         }
 
-        pub fn set_resolver(&self, resolver: Option<Rc<FileSystemResolver>>) {
+        pub fn set_resolver(&self, resolver: Option<Gc<FileSystemResolver>>) {
             *self.resolver.borrow_mut() = resolver;
         }
 
-        pub fn meta_mut(&self) -> RefMut<Option<Rc<RefCell<collections::Metadata<MetaValue>>>>> {
+        pub fn meta_mut(&self) -> GcCellRefMut<Option<Gc<GcCell<collections::Metadata<MetaValue>>>>> {
             self.meta.borrow_mut()
         }
     }
 
-    #[derive(Clone)]
+    #[derive(Clone, Trace, Finalize)]
     pub struct SymlinkInode {
         pub dev: u32,
         pub ino: u32,
         pub mode: u32,
         pub atime_ms: u128,
+        #[unsafe_ignore_trace]
         pub mtime_ms: Cell<u128>,
+        #[unsafe_ignore_trace]
         ctime_ms: Cell<u128>,
         pub birthtime_ms: u128,
+        #[unsafe_ignore_trace]
         nlink: Cell<usize>,
         pub symlink: Option<String>,
-        pub shadow_root: Option<Rc<Inode /*SymlinkInode*/>>,
-        meta: RefCell<Option<Rc<RefCell<collections::Metadata<MetaValue>>>>>,
+        pub shadow_root: Option<Gc<Inode /*SymlinkInode*/>>,
+        meta: GcCell<Option<Gc<GcCell<collections::Metadata<MetaValue>>>>>,
     }
 
     impl SymlinkInode {
@@ -2079,7 +2103,7 @@ pub mod vfs {
             ctime_ms: u128,
             birthtime_ms: u128,
             nlink: usize,
-            shadow_root: Option<Rc<Inode>>,
+            shadow_root: Option<Gc<Inode>>,
         ) -> Self {
             Self {
                 dev,
@@ -2124,7 +2148,7 @@ pub mod vfs {
             self.symlink.as_ref().unwrap()
         }
 
-        pub fn meta_mut(&self) -> RefMut<Option<Rc<RefCell<collections::Metadata<MetaValue>>>>> {
+        pub fn meta_mut(&self) -> GcCellRefMut<Option<Gc<GcCell<collections::Metadata<MetaValue>>>>> {
             self.meta.borrow_mut()
         }
     }
@@ -2153,51 +2177,51 @@ pub mod vfs {
     pub struct WalkResult {
         pub realpath: String,
         pub basename: String,
-        pub parent: Option<Rc<Inode>>,
-        pub links: Rc<RefCell<collections::SortedMap<String, Rc<Inode>>>>,
-        pub node: Option<Rc<Inode>>,
+        pub parent: Option<Gc<Inode>>,
+        pub links: Gc<GcCell<collections::SortedMap<String, Gc<Inode>>>>,
+        pub node: Option<Gc<Inode>>,
     }
 
     thread_local! {
-        static built_local_host_: RefCell<Option<Rc<dyn FileSystemResolverHost>>> = RefCell::new(None);
-        static built_local_ci_: RefCell<Option<Rc<FileSystem>>> = RefCell::new(None);
-        static built_local_cs_: RefCell<Option<Rc<FileSystem>>> = RefCell::new(None);
+        static built_local_host_: GcCell<Option<Gc<Box<dyn FileSystemResolverHost>>>> = Default::default();
+        static built_local_ci_: GcCell<Option<Gc<FileSystem>>> = Default::default();
+        static built_local_cs_: GcCell<Option<Gc<FileSystem>>> = Default::default();
     }
 
-    fn maybe_built_local_host() -> Option<Rc<dyn FileSystemResolverHost>> {
+    fn maybe_built_local_host() -> Option<Gc<Box<dyn FileSystemResolverHost>>> {
         built_local_host_.with(|built_local_host| built_local_host.borrow().clone())
     }
 
-    fn set_built_local_host(value: Option<Rc<dyn FileSystemResolverHost>>) {
+    fn set_built_local_host(value: Option<Gc<Box<dyn FileSystemResolverHost>>>) {
         built_local_host_.with(|built_local_host| {
             *built_local_host.borrow_mut() = value;
         })
     }
 
-    fn maybe_built_local_ci() -> Option<Rc<FileSystem>> {
+    fn maybe_built_local_ci() -> Option<Gc<FileSystem>> {
         built_local_ci_.with(|built_local_ci| built_local_ci.borrow().clone())
     }
 
-    fn set_built_local_ci(value: Option<Rc<FileSystem>>) {
+    fn set_built_local_ci(value: Option<Gc<FileSystem>>) {
         built_local_ci_.with(|built_local_ci| {
             *built_local_ci.borrow_mut() = value;
         })
     }
 
-    fn maybe_built_local_cs() -> Option<Rc<FileSystem>> {
+    fn maybe_built_local_cs() -> Option<Gc<FileSystem>> {
         built_local_cs_.with(|built_local_cs| built_local_cs.borrow().clone())
     }
 
-    fn set_built_local_cs(value: Option<Rc<FileSystem>>) {
+    fn set_built_local_cs(value: Option<Gc<FileSystem>>) {
         built_local_cs_.with(|built_local_cs| {
             *built_local_cs.borrow_mut() = value;
         })
     }
 
-    fn get_built_local(host: Rc<dyn FileSystemResolverHost>, ignore_case: bool) -> Rc<FileSystem> {
+    fn get_built_local(host: Gc<Box<dyn FileSystemResolverHost>>, ignore_case: bool) -> Gc<FileSystem> {
         if !matches!(
             maybe_built_local_host().as_ref(),
-            Some(built_local_host) if Rc::ptr_eq(
+            Some(built_local_host) if Gc::ptr_eq(
                 built_local_host,
                 &host,
             )
@@ -2207,8 +2231,8 @@ pub mod vfs {
             set_built_local_host(Some(host.clone()));
         }
         if maybe_built_local_ci().is_none() {
-            let resolver = Rc::new(create_resolver(host.clone()));
-            set_built_local_ci(Some(Rc::new(FileSystem::new(
+            let resolver = Gc::new(create_resolver(host.clone()));
+            set_built_local_ci(Some(Gc::new(FileSystem::new(
                 true,
                 Some(FileSystemOptions {
                     files: Some(FileSet::from_iter(IntoIterator::into_iter([
@@ -2271,7 +2295,7 @@ pub mod vfs {
             return maybe_built_local_ci().unwrap();
         }
         if maybe_built_local_cs().is_none() {
-            set_built_local_cs(Some(Rc::new(
+            set_built_local_cs(Some(Gc::new(
                 maybe_built_local_ci().unwrap().shadow(Some(false)),
             )));
             maybe_built_local_cs().unwrap().make_readonly();

--- a/harness/src/harness/vfs_util.rs
+++ b/harness/src/harness/vfs_util.rs
@@ -5,7 +5,6 @@ pub mod vfs {
     use std::cell::{Cell, Ref, RefCell, RefMut};
     use std::collections::HashMap;
     use std::iter::FromIterator;
-    use std::rc::Rc;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use typescript_rust::{

--- a/harness/src/mocha/mod.rs
+++ b/harness/src/mocha/mod.rs
@@ -44,7 +44,7 @@ pub fn register_config(args: &MochaArgs) {
     CONFIG
         .set(args.clone())
         .expect("Should only initialize Mocha config once");
-    // panic::set_hook(Box::new(|_| {}));
+    panic::set_hook(Box::new(|_| {}));
     set_up_channel();
 }
 
@@ -90,7 +90,6 @@ fn get_failures() -> Arc<Mutex<Vec<FailureInfo>>> {
 fn set_up_thread_pool_listener(job_channel_receiver: Receiver<JobChannelMessage>) {
     thread::spawn(move || {
         while let Ok(job_message) = job_channel_receiver.recv() {
-            println!("received job");
             get_thread_pool().execute(move || {
                 let JobChannelMessage {
                     job,

--- a/harness/src/mocha/mod.rs
+++ b/harness/src/mocha/mod.rs
@@ -1,11 +1,13 @@
 use clap::Parser;
-use futures::future::FutureExt;
 use once_cell::sync::OnceCell;
+use std::any::Any;
 use std::cell::{Cell, RefCell};
 use std::io::{self, Write};
-use std::panic;
-use tokio::task;
-use tokio_stream::{StreamExt, StreamMap};
+use std::panic::{self, UnwindSafe};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc::{channel, Receiver, Sender};
+use std::sync::{Arc, Mutex};
+use threadpool::ThreadPool;
 
 #[derive(Clone, Debug, Parser)]
 pub struct MochaArgs {
@@ -18,11 +20,32 @@ pub struct MochaArgs {
 
 static CONFIG: OnceCell<MochaArgs> = OnceCell::new();
 
+type Job = Box<dyn FnOnce() + Send + UnwindSafe>;
+struct JobChannelMessage {
+    job: Job,
+    enclosing_descriptions: Vec<String>,
+}
+
+impl JobChannelMessage {
+    fn new(job: Job, enclosing_descriptions: Vec<String>) -> Self {
+        Self {
+            job,
+            enclosing_descriptions,
+        }
+    }
+}
+
+thread_local! {
+    static THREAD_POOL: ThreadPool = Default::default();
+    static JOB_CHANNEL_SENDER: RefCell<Option<Sender<JobChannelMessage>>> = Default::default();
+}
+
 pub fn register_config(args: &MochaArgs) {
     CONFIG
         .set(args.clone())
         .expect("Should only initialize Mocha config once");
     panic::set_hook(Box::new(|_| {}));
+    set_up_channel();
 }
 
 fn config() -> &'static MochaArgs {
@@ -31,9 +54,86 @@ fn config() -> &'static MochaArgs {
         .expect("Tried to get Mocha config before it was set")
 }
 
+fn get_thread_pool() -> ThreadPool {
+    THREAD_POOL.with(|thread_pool| thread_pool.clone())
+}
+
+fn set_job_channel_sender(sender: Sender<JobChannelMessage>) {
+    JOB_CHANNEL_SENDER.with(|job_channel_sender| {
+        *job_channel_sender.borrow_mut() = Some(sender);
+    });
+}
+
+fn get_job_channel_sender() -> Sender<JobChannelMessage> {
+    JOB_CHANNEL_SENDER.with(|channel_sender| channel_sender.borrow().clone().unwrap())
+}
+
+fn send_job(job: JobChannelMessage) {
+    get_job_channel_sender().send(job).unwrap();
+}
+
+fn set_up_channel() {
+    let (sender, receiver) = channel::<JobChannelMessage>();
+    set_job_channel_sender(sender);
+    set_up_thread_pool_listener(receiver);
+}
+
+static NUM_PASSES: AtomicUsize = AtomicUsize::new(0);
+
+thread_local! {
+    static FAILURES: Arc<Mutex<Vec<FailureInfo>>> = Default::default();
+}
+
+fn get_failures() -> Arc<Mutex<Vec<FailureInfo>>> {
+    FAILURES.with(|failures| failures.clone())
+}
+
+fn set_up_thread_pool_listener(job_channel_receiver: Receiver<JobChannelMessage>) {
+    while let Ok(job_message) = job_channel_receiver.recv() {
+        get_thread_pool().execute(move || {
+            let JobChannelMessage {
+                job,
+                enclosing_descriptions,
+            } = job_message;
+            match panic::catch_unwind(job) {
+                Ok(_) => {
+                    print!(".");
+                    io::stdout().flush().unwrap();
+                    NUM_PASSES.fetch_add(1, Ordering::Relaxed);
+                }
+                Err(test_failure) => {
+                    print!("F");
+                    io::stdout().flush().unwrap();
+                    get_failures()
+                        .lock()
+                        .unwrap()
+                        .push(FailureInfo::new(test_failure, enclosing_descriptions));
+                }
+            }
+        });
+    }
+}
+
+pub fn print_results() {
+    get_thread_pool().join();
+    let failures = get_failures();
+    let failures = failures.lock().unwrap();
+    println!(
+        "\n{} passes, {} failures",
+        NUM_PASSES.load(Ordering::Relaxed),
+        failures.len()
+    );
+    for failure in failures.iter() {
+        for (enclosing_level, description) in failure.enclosing_descriptions.iter().enumerate() {
+            println!("{}{}:", "  ".repeat(enclosing_level), description);
+        }
+        println!("{}", failure.panic_message);
+    }
+}
+
 struct It {
     pub description: String,
-    pub callback: Box<dyn FnOnce() + Send>,
+    pub callback: Job,
     pub global_index: usize,
 }
 
@@ -56,11 +156,11 @@ impl DescribeContext {
 }
 
 thread_local! {
-    static describe_contexts_: RefCell<Vec<DescribeContext>> = RefCell::new(vec![]);
+    static DESCRIBE_CONTEXTS: RefCell<Vec<DescribeContext>> = RefCell::new(vec![]);
 }
 
 fn get_enclosing_describe_descriptions() -> Vec<String> {
-    describe_contexts_.with(|describe_contexts| {
+    DESCRIBE_CONTEXTS.with(|describe_contexts| {
         describe_contexts
             .borrow()
             .iter()
@@ -70,19 +170,19 @@ fn get_enclosing_describe_descriptions() -> Vec<String> {
 }
 
 thread_local! {
-    static num_its_: Cell<usize> = Cell::new(0);
+    static NUM_ITS: Cell<usize> = Cell::new(0);
 }
 
 fn get_next_it_index() -> usize {
-    num_its_.with(|num_its| {
+    NUM_ITS.with(|num_its| {
         let ret = num_its.get();
         num_its.set(ret + 1);
         ret
     })
 }
 
-pub fn describe<TCallback: FnOnce()>(description: &str, callback: TCallback) {
-    describe_contexts_.with(|describe_contexts| {
+pub fn describe(description: &str, callback: impl FnOnce()) {
+    DESCRIBE_CONTEXTS.with(|describe_contexts| {
         describe_contexts
             .borrow_mut()
             .push(DescribeContext::new(description.to_owned()));
@@ -94,7 +194,7 @@ pub fn describe<TCallback: FnOnce()>(description: &str, callback: TCallback) {
         befores,
         afters,
         ..
-    } = describe_contexts_.with(|describe_contexts| describe_contexts.borrow_mut().pop().unwrap());
+    } = DESCRIBE_CONTEXTS.with(|describe_contexts| describe_contexts.borrow_mut().pop().unwrap());
     for before in befores {
         before()
     }
@@ -109,8 +209,7 @@ pub fn describe<TCallback: FnOnce()>(description: &str, callback: TCallback) {
         } = it;
         let mut enclosing_descriptions = enclosing_descriptions.clone();
         enclosing_descriptions.push(description);
-        let join_handle = task::spawn_blocking(callback);
-        register_it_join_handle(join_handle, enclosing_descriptions);
+        send_job(JobChannelMessage::new(callback, enclosing_descriptions));
     }
     for after in afters {
         after()
@@ -131,30 +230,11 @@ fn should_run_it(it: &It) -> bool {
     true
 }
 
-thread_local! {
-    static it_join_handles_: RefCell<Option<Vec<ItJoinHandle>>> = RefCell::new(Some(vec![]));
-}
-
-struct ItJoinHandle {
-    join_handle: task::JoinHandle<()>,
-    enclosing_descriptions: Vec<String>,
-}
-
-fn register_it_join_handle(join_handle: task::JoinHandle<()>, enclosing_descriptions: Vec<String>) {
-    it_join_handles_.with(|it_join_handles| {
-        it_join_handles
-            .borrow_mut()
-            .as_mut()
-            .unwrap()
-            .push(ItJoinHandle {
-                join_handle,
-                enclosing_descriptions,
-            });
-    });
-}
-
-pub fn it<TCallback: FnOnce() + Send + 'static>(description: &str, callback: TCallback) {
-    describe_contexts_.with(|describe_contexts| {
+pub fn it<TCallback: FnOnce() + Send + UnwindSafe + 'static>(
+    description: &str,
+    callback: TCallback,
+) {
+    DESCRIBE_CONTEXTS.with(|describe_contexts| {
         let mut describe_contexts = describe_contexts.borrow_mut();
         let index = describe_contexts.len() - 1;
         describe_contexts[index].its.push(It {
@@ -166,7 +246,7 @@ pub fn it<TCallback: FnOnce() + Send + 'static>(description: &str, callback: TCa
 }
 
 pub fn before<TCallback: FnOnce() + 'static>(callback: TCallback) {
-    describe_contexts_.with(|describe_contexts| {
+    DESCRIBE_CONTEXTS.with(|describe_contexts| {
         let mut describe_contexts = describe_contexts.borrow_mut();
         let index = describe_contexts.len() - 1;
         describe_contexts[index].befores.push(Box::new(callback));
@@ -174,50 +254,11 @@ pub fn before<TCallback: FnOnce() + 'static>(callback: TCallback) {
 }
 
 pub fn after<TCallback: FnOnce() + 'static>(callback: TCallback) {
-    describe_contexts_.with(|describe_contexts| {
+    DESCRIBE_CONTEXTS.with(|describe_contexts| {
         let mut describe_contexts = describe_contexts.borrow_mut();
         let index = describe_contexts.len() - 1;
         describe_contexts[index].afters.push(Box::new(callback));
     });
-}
-
-pub async fn collect_results() {
-    let it_join_handles = it_join_handles_
-        .with(|it_join_handles| it_join_handles.borrow_mut().take())
-        .unwrap();
-    let single_future_streams = it_join_handles.into_iter().map(
-        |ItJoinHandle {
-             join_handle,
-             enclosing_descriptions,
-         }| (enclosing_descriptions, join_handle.into_stream()),
-    );
-    let mut stream_map = StreamMap::new();
-    for (enclosing_descriptions, stream) in single_future_streams {
-        stream_map.insert(enclosing_descriptions, stream);
-    }
-    let mut num_passes = 0;
-    let mut failures: Vec<FailureInfo> = vec![];
-    while let Some((enclosing_descriptions, join_handle_result)) = stream_map.next().await {
-        match join_handle_result {
-            Ok(_) => {
-                print!(".");
-                io::stdout().flush().unwrap();
-                num_passes += 1;
-            }
-            Err(err) => {
-                print!("F");
-                io::stdout().flush().unwrap();
-                failures.push(FailureInfo::new(err, enclosing_descriptions));
-            }
-        }
-    }
-    println!("\n{} passes, {} failures", num_passes, failures.len());
-    for failure in failures {
-        for (enclosing_level, description) in failure.enclosing_descriptions.iter().enumerate() {
-            println!("{}{}:", "  ".repeat(enclosing_level), description);
-        }
-        println!("{}", failure.panic_message);
-    }
 }
 
 struct FailureInfo {
@@ -226,8 +267,7 @@ struct FailureInfo {
 }
 
 impl FailureInfo {
-    pub fn new(join_error: task::JoinError, enclosing_descriptions: Vec<String>) -> Self {
-        let panic = join_error.into_panic();
+    pub fn new(panic: Box<dyn Any + Send>, enclosing_descriptions: Vec<String>) -> Self {
         let panic_type_id = panic.type_id();
         Self {
             enclosing_descriptions,

--- a/test_runner/Cargo.toml
+++ b/test_runner/Cargo.toml
@@ -13,6 +13,7 @@ lazy_static = "1.4.0"
 regex = "1.5.4"
 clap = { version = "4.0.29", features = ["derive"] }
 tokio = { version = "1.23.0", features = ["full"] }
+gc = { git = "https://github.com/helixbass/rust-gc", rev = "32dfa44", features = ["derive", "serde"] }
 
 [dev-dependencies]
 

--- a/test_runner/src/bin/runner.rs
+++ b/test_runner/src/bin/runner.rs
@@ -2,9 +2,8 @@ use clap::Parser;
 
 use test_runner::{run, Args};
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let args = Args::parse();
 
-    run(&args).await
+    run(&args)
 }

--- a/test_runner/src/test_runner/compiler_runner.rs
+++ b/test_runner/src/test_runner/compiler_runner.rs
@@ -1,9 +1,7 @@
 use gc::{Finalize, Gc, Trace};
 use regex::Regex;
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::Path as StdPath;
-use std::rc::Rc;
 
 use harness::{
     after, before, compiler, describe, get_file_based_test_configuration_description,

--- a/test_runner/src/test_runner/compiler_runner.rs
+++ b/test_runner/src/test_runner/compiler_runner.rs
@@ -52,7 +52,7 @@ impl CompilerBaselineRunner {
     }
 
     pub fn new_runner_base(test_type: CompilerTestType) -> RunnerBase {
-        RunnerBase::new(Rc::new(Self::new(test_type)))
+        RunnerBase::new(Gc::new(Self::new(test_type)))
     }
 
     fn check_test_code_output(&self, file_name: &str, test: Option<&CompilerFileBasedTest>) {

--- a/test_runner/src/test_runner/runner.rs
+++ b/test_runner/src/test_runner/runner.rs
@@ -41,7 +41,7 @@ fn run_tests(runners: &[RunnerBase]) {
             /*runner instanceof CompilerBaselineRunner || runner instanceof FourSlashRunner*/
             {
                 for sf in runner.enumerate_test_files() {
-                    let full = match sf {
+                    let full = match &sf {
                         StringOrFileBasedTest::String(sf) => sf.clone(),
                         StringOrFileBasedTest::FileBasedTest(sf) => sf.file.clone(),
                     };

--- a/test_runner/src/test_runner/runner.rs
+++ b/test_runner/src/test_runner/runner.rs
@@ -131,8 +131,8 @@ pub struct Args {
     pub mocha_args: MochaArgs,
 }
 
-pub async fn run(args: &Args) {
+pub fn run(args: &Args) {
     mocha::register_config(&args.mocha_args);
     start_test_environment();
-    mocha::collect_results().await
+    mocha::print_results()
 }

--- a/test_runner/src/test_runner/runner.rs
+++ b/test_runner/src/test_runner/runner.rs
@@ -132,11 +132,7 @@ pub struct Args {
 }
 
 pub fn run(args: &Args) {
-    println!("pre-register_config()");
     mocha::register_config(&args.mocha_args);
-    println!("post-register_config()");
     start_test_environment();
-    println!("post-start_test_environment()");
     mocha::print_results();
-    println!("post-print_results()");
 }

--- a/test_runner/src/test_runner/runner.rs
+++ b/test_runner/src/test_runner/runner.rs
@@ -1,13 +1,14 @@
 use clap::Parser;
+use gc::GcCell;
 use regex::Regex;
-use std::cell::{Cell, RefCell};
+use std::cell::Cell;
 use std::collections::HashMap;
 
 use crate::{CompilerBaselineRunner, CompilerTestType};
 use harness::{mocha, vpath, MochaArgs, RunnerBase, StringOrFileBasedTest};
 
 thread_local! {
-    static runners_: RefCell<Vec<RunnerBase>> = RefCell::new(vec![]);
+    static runners_: GcCell<Vec<RunnerBase>> = Default::default();
 }
 
 fn with_runners<TReturn, TCallback: FnMut(&[RunnerBase]) -> TReturn>(

--- a/test_runner/src/test_runner/runner.rs
+++ b/test_runner/src/test_runner/runner.rs
@@ -132,7 +132,11 @@ pub struct Args {
 }
 
 pub fn run(args: &Args) {
+    println!("pre-register_config()");
     mocha::register_config(&args.mocha_args);
+    println!("post-register_config()");
     start_test_environment();
-    mocha::print_results()
+    println!("post-start_test_environment()");
+    mocha::print_results();
+    println!("post-print_results()");
 }

--- a/typescript_rust/src/compiler/builder_public.rs
+++ b/typescript_rust/src/compiler/builder_public.rs
@@ -1,9 +1,9 @@
-use gc::Gc;
+use gc::{Finalize, Gc, Trace};
 use std::rc::Rc;
 
 use crate::{CompilerOptions, Node, Program};
 
-pub trait BuilderProgram {
+pub trait BuilderProgram: Trace + Finalize {
     fn get_program(&self) -> Gc<Box<Program>>;
     fn get_compiler_options(&self) -> Gc<CompilerOptions>;
     fn get_source_files(&self) -> &[Gc<Node /*SourceFile*/>];

--- a/typescript_rust/src/compiler/command_line_parser/lines_2500_2750.rs
+++ b/typescript_rust/src/compiler/command_line_parser/lines_2500_2750.rs
@@ -236,17 +236,20 @@ pub(super) fn parse_json_config_file_content_worker<
     ParsedCommandLine {
         options: options.clone(),
         watch_options,
-        file_names: get_file_names(
-            &config_file_specs,
-            &options,
-            host,
-            extra_file_extensions,
-            raw,
-            resolution_stack,
-            &mut errors.clone().borrow_mut(),
-            config_file_name,
-            &base_path_for_file_names,
-        ),
+        file_names: {
+            let value = get_file_names(
+                &config_file_specs,
+                &options,
+                host,
+                extra_file_extensions,
+                raw,
+                resolution_stack,
+                &mut errors.clone().borrow_mut(),
+                config_file_name,
+                &base_path_for_file_names,
+            );
+            value
+        },
         project_references: get_project_references(
             raw,
             source_file,

--- a/typescript_rust/src/compiler/watch.rs
+++ b/typescript_rust/src/compiler/watch.rs
@@ -403,9 +403,9 @@ pub fn list_files<TWrite: FnMut(&str)>(program: ProgramOrBuilderProgram, mut wri
     if matches!(options.explain_files, Some(true)) {
         explain_files(
             &*if is_builder_program(&program) {
-                enum_unwrapped!(program, [ProgramOrBuilderProgram, BuilderProgram]).get_program()
+                enum_unwrapped!(&program, [ProgramOrBuilderProgram, BuilderProgram]).get_program()
             } else {
-                enum_unwrapped!(program, [ProgramOrBuilderProgram, Program])
+                enum_unwrapped!(&program, [ProgramOrBuilderProgram, Program]).clone()
             },
             write,
         );

--- a/typescript_rust/src/compiler/watch.rs
+++ b/typescript_rust/src/compiler/watch.rs
@@ -360,9 +360,10 @@ pub fn get_error_summary_text(error_count: usize, new_line: &str) -> String {
     )
 }
 
+#[derive(Trace, Finalize)]
 pub enum ProgramOrBuilderProgram {
     Program(Gc<Box<Program>>),
-    BuilderProgram(Rc<dyn BuilderProgram>),
+    BuilderProgram(Gc<Box<dyn BuilderProgram>>),
 }
 
 impl ProgramOrBuilderProgram {
@@ -387,8 +388,8 @@ impl From<Gc<Box<Program>>> for ProgramOrBuilderProgram {
     }
 }
 
-impl From<Rc<dyn BuilderProgram>> for ProgramOrBuilderProgram {
-    fn from(value: Rc<dyn BuilderProgram>) -> Self {
+impl From<Gc<Box<dyn BuilderProgram>>> for ProgramOrBuilderProgram {
+    fn from(value: Gc<Box<dyn BuilderProgram>>) -> Self {
         Self::BuilderProgram(value)
     }
 }

--- a/typescript_rust/src/execute_command_line/execute_command_line/lines_500_end.rs
+++ b/typescript_rust/src/execute_command_line/execute_command_line/lines_500_end.rs
@@ -261,6 +261,7 @@ pub(super) fn perform_build<
     sys.exit(Some(exit_status));
 }
 
+#[derive(Trace, Finalize)]
 struct BuilderProgramDummy {}
 
 impl BuilderProgram for BuilderProgramDummy {

--- a/typescript_services_rust/Cargo.toml
+++ b/typescript_services_rust/Cargo.toml
@@ -9,6 +9,7 @@ default-run = "tsserver-rust"
 [dependencies]
 # tsc-rust = { git = "https://github.com/helixbass/tsc-rust", rev = "fa1079d5" }
 typescript_rust = { path = "../typescript_rust" }
+gc = { git = "https://github.com/helixbass/rust-gc", rev = "deaff036b", features = ["derive", "serde"] }
 
 [lib]
 name = "typescript_services_rust"

--- a/typescript_services_rust/Cargo.toml
+++ b/typescript_services_rust/Cargo.toml
@@ -9,7 +9,7 @@ default-run = "tsserver-rust"
 [dependencies]
 # tsc-rust = { git = "https://github.com/helixbass/tsc-rust", rev = "fa1079d5" }
 typescript_rust = { path = "../typescript_rust" }
-gc = { git = "https://github.com/helixbass/rust-gc", rev = "deaff036b", features = ["derive", "serde"] }
+gc = { git = "https://github.com/helixbass/rust-gc", rev = "32dfa44", features = ["derive", "serde"] }
 
 [lib]
 name = "typescript_services_rust"

--- a/typescript_services_rust/src/server/editor_services.rs
+++ b/typescript_services_rust/src/server/editor_services.rs
@@ -1,7 +1,11 @@
-use std::rc::Rc;
+use gc::{Finalize, Gc, Trace};
 
 pub enum ProjectServiceEvent {}
 
-pub type ProjectServiceEventHandler = Rc<dyn Fn(&ProjectServiceEvent)>;
+pub type ProjectServiceEventHandler = Gc<Box<dyn HandleProjectServiceEvent>>;
+
+pub trait HandleProjectServiceEvent: Trace + Finalize {
+    fn call(&self, something: &ProjectServiceEvent);
+}
 
 pub struct ProjectService;

--- a/typescript_services_rust/src/server/session.rs
+++ b/typescript_services_rust/src/server/session.rs
@@ -1,3 +1,4 @@
+use gc::{Finalize, Gc, Trace};
 use std::rc::Rc;
 
 use crate::{
@@ -7,20 +8,20 @@ use crate::{
 
 pub type RequestId = usize;
 
-pub trait ServerCancellationToken: HostCancellationToken {
+pub trait ServerCancellationToken: HostCancellationToken + Trace + Finalize {
     fn set_request(&self, request_id: RequestId);
     fn reset_request(&self, request_id: RequestId);
 }
 
 pub struct SessionOptions {
-    pub host: Rc<dyn ServerHost>,
-    pub cancellation_token: Rc<dyn ServerCancellationToken>,
+    pub host: Gc<Box<dyn ServerHost>>,
+    pub cancellation_token: Gc<Box<dyn ServerCancellationToken>>,
     pub use_single_inferred_project: bool,
     pub use_inferred_project_per_project_root: bool,
-    pub typings_installer: Rc<dyn ITypingsInstaller>,
-    pub byte_length: Rc<dyn Fn(&str, Option<&str>) -> usize>,
-    pub hrtime: Rc<dyn Fn(Option<&[usize]>) -> Vec<usize>>,
-    pub logger: Rc<dyn Logger>,
+    pub typings_installer: Gc<Box<dyn ITypingsInstaller>>,
+    pub byte_length: Gc<Box<dyn ByteLength>>,
+    pub hrtime: Gc<Box<dyn Hrtime>>,
+    pub logger: Gc<Box<dyn Logger>>,
     pub can_use_events: bool,
     pub event_handler: Option<ProjectServiceEventHandler>,
     pub suppress_diagnostic_events: Option<bool>,
@@ -33,4 +34,12 @@ pub struct SessionOptions {
     pub plugin_probe_locations: Option<Vec<String>>,
     pub allow_local_plugin_loads: Option<bool>,
     pub types_map_location: Option<String>,
+}
+
+pub trait ByteLength: Trace + Finalize {
+    fn call(&self, something: &str, something_else: Option<&str>) -> usize;
+}
+
+pub trait Hrtime: Trace + Finalize {
+    fn call(&self, something: Option<&[usize]>) -> Vec<usize>;
 }

--- a/typescript_services_rust/src/server/typings_cache.rs
+++ b/typescript_services_rust/src/server/typings_cache.rs
@@ -1,3 +1,4 @@
+use gc::{Finalize, Trace};
 use std::future::Future;
 use std::rc::Rc;
 
@@ -12,7 +13,7 @@ pub struct InstallPackageOptionsWithProject {
     pub project_root_path: Path,
 }
 
-pub trait ITypingsInstaller {
+pub trait ITypingsInstaller: Trace + Finalize {
     fn is_known_types_package_name(&self, name: &str) -> bool;
     fn install_package(
         &self,

--- a/typescript_services_rust/src/server/utilities_public.rs
+++ b/typescript_services_rust/src/server/utilities_public.rs
@@ -1,3 +1,5 @@
+use gc::{Finalize, Trace};
+
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum LogLevel {
     Terse,
@@ -23,7 +25,7 @@ impl LogLevel {
 
 // export const emptyArray: SortedReadonlyArray<never> = createSortedArray<never>();
 
-pub trait Logger {
+pub trait Logger: Trace + Finalize {
     fn close(&self);
     fn has_level(&self, level: LogLevel) -> bool;
     fn logging_enabled(&self) -> bool;

--- a/typescript_services_rust/src/services/services.rs
+++ b/typescript_services_rust/src/services/services.rs
@@ -1,5 +1,7 @@
+use gc::Gc;
 use std::convert::TryFrom;
 use std::rc::Rc;
+
 use typescript_rust::{
     get_source_file_of_node, position_is_synthesized, CompilerOptions, CompilerOptionsBuilder,
     Debug_, JsxEmit, Node, NodeInterface, ReadonlyTextRange, ScriptTarget, SourceFileLike,
@@ -7,7 +9,7 @@ use typescript_rust::{
 
 pub trait NodeServicesInterface {
     fn assert_has_real_position(&self, message: Option<&str>);
-    fn get_source_file(&self) -> Rc<Node /*SourceFile*/>;
+    fn get_source_file(&self) -> Gc<Node /*SourceFile*/>;
     // TODO: this should be updated to return Rc<SourceText> or whatever
     fn get_full_text(&self, source_file: Option<&Node /*SourceFile*/>) -> String;
 }
@@ -20,7 +22,7 @@ impl NodeServicesInterface for Node {
         );
     }
 
-    fn get_source_file(&self) -> Rc<Node /*SourceFile*/> {
+    fn get_source_file(&self) -> Gc<Node /*SourceFile*/> {
         get_source_file_of_node(Some(self)).unwrap()
     }
 

--- a/typescript_services_rust/src/services/services.rs
+++ b/typescript_services_rust/src/services/services.rs
@@ -1,6 +1,5 @@
 use gc::Gc;
 use std::convert::TryFrom;
-use std::rc::Rc;
 
 use typescript_rust::{
     get_source_file_of_node, position_is_synthesized, CompilerOptions, CompilerOptionsBuilder,

--- a/typescript_services_rust/src/tsserver/server.rs
+++ b/typescript_services_rust/src/tsserver/server.rs
@@ -1,3 +1,4 @@
+use gc::{Finalize, Gc, Trace};
 use std::rc::Rc;
 
 use crate::{
@@ -33,12 +34,20 @@ pub fn get_log_level(level: Option<&str>) -> Option<LogLevel> {
 
 pub struct StartInput {
     pub args: Vec<String>,
-    pub logger: Rc<dyn Logger>,
-    pub cancellation_token: Rc<dyn ServerCancellationToken>,
+    pub logger: Gc<Box<dyn Logger>>,
+    pub cancellation_token: Gc<Box<dyn ServerCancellationToken>>,
     pub server_mode: Option<LanguageServiceMode>,
     pub unknown_server_mode: Option<String>,
-    pub start_session:
-        Rc<dyn Fn(StartSessionOptions, Rc<dyn Logger>, Rc<dyn ServerCancellationToken>)>,
+    pub start_session: Gc<Box<dyn StartSession>>,
+}
+
+pub trait StartSession: Trace + Finalize {
+    fn call(
+        &self,
+        something: StartSessionOptions,
+        something_else: Gc<Box<dyn Logger>>,
+        something_else_else: Gc<Box<dyn ServerCancellationToken>>,
+    );
 }
 
 pub fn start(


### PR DESCRIPTION
In this PR:
- `gc`-ify most of the test harness stuff
- switch test harness to using `threadpool` + job-message-passing + `catch_unwind()`

Not in this PR:
It looks like running tests via the test harness is still leaking some memory, I messed around with that a bit but should dig in more at some point